### PR TITLE
保守運用レビュー指摘の修正 (deploy script / CORS fail-closed / CI gate / concurrency ほか)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,17 @@ on:
   pull_request:
     branches: [main, develop]
 
+# ref ごとに 1 run。PR は新しい push で古い run をキャンセル (CI 節約)。
+# push (= deploy) はキャンセルせずキューイングし、最新 run が最後に走るので
+# 「古い deploy が後から完了して新しい成果物を上書きする」競合を防ぐ。
+# 本番デプロイを途中キャンセルしないため cancel-in-progress は PR のみ true。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # 構成:
-#   test                   — どのトリガでも必ず走る (tsc + テスト)
+#   test                   — どのトリガでも必ず走る (shared / workers のユニットテスト)
+#   check                  — どのトリガでも必ず走る (全 package typecheck/build + Worker config dry-run)
 #   deploy-preview         — PR で Pages のプレビュー URL を発行 (Workers staging 向け)
 #   deploy-staging         — develop push で Workers staging + Pages staging を更新
 #   deploy-production      — main  push で Workers production + Pages production を更新
@@ -42,11 +51,44 @@ jobs:
         run: npm run test:run -w @typedcode/workers
 
   # --------------------------------------------------------------------
+  # 品質ゲート (merge 前に全 package を typecheck/build + Worker config 検証)
+  # build は従来 deploy job で初めて走っていたため、main/develop に入ってから
+  # 失敗する余地があった。push/PR どちらでも走らせ deploy の前提条件にする。
+  # secrets 不要 (VITE_* 無しでも build は通る / wrangler は --dry-run)。
+  # --------------------------------------------------------------------
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --include=optional
+
+      - name: Typecheck (all packages)
+        run: npm run typecheck
+
+      - name: Build (all packages)
+        run: npm run build
+        env:
+          NODE_OPTIONS: "--max-old-space-size=4096"
+
+      - name: Validate Worker config (staging dry-run)
+        run: npm run deploy:staging -w @typedcode/workers -- --dry-run --outdir /tmp/wrangler-dryrun-staging
+
+      - name: Validate Worker config (production dry-run)
+        run: npm run deploy:production -w @typedcode/workers -- --dry-run --outdir /tmp/wrangler-dryrun-production
+
+  # --------------------------------------------------------------------
   # PR: Pages プレビューデプロイ (Workers は触らない)
   # PR ビルドは staging API を指す。
   # --------------------------------------------------------------------
   deploy-preview:
-    needs: test
+    needs: [test, check]
     # head_ref != 'develop' で `develop → main` の PR (= PR #60 など) を除外する。
     # この種類の PR では develop push 起因の deploy-staging が `develop.<project>.pages.dev`
     # にデプロイするのと URL が衝突するため、PR 側の preview は走らせない。
@@ -148,7 +190,7 @@ jobs:
   # 自動デプロイ。承認ゲートなし。
   # --------------------------------------------------------------------
   deploy-staging:
-    needs: test
+    needs: [test, check]
     if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
     runs-on: ubuntu-latest
     environment:
@@ -203,7 +245,7 @@ jobs:
   # GitHub Environment "production" の Required reviewers で承認待ち。
   # --------------------------------------------------------------------
   deploy-production:
-    needs: test
+    needs: [test, check]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     environment:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -245,19 +245,23 @@ CI が `wrangler` を使ってデプロイするので、適切な権限の API 
 
 | Secret | 値 |
 |---|---|
-| `CLOUDFLARE_API_TOKEN` | M1 で控えた token 文字列 |
 | `CLOUDFLARE_ACCOUNT_ID` | account ID |
 | `CLOUDFLARE_PROJECT_NAME` | Cloudflare Pages のプロジェクト名 (**M3 で作成**したもの) |
