### PR TITLE
ci: develop→main PR に staging プレビュー URL をコメント

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,8 @@ concurrency:
 # 構成:
 #   test                   — どのトリガでも必ず走る (shared / workers のユニットテスト)
 #   check                  — どのトリガでも必ず走る (全 package typecheck/build + Worker config dry-run)
-#   deploy-preview         — PR で Pages のプレビュー URL を発行 (Workers staging 向け)
+#   deploy-preview         — feature → develop PR で Pages のプレビュー URL を発行 (Workers staging 向け)
+#   comment-staging-preview— develop → main PR に staging URL をコメント (新規 preview は作らない)
 #   deploy-staging         — develop push で Workers staging + Pages staging を更新
 #   deploy-production      — main  push で Workers production + Pages production を更新
 #                            (GitHub Environment "production" の Required reviewers で承認待ち)
@@ -182,6 +183,57 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
                 body: body
+              });
+            }
+
+  # --------------------------------------------------------------------
+  # develop → main PR: 新規プレビューは作らない (develop push の deploy-staging が
+  # develop.<project>.pages.dev に出すのと URL が衝突するため)。代わりに、その
+  # staging URL を PR にコメントする。本番昇格前に確認すべき成果物がこれ。
+  # --------------------------------------------------------------------
+  comment-staging-preview:
+    needs: [test, check]
+    if: github.event_name == 'pull_request' && github.head_ref == 'develop' && github.base_ref == 'main'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment staging preview URL on the PR
+        uses: actions/github-script@v9
+        env:
+          PROJECT_NAME: ${{ secrets.CLOUDFLARE_PROJECT_NAME }}
+        with:
+          script: |
+            const url = `https://develop.${process.env.PROJECT_NAME}.pages.dev`;
+            const marker = '## 🔍 Staging Preview (develop → main)';
+            const body = `${marker}
+
+            | Name | URL |
+            |------|-----|
+            | Staging | ${url} |
+
+            この PR は develop を main に昇格します。develop の最新ビルドは常時この staging URL にデプロイされています (API: **staging** Workers)。本番デプロイ前の動作確認はここで行ってください。
+            *Promotion candidate: ${context.sha.substring(0, 7)}*`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const botComment = comments.find(c => c.user.type === 'Bot' && c.body.includes(marker));
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
               });
             }
 


### PR DESCRIPTION
## 背景
`develop → main` の PR（昇格 PR）では `deploy-preview` を意図的にスキップしているため、PR 画面にプレビュー URL が出ませんでした。

スキップの理由: develop push で走る `deploy-staging` が `develop.<project>.pages.dev` に出すのと、PR 側プレビュー（`--branch=develop`）が**同じ URL に衝突/競合**するため（`deploy-preview` の `if: github.head_ref != 'develop'`）。

## 変更
新規プレビューを作る代わりに、**`comment-staging-preview` job** を追加。`develop → main` PR に対し、develop の成果物が常時デプロイされている **staging URL（`https://develop.<project>.pages.dev`）** を PR コメントで提示します。これが本番昇格前に動作確認すべき成果物そのものです（API バックエンドは staging Workers）。

- 条件: `pull_request` かつ `head_ref == 'develop'` かつ `base_ref == 'main'`
- 既存コメントは marker で検出して更新（PR ごとに 1 コメント）
- `CLOUDFLARE_PROJECT_NAME` は `env:` 経由で渡し直接補間を避ける
- 新規 deploy はしない（コメントのみ）ので URL 衝突は起きない

## 反映の流れ
このPRを develop にマージ → develop に新コミットが入る → **既存の develop→main PR (#64) の CI が再実行**され、`comment-staging-preview` が走って #64 に staging URL コメントが付きます（`pull_request` の workflow は head=develop 側の定義で動くため）。

> 補足: 真の「production ビルドのプレビュー」を別途出すことも可能ですが、ランダムな `*.pages.dev` プレビュー URL は本番 Turnstile / CORS の許可ホストに入らず失敗するため、昇格 PR の確認先としては staging URL が最適です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)