### PR TITLE
Update Open Graph and Twitter Card URLs in editor and verification pages

### DIFF
--- a/packages/editor/index.html
+++ b/packages/editor/index.html
@@ -9,8 +9,8 @@
   <meta property="og:title" content="TypedCode">
   <meta property="og:description" content="コードがタイピングされたことを証明するエディタ - SHA-256ハッシュチェーンとPoSWで改ざん不可能な証明を生成">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://typedcode.net">
-  <meta property="og:image" content="https://typedcode.net/ogp.png">
+  <meta property="og:url" content="https://typedcode.dev">
+  <meta property="og:image" content="https://typedcode.dev/ogp.png?v=1">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:locale" content="ja_JP">
@@ -19,7 +19,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="TypedCode">
   <meta name="twitter:description" content="コードがタイピングされたことを証明するエディタ - SHA-256ハッシュチェーンとPoSWで改ざん不可能な証明を生成">
-  <meta name="twitter:image" content="https://typedcode.net/ogp.png">
+  <meta name="twitter:image" content="https://typedcode.dev/ogp.png?v=1">
   <title>TypedCode</title>
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png">

--- a/packages/verify/index.html
+++ b/packages/verify/index.html
@@ -9,8 +9,8 @@
   <meta property="og:title" content="TypedCode Verify">
   <meta property="og:description" content="タイピング証明の検証ツール - ハッシュチェーンとPoSWを検証してコードの真正性を確認">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://typedcode.net/verify/">
-  <meta property="og:image" content="https://typedcode.net/ogp.png">
+  <meta property="og:url" content="https://typedcode.dev/verify/">
+  <meta property="og:image" content="https://typedcode.dev/ogp.png?v=1">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:locale" content="ja_JP">
@@ -19,7 +19,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="TypedCode Verify">
   <meta name="twitter:description" content="タイピング証明の検証ツール - ハッシュチェーンとPoSWを検証してコードの真正性を確認">
-  <meta name="twitter:image" content="https://typedcode.net/ogp.png">
+  <meta name="twitter:image" content="https://typedcode.dev/ogp.png?v=1">
   <title>TypedCode Verify</title>
   <link rel="stylesheet" href="./src/styles/main.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">


### PR DESCRIPTION
- Changed Open Graph and Twitter Card meta tags in index.html and verify/index.html to use the new domain (typedcode.dev).
- Updated image URLs to include a version query parameter for cache management.

These updates ensure proper social media sharing and enhance the visibility of the application with the new domain.