+
+> **`CLOUDFLARE_API_TOKEN` は repo level に置かない**。preview / staging / production で同一 token を共用すると、PR プレビュー (= fork や任意ブランチから走り得る) でも本番デプロイ権限を持つ token が露出する。**Environment secret として環境ごとに分け**、production token は production Environment (承認ゲート配下) に置く。
+>
+> deploy job はすべて `environment:` を宣言しているので、**Environment secret は同名の repo secret を自動的に上書き**する。ワークフロー側 (`${{ secrets.CLOUDFLARE_API_TOKEN }}`) は変更不要。
 
 ### GitHub Environments の作成
 
 Settings → Environments → **New environment**:
 
-#### Environment `staging` (承認不要、develop push で自動デプロイ)
+#### Environment `staging` (承認不要、develop push で自動デプロイ。preview もこの環境を使う)
 - Secrets (Add secret):
 
   | Secret | 値 |
   |---|---|
+  | `CLOUDFLARE_API_TOKEN` | **staging/preview 専用 token**。Pages:Edit + 対象 staging Worker への権限に絞る (本番 Worker 編集権限は付けない) |
   | `VITE_API_URL` | staging Worker の URL (`https://typedcode-api-staging.<your-subdomain>.workers.dev`) |
   | `VITE_TURNSTILE_SITE_KEY` | staging 用 Turnstile widget の Site Key |
 
@@ -266,11 +270,13 @@ Settings → Environments → **New environment**:
 
   | Secret | 値 |
   |---|---|
+  | `CLOUDFLARE_API_TOKEN` | **本番専用 token**。承認ゲート配下なので Approve を経ないと使われない |
   | `VITE_API_URL` | 本番 Worker の URL |
   | `VITE_TURNSTILE_SITE_KEY` | 本番 Turnstile Site Key |
 
 - **Deployment protection rules** → **Required reviewers** を ON にして自分 (またはチーム) を 1 名以上追加
   → これで `main` push 時に Actions タブで Approve を押すまで本番デプロイが保留される
+  → 本番 `CLOUDFLARE_API_TOKEN` もこのゲートの内側にあるため、承認なしには使われない
 
 ## M3. Cloudflare 側の準備
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build:editor": "npm run build -w @typedcode/editor",
     "build:verify": "npm run build -w @typedcode/verify",
     "build:verify-cli": "npm run build -w @typedcode/verify-cli",
