### PR TITLE
Enhance screen sharing functionality with opt-out options and UI improvements

### DIFF
--- a/packages/editor/src/i18n/translations/en.ts
+++ b/packages/editor/src/i18n/translations/en.ts
@@ -248,6 +248,8 @@ export const en: TranslationKeys = {
     // Opt-out banner
     optedOutBanner: 'Running without screen sharing',
     enableScreenShare: 'Enable Screen Sharing',
+    // Continue without screen share (lock overlay)
+    continueWithoutButton: 'Continue Without Screen Sharing',
   },
 
   statusBar: {

--- a/packages/editor/src/i18n/translations/ja.ts
+++ b/packages/editor/src/i18n/translations/ja.ts
@@ -248,6 +248,8 @@ export const ja: TranslationKeys = {
     // Opt-out banner
     optedOutBanner: '画面共有なしモードで動作中',
     enableScreenShare: '画面共有を有効にする',
+    // Continue without screen share (lock overlay)
+    continueWithoutButton: '画面共有なしで継続',
   },
 
   statusBar: {

--- a/packages/editor/src/styles/components/_modals.css
+++ b/packages/editor/src/styles/components/_modals.css
@@ -911,6 +911,30 @@
   background: var(--accent-secondary);
 }
 
+.screen-capture-lock-content .btn-secondary {
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+}
+
+.screen-capture-lock-content .btn-secondary:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.screen-capture-lock-content-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 8px;
+  width: 100%;
+}
+
+.screen-capture-lock-content-buttons .btn {
+  width: 100%;
+  justify-content: center;
+}
+
 /* Screen Share Guide - Chrome共有ダイアログの非表示ボタンを押すよう促すガイド */
 .screen-share-guide {
   position: fixed;

--- a/packages/editor/src/ui/dialogs/ScreenCaptureDialogs.ts
+++ b/packages/editor/src/ui/dialogs/ScreenCaptureDialogs.ts
@@ -272,9 +272,12 @@ export async function showScreenCaptureRequiredDialog(): Promise<boolean> {
 
 /**
  * 画面共有停止時のロックオーバーレイを表示
+ * @param onResume 画面共有を再開するコールバック
+ * @param onContinueWithout 画面共有なしで継続するコールバック（オプション）
  */
 export function showScreenCaptureLockOverlay(
-  onResume: () => Promise<boolean>
+  onResume: () => Promise<boolean>,
+  onContinueWithout?: () => Promise<boolean>
 ): void {
   showLockOverlay({
     overlayId: SCREEN_CAPTURE_LOCK_OVERLAY_ID,
@@ -287,6 +290,15 @@ export function showScreenCaptureLockOverlay(
       const result = await onResume();
       return result; // false を返すとオーバーレイが閉じない
     },
+    secondaryButtonText: onContinueWithout
+      ? (t('screenCapture.continueWithoutButton') ?? '画面共有なしで継続')
+      : undefined,
+    onSecondaryAction: onContinueWithout
+      ? async () => {
+          const result = await onContinueWithout();
+          return result;
+        }
+      : undefined,
   });
 }
 


### PR DESCRIPTION
- Added a secondary button to the screen capture lock overlay, allowing users to continue without screen sharing.
- Implemented a callback for the new opt-out option, enhancing user control over screen sharing preferences.
- Updated translations for the new functionality in both English and Japanese.
- Enhanced styles for the modal buttons to improve user experience.

These changes improve the application's handling of screen sharing, providing users with more flexibility and clearer options.