+    "typecheck": "npm run typecheck --workspaces --if-present",
     "doctor": "node scripts/doctor.mjs"
   },
   "engines": {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@typedcode/shared": "*",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,6 +9,7 @@
     "./checkpoint": "./src/checkpointEntry.ts"
   },
   "scripts": {
+    "typecheck": "tsc --noEmit",
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage"

--- a/packages/verify-cli/package.json
+++ b/packages/verify-cli/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@typedcode/shared": "*"

--- a/packages/verify/package.json
+++ b/packages/verify/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@typedcode/shared": "*",

--- a/packages/workers/.gitignore
+++ b/packages/workers/.gitignore
@@ -1,6 +1,8 @@
 # Cloudflare Workers
 .wrangler/
 .dev.vars
+# wrangler types で生成 (cf-typegen)。手書き Env と同期確認用、commit はしない
+worker-configuration.d.ts
 
 # Dependencies
 node_modules/

--- a/packages/workers/CLAUDE.md
+++ b/packages/workers/CLAUDE.md
@@ -59,14 +59,15 @@ src/
 
 CORS は `ALLOWED_ORIGINS` (env var, カンマ区切り) による**許可リスト方式**で実装する (`src/index.ts` の `resolveCorsOrigin`)。
 
-許可判定の優先順位:
+許可判定の優先順位 (**fail-closed**):
 
 1. `ALLOWED_ORIGINS` に一致 (**完全一致** or `https://*.domain` の**サブドメイン wildcard**) → その Origin を reflect
 2. `ENVIRONMENT === 'development'` のとき `localhost` / `127.0.0.1` → 自動許可 (DX)
-3. `ALLOWED_ORIGINS` **未設定** → 後方互換で reflect (デプロイ破壊回避)。**production / staging では必ず設定すること**
-4. それ以外 → `Access-Control-Allow-Origin` を**付与しない** (ブラウザのクロスオリジン読み取りを拒否)
+3. それ以外 → `Access-Control-Allow-Origin` を**付与しない** (ブラウザのクロスオリジン読み取りを拒否)
 
 ワイルドカード `*` は一切返さない (Origin 不在のリクエストにはヘッダ自体を付けない)。許可オリジンは `wrangler.{production,staging}.toml` の `[vars]` に直接 commit する (公開ドメインでありシークレットではない)。
+
+**fail-closed**: 非 development で `ALLOWED_ORIGINS` が空 / 不一致なら拒否する。以前は未設定時に任意 Origin を reflect する fail-open だったが、staging/production の config に値を commit したため廃止した。**新しい環境を追加するときは `ALLOWED_ORIGINS` の設定が必須** (未設定だとフロントから API を読めない)。
 
 **editor と verify は同一 Pages プロジェクト** (`editor=/`, `verify=/verify`) にデプロイされるため origin は環境ごとに 1 つ。実際の設定:
 

--- a/packages/workers/CLAUDE.md
+++ b/packages/workers/CLAUDE.md
@@ -91,6 +91,15 @@ CORS は `ALLOWED_ORIGINS` (env var, カンマ区切り) による**許可リス
 |---|---|---|
 | `CHECKPOINT_SESSIONS` | `firstSeenAt`, `lastCheckpointIndex`, `lastServerTimestamp`, `signedCount`, `lastEnvelope` (冪等用) | 7 日 |
 
+## 観測性・シークレット宣言・型 (運用)
+
+`wrangler.{staging,production}.toml` に以下を宣言している (dev の `wrangler.toml` は skip-worktree なので対象外):
+
+- **`[observability] enabled = true`**: Workers Logs を有効化。`head_sampling_rate = 1` は低トラフィックな署名 API 向けに全リクエスト記録。トラフィックが増えたら下げる。
+- **`[secrets] required = [...]`**: `TURNSTILE_SECRET_KEY` / `ATTESTATION_SECRET_KEY` / `CHECKPOINT_SIGNING_KEY_ID` / `CHECKPOINT_SIGNING_KEY_JWK` を必須宣言。`wrangler secret put` 漏れがあると **deploy 時にエラー**になり、設定漏れによる本番事故を防ぐ。`--dry-run` (CI の config 検証) では secret の存在チェックは走らない。
+
+**Env の型**: 現状 `src/index.ts` の `Env` / `checkpoint.ts` の `CheckpointEnv` は手書き。`npm run cf-typegen` (= `wrangler types`) で config から `worker-configuration.d.ts` を生成できる (gitignore 済み・commit しない)。生成された runtime types へ完全移行 (= `@cloudflare/workers-types` を外し tsconfig を更新、手書き `Env` を撤去) は**別途の follow-up**。今は手書き `Env` が source of truth なので、binding を増やしたら手書き側も更新すること。
+
 ## ローカル開発のフロー
 
 1. `cp .dev.vars.example .dev.vars` で雛形コピー

--- a/packages/workers/CLAUDE.md
+++ b/packages/workers/CLAUDE.md
@@ -120,19 +120,23 @@ CORS は `ALLOWED_ORIGINS` (env var, カンマ区切り) による**許可リス
 GitHub repo の Settings → Environments に **2 つの環境** を作成:
 
 **Repo level (Settings → Secrets and variables → Actions)**
-- `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_PROJECT_NAME`
-  (環境共通の Cloudflare 認証情報)
+- `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_PROJECT_NAME` (環境共通)
+- **`CLOUDFLARE_API_TOKEN` は repo level に置かない** — 後述の通り Environment ごとに分ける (preview/staging で本番デプロイ権限の token を露出させない)
 
-**Environment `staging`** (承認なし、自動デプロイ)
+**Environment `staging`** (承認なし、自動デプロイ。preview もこの環境)
 - Secrets:
+  - `CLOUDFLARE_API_TOKEN` — **staging/preview 専用** (Pages:Edit + staging Worker のみ。本番 Worker 権限なし)
   - `VITE_API_URL` — staging Workers の URL (ビルド時に bundle に baked-in)
   - `VITE_TURNSTILE_SITE_KEY` — staging 用 Turnstile site key
 
 **Environment `production`** (Required reviewers 設定推奨 = 承認待ち)
 - Secrets:
+  - `CLOUDFLARE_API_TOKEN` — **本番専用** (承認ゲート配下なので Approve を経ないと使われない)
   - `VITE_API_URL` — 本番 Workers の URL
   - `VITE_TURNSTILE_SITE_KEY` — 本番 Turnstile site key
 - **Protection rule**: Required reviewers に 1 名以上 (自分でもよい) → main push 時に Actions タブで手動承認が必要になる
+
+> deploy job は全て `environment:` を宣言済みなので、Environment secret は同名 repo secret を**自動上書き**する。ワークフロー変更は不要。
 
 (KV namespace ID は wrangler.{staging,production}.toml に直接 commit するので環境 secret には入れない)
 

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -8,6 +8,7 @@
     "deploy:staging": "wrangler deploy --config wrangler.staging.toml",
     "deploy:production": "wrangler deploy --config wrangler.production.toml",
     "typecheck": "tsc --noEmit",
+    "cf-typegen": "wrangler types --config wrangler.staging.toml",
     "gen-checkpoint-key": "node scripts/generate-checkpoint-key.mjs",
     "test": "vitest",
     "test:run": "vitest run"

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -4,8 +4,10 @@
   "type": "module",
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy",
-    "deploy:prod": "wrangler deploy --env production",
+    "deploy": "echo 'Refusing bare deploy: it would target the production Worker name with the local dev config. Use deploy:staging or deploy:production (each pins --config).' && exit 1",
+    "deploy:staging": "wrangler deploy --config wrangler.staging.toml",
+    "deploy:production": "wrangler deploy --config wrangler.production.toml",
+    "typecheck": "tsc --noEmit",
     "gen-checkpoint-key": "node scripts/generate-checkpoint-key.mjs",
     "test": "vitest",
     "test:run": "vitest run"

--- a/packages/workers/src/__tests__/cors.test.ts
+++ b/packages/workers/src/__tests__/cors.test.ts
@@ -51,10 +51,16 @@ describe('CORS allowed-origin policy', () => {
     expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
   });
 
-  it('falls back to reflecting the origin when ALLOWED_ORIGINS is unset (backward compat)', async () => {
+  it('fail-closed: rejects any origin when ALLOWED_ORIGINS is unset in a non-dev environment', async () => {
     const env = baseEnv({ ALLOWED_ORIGINS: undefined });
     const res = await worker.fetch(preflight('https://anything.example.com'), env);
-    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://anything.example.com');
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
+  });
+
+  it('development still allows localhost even when ALLOWED_ORIGINS is unset', async () => {
+    const env = baseEnv({ ENVIRONMENT: 'development', ALLOWED_ORIGINS: undefined });
+    const res = await worker.fetch(preflight('http://localhost:5173'), env);
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:5173');
   });
 
   it('never emits a wildcard "*" Access-Control-Allow-Origin', async () => {

--- a/packages/workers/src/index.ts
+++ b/packages/workers/src/index.ts
@@ -89,11 +89,14 @@ function originMatchesPattern(origin: string, pattern: string): boolean {
  * リクエスト Origin を許可リストに照合し、許可するときのみその Origin を返す。
  * 返り値を `Access-Control-Allow-Origin` にそのまま入れる (reflect)。許可しないときは null。
  *
- * 優先順位:
+ * 優先順位 (**fail-closed**):
  *  1. `ALLOWED_ORIGINS` に一致 (完全一致 or `*.domain` サブドメイン wildcard) → 許可
  *  2. `ENVIRONMENT === 'development'` のとき localhost / 127.0.0.1 → 許可 (開発体験)
- *  3. `ALLOWED_ORIGINS` 未設定 → 後方互換で reflect (デプロイ破壊回避。production では設定必須)
- *  4. それ以外 → 拒否 (ヘッダを付与しない)
+ *  3. それ以外 → 拒否 (ヘッダを付与しない)
+ *
+ * 旧実装は `ALLOWED_ORIGINS` 未設定時に任意 Origin を reflect する fail-open
+ * だったが、staging/production の wrangler config に値を commit したため廃止。
+ * 非 development で許可リストが空 / 不一致なら拒否する (新環境では設定必須)。
  *
  * なお CORS はブラウザのクロスオリジン**読み取り**のみを制限するもので、
  * サーバ間アクセス (curl 等) は防げない。署名 API の濫用は per-session 上限
@@ -104,8 +107,7 @@ function resolveCorsOrigin(origin: string | null, env: CorsEnv): string | null {
   const allowed = parseAllowedOrigins(env);
   if (allowed.some(pattern => originMatchesPattern(origin, pattern))) return origin;
   if (env.ENVIRONMENT === 'development' && isLocalhostOrigin(origin)) return origin;
-  if (allowed.length === 0) return origin; // 未設定時のみ後方互換 reflect
-  return null;
+  return null; // fail-closed: 許可リストに無い (or 未設定の) Origin は拒否
 }
 
 /**

--- a/packages/workers/wrangler.production.toml
+++ b/packages/workers/wrangler.production.toml
@@ -19,12 +19,28 @@ name = "typedcode-api"
 main = "src/index.ts"
 compatibility_date = "2025-12-26"
 
+# Workers Logs を有効化 (運用時の観測性)。head_sampling_rate=1 は低トラフィックな
+# 署名 API 向けに全リクエストを記録する。トラフィックが増えたら下げる。
+[observability]
+enabled = true
+head_sampling_rate = 1
+
 [vars]
 ENVIRONMENT = "production"
 # CORS 許可オリジン (カンマ区切り)。editor / verify は同一 Pages プロジェクト
 # (editor=/, verify=/verify) なので origin は 1 つ。カスタムドメインと既定の
 # pages.dev の両方を許可する。シークレットではない公開ドメインなので直接 commit してよい。
 ALLOWED_ORIGINS = "https://typedcode.dev,https://typedcode.pages.dev"
+
+# 必須シークレットを宣言 (wrangler secret put で投入)。未設定のままデプロイすると
+# wrangler が deploy 時にエラーにするので、設定漏れによる本番事故を防げる。
+[secrets]
+required = [
+  "TURNSTILE_SECRET_KEY",
+  "ATTESTATION_SECRET_KEY",
+  "CHECKPOINT_SIGNING_KEY_ID",
+  "CHECKPOINT_SIGNING_KEY_JWK",
+]
 
 [[kv_namespaces]]
 binding = "CHECKPOINT_SESSIONS"

--- a/packages/workers/wrangler.staging.toml
+++ b/packages/workers/wrangler.staging.toml
@@ -18,6 +18,11 @@ name = "typedcode-api-staging"
 main = "src/index.ts"
 compatibility_date = "2025-12-26"
 
+# Workers Logs を有効化 (運用時の観測性)。head_sampling_rate=1 で全リクエスト記録。
+[observability]
+enabled = true
+head_sampling_rate = 1
+
 [vars]
 ENVIRONMENT = "staging"
 # CORS 許可オリジン。staging Worker は develop デプロイ (develop.typedcode.pages.dev)
@@ -25,6 +30,15 @@ ENVIRONMENT = "staging"
 # サブドメイン wildcard で自プロジェクト配下の pages.dev を許可する
 # (*.pages.dev のように広げないこと: 自プロジェクトの branch alias に限定される)。
 ALLOWED_ORIGINS = "https://*.typedcode.pages.dev"
+
+# 必須シークレット宣言 (wrangler secret put で投入)。未設定だと deploy 時にエラー。
+[secrets]
+required = [
+  "TURNSTILE_SECRET_KEY",
+  "ATTESTATION_SECRET_KEY",
+  "CHECKPOINT_SIGNING_KEY_ID",
+  "CHECKPOINT_SIGNING_KEY_JWK",
+]
 
 [[kv_namespaces]]
 binding = "CHECKPOINT_SESSIONS"


### PR DESCRIPTION
保守運用レビューの指摘 6 件を事実確認し、影響範囲を検証した上で修正しました。指摘ごとに 1 コミットです。

## 修正一覧

| # | 重要度 | 内容 | 対応 |
|---|---|---|---|
| 1 | **High** | 裸の `deploy`/`deploy:prod` がトップレベル `wrangler.toml` (production 名 + dev env + placeholder KV) を参照し誤デプロイし得た | `deploy:staging`/`deploy:production` を `--config` 固定に。裸 `deploy` はエラー終了ガードに置換。各 package に `typecheck` 追加 |
| 2 | **Med-High** | `ALLOWED_ORIGINS` 未設定時に任意 Origin を reflect する fail-open | `resolveCorsOrigin` を **fail-closed** 化 (非 dev + 不一致 → 拒否)。staging/production は設定済みなので影響なし |
| 3 | Med | CI `test` が shared/workers テストのみ。typecheck/build が merge 前ゲートでない | `check` job 追加 (全 package typecheck + build + Worker config dry-run)、deploy の `needs` に追加 |
| 4 | Med | workflow に `concurrency` 無し → 古い deploy が新成果物を上書きし得る | ref 単位の `concurrency`。PR はキャンセル、push はキューイング (最新が最後に走る・本番は途中キャンセルしない) |
| 5 | Med | `CLOUDFLARE_API_TOKEN` が repo-level 共用 | Environment scope への分離を setup.md / CLAUDE.md に明文化 (job は `environment:` 宣言済みなのでワークフロー変更不要) |
| 6 | Med-Low | wrangler に observability / secrets 宣言 / 生成型が無い | `[observability] enabled=true`、`[secrets] required=[...]` を staging/production に追加。`cf-typegen` 追加 + 型移行を follow-up として明記 |

## 事実確認メモ

- **#2 の前段**「config が未設定」は PR #62 マージ済みで**既に解消**。残る本質 (fail-open フォールバック) を fail-closed 化しました。
- **#1 の `wrangler.toml`** は skip-worktree (各開発者ローカル) のため、コミットされる `package.json` スクリプト側を是正。CI は wrangler-action に `--config` を直接渡すため npm script 変更の影響なし。
- `[observability]` / `[secrets].required` はいずれも `wrangler --dry-run` で検証済み (unexpected-field 警告なし)。`--dry-run` は secret 存在チェックを行わないため CI の config 検証ゲートは green のまま。

## テスト

- shared **183 passing** / workers **30 passing** (CORS fail-closed の期待値更新 + dev localhost 許可ケース追加)
- 全 package `tsc --noEmit` クリーン、`npm run build` 成功、staging/production の `wrangler --dry-run` 成功

## レビュー時の確認事項 (運用作業)

コード/設定は本 PR で揃いますが、以下は GitHub/Cloudflare 側の手作業が必要です:
- `CLOUDFLARE_API_TOKEN` を repo-level から **staging/production Environment secret** へ移設 (#5)
- staging/production Worker に必須 4 secrets が投入済みか確認 (#6 の `[secrets].required` は未投入だと deploy が失敗します)

🤖 Generated with [Claude Code](https://claude.com/claude-code)