### PR TITLE
ADR-0009 検証と直交する pluggable 分析層 framework + 最小スキャフォールド (Proposed)

### DIFF
--- a/docs/adr/0009-pluggable-analysis-layer.md
+++ b/docs/adr/0009-pluggable-analysis-layer.md
@@ -1,0 +1,119 @@
+# ADR-0009: 改ざん検証と直交する pluggable な分析層フレームワークを定義する
+
+- **Status**: Proposed
+- **Date**: 2026-06-06
+- **Deciders**: (PR 上の合意者 / レビュアー)
+- **PR / Commit**: (this PR)
+
+> ADR-0007 が「**分析ロジックは別 ADR・後段で pluggable**」と明記した、その別 ADR。捕捉済み信号を消費して**生成 AI 利用を間接判定する分析層**の枠組みを確定する。本 ADR は **framework（差し込み口・出力モデル・実行場所・配置/開示・evasion 方針）を確定**し、**4 分析器それぞれのアルゴリズムは後続 spec/ADR に委ねる**（進化＆evasion 感度が高いため）。
+
+## Context
+
+ADR-0006（封印問題束縛）・ADR-0007（生信号の最大捕捉）・ADR-0008（フルスクリーン記録）で「**束縛**」と「**捕捉**」を確定した。残るのが捕捉信号を消費する「**分析**」=「これは人間が打ったものか / 生成 AI の出力を転写したものか」を間接判定する層。前提:
+
+- **検証と分析は別物 (直交)**:
+  - **検証** = `verifyProofFile() → FullVerificationResult` ([packages/shared/src/verification.ts](../../packages/shared/src/verification.ts))。chain / PoSW / 署名 cp の**暗号的整合性**。決定論的で settled。**触らない**。
+  - **分析** = 人間らしさ / 異常度。**確率的・ヒューリスティック・反証可能で差し替え前提**。
+  - 暗号的に VALID な proof でも分析は「要確認」になり得るし、その逆もある。**混ぜてはならない**。
+- **クライアントは半信頼/敵対的**: コードは公開なので**捕捉ロジックは隠せない** (クライアント JS)。一方**分析ロジックは隠せる/進化させられる**。ここに非対称性がある。
+- **ブラウザの限界 (ADR-0007 と同じ)**: 他アプリを見られない → AI 直接検出は不可能。分析は常に間接 (入力の出自・liveness・ギャップ)。判定の本丸は**監督 (air gap) ＋証拠**。
+- **試験倫理**: 誤検知は致命的。誤った告発はデュープロセス上も許されない。→ 出力は**人間のレビューを補助する advisory** でなければならない。
+- **既に散在する advisory の芽**: コードには既に `isPureTyping` (paste/drop 検出)、`suspiciousBulkInsertEventIndexes`、署名 cp の `postHocSuspected`、verify の**空の `typingPatternAnalysis` / TypingPatternCard** がある。本 ADR はこれらの**散在 advisory を統合する受け皿**でもある (ゼロからの新設ではない)。
+
+## Considered Options
+
+### Option A: 検証に統合する (analyzer を `verifyProofFile` に組み込み `valid` に反映)
+- Pros: 単純、1 か所。
+- Cons: **暗号的整合性と確率的判定を混ぜる**＝致命的。人間らしさが `VALID/INVALID` に混入し、誤検知が「検証失敗」に化ける。差し替え不能。デュープロセスにも反する。→ **却下**。
+
+### Option B: verify / verify-cli に直書きする (分析を web/CLI それぞれにハードコード)
+- Pros: すぐ書ける。
+- Cons: ロジック重複、pluggable でない、進化のたび両方改修。ADR-0007 の「差し替え前提」に反する。→ **却下**。
+
+### Option C: 検証と直交する pluggable framework として分離定義する
+- 契約 `Analyzer.analyze((proof, verification)) → AnalysisSignal[]`、orchestrator が N 個を合成して `AnalysisReport` を生成。
+- 出力は **advisory signal ＋証拠 ＋要確認優先度のみ**、**判定 (pass/fail) はしない**。
+- 契約/型/orchestrator は shared、開示可の分析器は verify＋CLI、感度高は採点者側 private。**proof には焼かない** (後付け・再実行可能)。
+- 4 次元は**初期分析器セット**だが各アルゴは別 spec/ADR。
+- Pros: 直交性保持・差し替え可・再実行可・evasion 耐性 (感度高ロジック非配布)・既存 advisory の統合先。
+- Cons: 抽象 (contract/orchestrator/registry) の導入コスト、感度高分析器の配布管理。→ **採用**。
+
+## Decision
+
+Option C を採用。中心判断 = **分析層は暗号検証と直交する pluggable framework**。確定事項:
+
+1. **直交**: `verifyProofFile` / `FullVerificationResult` は**不変**。分析は `(ExportedProof, FullVerificationResult)` を消費する**新規 consumer**。暗号 VALID と分析スコアは独立軸として併記する (一方が他方を上書きしない)。
+2. **post-hoc / オフライン / クリティカルパス外**: 採点時に export 済み proof に対して走る。**エディタ内でライブには走らせない** (ADR-0008「止めない」原則・サーバ best-effort と整合)。
+3. **契約 (framework の核)** — 具体型は実装 PR で確定するが、形は以下:
+   ```typescript
+   type AnalysisDimension =
+     | 'automation'                    // 合成入力検出
+     | 'keystroke-content-consistency' // 打鍵動態 ↔ 内容の整合
+     | 'transcription-topology'        // 構築の形 (線形転写 vs 著述)
+     | 'focus-burst-correlation';      // 離脱 ↔ バーストの相関
+
+   interface AnalysisInput { proof: ExportedProof; verification: FullVerificationResult; }
+
+   interface EvidenceRef { fromEventIndex: number; toEventIndex?: number; note?: string; }
+
+   interface AnalysisSignal {
+     analyzerId: string;
+     dimension: AnalysisDimension;
+     score: number;        // 0..1 異常度
+     confidence: number;   // 0..1 確信度
+     severity: 'info' | 'notice' | 'review';
+     evidence: EvidenceRef[];   // 必須: event index / 時間範囲への参照
+     summary: string;
+   }
+
+   interface Analyzer { id: string; version: string; analyze(input: AnalysisInput): AnalysisSignal[] | Promise<AnalysisSignal[]>; }
+
+   interface AnalysisReport {
+     analyzerVersions: Record<string, string>;
+     signals: AnalysisSignal[];
+     reviewPriority: number;   // 集約された「要確認」度 — 判定ではない
+   }
+   ```
+   - **判定しない**: 自動 pass/fail を出さない。`reviewPriority` は**人間レビューの優先度**のみ。最終判断は監督/採点者。
+   - **証拠リンク必須**: 各 signal は event index / 時間範囲を指し、人間が当該箇所を検分できる。
+4. **配置 / 開示**: 契約・型・orchestrator・出力モデルは **shared (の非 crypto モジュール)**。開示してよい分析器 (自動化判定など) は **verify＋CLI に同梱**。閾値/重みが感度高いものは**採点者側 private** (verify-cli のビルドに注入、web verify には配布しない)。**proof に分析結果を焼き込まない** (後付け・再実行可能成果物、`analyzerVersion` で出自記録)。
+5. **初期分析器セット = 4 次元** (自動化判定 / keystroke↔content 整合 / 転写トポロジー / focus↔バースト相関)。各アルゴリズムは**別 spec/ADR** で確定する (進化＆evasion 感度のため本 ADR では決めない)。
+6. **既存 advisory の収容**: `isPureTyping` / bulk-insert 疑い / 署名 cp `postHocSuspected` 等の散在信号は、将来この framework の signal として**段階的に再表現**できる (後方互換、急がない)。
+
+## Consequences
+
+### Positive
+
+- 暗号検証の純度を保ったまま、人間らしさ分析を**任意に差し替え/追加**できる。
+- ADR-0007 の全捕捉が活き、**古い proof も将来の改良分析器 (ML 含む) で再評価可能**。
+- 感度高ロジックを非配布にでき、**evasion 耐性**を確保 (公開クライアントの非対称性を利用)。
+- 出力が advisory ＋証拠 ＋優先度のみ ＝ **誤検知の致命性を回避**し、監督/採点者の判断を補助する。
+- verify の空 `TypingPatternCard` 等、既存の半端な分析 UI に**正式な受け皿**を与える。
+
+### Negative / Trade-offs
+
+- 抽象 (contract / orchestrator / registry) の導入コスト。
+- 感度高分析器の**配布管理** (採点者側ビルドに private 注入する運用フローが要る)。
+- **evasion との軍拡**: 分析を公開する分だけ回避されやすい → 感度高は非公開＋進化前提で緩和。
+- 分析の有効性そのものは**未実証** (4 次元の精度・誤検知率は実データ評価が必要) → advisory 立て付けで被害を限定。
+
+### Follow-ups / 残課題
+
+- **4 分析器それぞれのアルゴリズム spec/ADR** (推奨順: 自動化判定 → keystroke↔content → 転写トポロジー → focus↔バースト)。各々に評価 (誤検知率・回避耐性)。
+- `AnalysisReport` / `AnalysisSignal` の**具体型を shared / system-spec.md に定義** (最初の分析器実装 PR と同時)。
+- **orchestrator / registry** の実装 (`checkpointKeys` registry が参考)。
+- verify の **`TypingPatternCard` を `AnalysisReport` 駆動に再配線**、verify-cli に `--- Analysis ---` セクション追加。
+- 感度高分析器の **private 配布フロー** (採点者側ビルドへの注入手順) の設計。
+- 既存散在 advisory (`isPureTyping` 等) の **signal への段階移行**方針。
+
+## References
+
+- [ADR-0007](0007-maximal-signal-capture.md) — 生信号の最大捕捉 (本 ADR はその**消費側**)
+- [ADR-0006](0006-exam-mode-sealed-problem-binding.md) — 試験モードの封印問題束縛
+- [ADR-0005](0005-input-type-policy.md) — paste/import の構造的禁止 (入力出自の既存方針)
+- [ADR-0004](0004-verifier-checkpoint-stance.md) — 未署名 cp を成功条件にしない (**advisory を成功条件にしない**既存前例)
+- [packages/shared/src/verification.ts](../../packages/shared/src/verification.ts) — `verifyProofFile` / `FullVerificationResult` (直交する暗号検証)
+- [packages/shared/src/types/proof.ts](../../packages/shared/src/types/proof.ts) — `ExportedProof` / `StoredEvent` (分析の入力)
+- `packages/verify/src/ui/ResultPanel.ts` — `TypingPatternCard` (分析 UI の受け皿)
+- `packages/verify-cli/src/output.ts` — CLI 出力 (`Analysis` セクション追加先)
+- [docs/system-spec.md](../system-spec.md) — 型定義の定義先

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,6 +39,7 @@
 | [0006](0006-exam-mode-sealed-problem-binding.md) | Proposed | 試験モードは封印問題パッケージで proof を試験にバインドする |
 | [0007](0007-maximal-signal-capture.md) | Proposed | 記録/試験モードで捕捉する生信号を最大化し確定する |
 | [0008](0008-exam-fullscreen-request-not-enforce.md) | Proposed | 試験モードはフルスクリーンを要求するが強制せず状態を記録する |
+| [0009](0009-pluggable-analysis-layer.md) | Proposed | 改ざん検証と直交する pluggable な分析層フレームワークを定義する |
 
 ## 参考
 

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -36,6 +36,7 @@
 | `attestation.ts` | 人間認証クライアント |
 | `fileProcessing/` | ZIP / JSON 解析 |
 | `types.ts` (実体は `types/`) | 全公開型 |
+| `analysis/` | 分析層フレームワーク (ADR-0009)。`runAnalysis` + 差し替え可能な `Analyzer`。検証と**直交**する advisory のみ。器のみで中身はプレースホルダ |
 
 ## 型定義の運用
 

--- a/packages/shared/src/__tests__/analysisOrchestrator.test.ts
+++ b/packages/shared/src/__tests__/analysisOrchestrator.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { runAnalysis } from '../analysis/orchestrator.js';
+import { pureTypingAnalyzer } from '../analysis/analyzers/pureTypingAnalyzer.js';
+import type {
+  AnalysisInput,
+  AnalysisSignal,
+  Analyzer,
+} from '../analysis/types.js';
+
+/** 分析器が触る最小フィールドだけを持つ AnalysisInput を組む (残りは未使用)。 */
+function makeInput(opts: {
+  isPureTyping?: boolean;
+  timestamps?: number[];
+}): AnalysisInput {
+  const events = (opts.timestamps ?? []).map((t, i) => ({
+    sequence: i,
+    timestamp: t,
+  }));
+  return {
+    proof: { proof: { events } } as unknown as AnalysisInput['proof'],
+    verification: {
+      valid: true,
+      metadataValid: true,
+      chainValid: true,
+      isPureTyping: opts.isPureTyping ?? true,
+    } as AnalysisInput['verification'],
+  };
+}
+
+function fixedAnalyzer(
+  id: string,
+  signals: AnalysisSignal[]
+): Analyzer {
+  return { id, version: '1.0.0', analyze: () => signals };
+}
+
+function signal(partial: Partial<AnalysisSignal> & { analyzerId: string }): AnalysisSignal {
+  return {
+    dimension: 'automation',
+    score: 1,
+    confidence: 1,
+    severity: 'review',
+    evidence: [],
+    summary: 'test',
+    ...partial,
+  };
+}
+
+describe('runAnalysis orchestrator', () => {
+  it('aggregates signals from every analyzer', async () => {
+    const report = await runAnalysis(makeInput({}), [
+      fixedAnalyzer('a', [signal({ analyzerId: 'a' })]),
+      fixedAnalyzer('b', [signal({ analyzerId: 'b' })]),
+    ]);
+    expect(report.signals.map((s) => s.analyzerId)).toEqual(['a', 'b']);
+  });
+
+  it('records each analyzer id to its version for provenance', async () => {
+    const report = await runAnalysis(makeInput({}), [
+      fixedAnalyzer('a', []),
+      fixedAnalyzer('b', []),
+    ]);
+    expect(report.analyzerVersions).toEqual({ a: '1.0.0', b: '1.0.0' });
+  });
+
+  it('sets reviewPriority to the max severity-weighted contribution', async () => {
+    const report = await runAnalysis(makeInput({}), [
+      fixedAnalyzer('a', [signal({ analyzerId: 'a', severity: 'review', score: 1, confidence: 1 })]),
+    ]);
+    expect(report.reviewPriority).toBe(1);
+  });
+
+  it('does not let info signals raise reviewPriority', async () => {
+    const report = await runAnalysis(makeInput({}), [
+      fixedAnalyzer('a', [signal({ analyzerId: 'a', severity: 'info', score: 1, confidence: 1 })]),
+    ]);
+    expect(report.reviewPriority).toBe(0);
+  });
+
+  it('keeps other analyzers when one throws', async () => {
+    const throwing: Analyzer = {
+      id: 'boom',
+      version: '1.0.0',
+      analyze: () => {
+        throw new Error('analyzer failure');
+      },
+    };
+    const report = await runAnalysis(makeInput({}), [
+      throwing,
+      fixedAnalyzer('ok', [signal({ analyzerId: 'ok' })]),
+    ]);
+    expect(report.signals.map((s) => s.analyzerId)).toEqual(['ok']);
+    expect(report.analyzerVersions['boom']).toBe('1.0.0');
+  });
+});
+
+describe('pureTypingAnalyzer (placeholder)', () => {
+  it('emits a notice when verification reports non-pure typing', async () => {
+    const report = await runAnalysis(makeInput({ isPureTyping: false }), [pureTypingAnalyzer]);
+    expect(report.signals).toHaveLength(1);
+    expect(report.signals[0]?.severity).toBe('notice');
+    expect(report.signals[0]?.dimension).toBe('transcription-topology');
+  });
+
+  it('stays silent when typing is pure', async () => {
+    const report = await runAnalysis(makeInput({ isPureTyping: true }), [pureTypingAnalyzer]);
+    expect(report.signals).toHaveLength(0);
+  });
+});

--- a/packages/shared/src/analysis/analyzers/index.ts
+++ b/packages/shared/src/analysis/analyzers/index.ts
@@ -1,0 +1,19 @@
+/**
+ * 既定で公開してよい (= 開示しても evasion を大きく助けない) サンプル分析器。
+ *
+ * いずれも **方向性を示すプレースホルダ** であり、実用的な判定ロジックではない
+ * (ADR-0009)。感度の高い本物の分析器は採点者側に private で足す想定。
+ * 差し替え方: `runAnalysis(input, [myAnalyzer, ...defaultAnalyzers])`。
+ */
+
+import type { Analyzer } from '../types.js';
+import { largestGapAnalyzer } from './largestGapAnalyzer.js';
+import { pureTypingAnalyzer } from './pureTypingAnalyzer.js';
+
+export const defaultAnalyzers: readonly Analyzer[] = [
+  largestGapAnalyzer,
+  pureTypingAnalyzer,
+];
+
+export { largestGapAnalyzer } from './largestGapAnalyzer.js';
+export { pureTypingAnalyzer } from './pureTypingAnalyzer.js';

--- a/packages/shared/src/analysis/analyzers/largestGapAnalyzer.ts
+++ b/packages/shared/src/analysis/analyzers/largestGapAnalyzer.ts
@@ -1,0 +1,48 @@
+/**
+ * [プレースホルダ分析器] イベント間の最大時間ギャップを 1 つの `info` signal にする。
+ *
+ * 目的は **方向性のデモ**: event ストリームを読み、証拠 (event 範囲) 付きで signal を
+ * 出す形を示すだけ。判定はしない (`info` なので reviewPriority に寄与しない)。
+ *
+ * 本物の focus↔バースト相関 (離脱 → 復帰 → 即・高速・低エラーのバースト検出) は
+ * 後続 spec/ADR。ここを差し替える形で実装する。
+ */
+
+import type { AnalysisInput, AnalysisSignal, Analyzer } from '../types.js';
+
+const ID = 'example-largest-gap';
+
+export const largestGapAnalyzer: Analyzer = {
+  id: ID,
+  version: '0.0.0',
+  analyze(input: AnalysisInput): AnalysisSignal[] {
+    const events = input.proof.proof.events;
+    if (events.length < 2) return [];
+
+    let maxGapMs = 0;
+    let atIndex = -1;
+    for (let i = 1; i < events.length; i++) {
+      const prev = events[i - 1]!;
+      const cur = events[i]!;
+      const gap = cur.timestamp - prev.timestamp;
+      if (gap > maxGapMs) {
+        maxGapMs = gap;
+        atIndex = i;
+      }
+    }
+    if (atIndex < 0) return [];
+
+    const gap = Math.round(maxGapMs);
+    return [
+      {
+        analyzerId: ID,
+        dimension: 'focus-burst-correlation',
+        score: 0, // プレースホルダ: 異常度は判定しない
+        confidence: 0,
+        severity: 'info',
+        evidence: [{ fromEventIndex: atIndex - 1, toEventIndex: atIndex, note: `gap ${gap}ms` }],
+        summary: `Largest inter-event gap: ${gap}ms (placeholder)`,
+      },
+    ];
+  },
+};

--- a/packages/shared/src/analysis/analyzers/pureTypingAnalyzer.ts
+++ b/packages/shared/src/analysis/analyzers/pureTypingAnalyzer.ts
@@ -1,0 +1,32 @@
+/**
+ * [プレースホルダ分析器] 既存の advisory `isPureTyping` を分析 signal に "折り込む" デモ。
+ *
+ * ADR-0009 の「散在する advisory (`isPureTyping` 等) を framework の signal へ段階移行
+ * する」方針の最小例であり、**検証結果 (`FullVerificationResult`) を消費する形**を示す。
+ * paste/drop の存在は弱い手掛かりとして `notice` を 1 つ出すだけで、判定はしない。
+ *
+ * 本物の転写トポロジー分析 (`range`/`rangeOffset` から構築の形を見る) は後続 spec/ADR。
+ */
+
+import type { AnalysisInput, AnalysisSignal, Analyzer } from '../types.js';
+
+const ID = 'example-pure-typing';
+
+export const pureTypingAnalyzer: Analyzer = {
+  id: ID,
+  version: '0.0.0',
+  analyze(input: AnalysisInput): AnalysisSignal[] {
+    if (input.verification.isPureTyping) return [];
+    return [
+      {
+        analyzerId: ID,
+        dimension: 'transcription-topology',
+        score: 0.3, // プレースホルダ: paste/drop の存在は弱い手掛かり
+        confidence: 0.5,
+        severity: 'notice',
+        evidence: [], // 本実装では paste/drop の event index を載せる
+        summary: 'Non-pure typing: paste/drop present (placeholder)',
+      },
+    ];
+  },
+};

--- a/packages/shared/src/analysis/index.ts
+++ b/packages/shared/src/analysis/index.ts
@@ -1,0 +1,23 @@
+/**
+ * 分析層 (ADR-0009): 検証と **直交** する pluggable な人間らしさ / 異常度分析の「器」。
+ *
+ * `Analyzer` を差すだけで増減・差し替え可能。アルゴリズムの中身は後続 spec/ADR。
+ * 既定の分析器 (`defaultAnalyzers`) は方向性を示すプレースホルダのみ。
+ */
+
+export type {
+  AnalysisDimension,
+  AnalysisSeverity,
+  EvidenceRef,
+  AnalysisSignal,
+  AnalysisInput,
+  Analyzer,
+  AnalysisReport,
+} from './types.js';
+
+export { runAnalysis } from './orchestrator.js';
+export {
+  defaultAnalyzers,
+  largestGapAnalyzer,
+  pureTypingAnalyzer,
+} from './analyzers/index.js';

--- a/packages/shared/src/analysis/orchestrator.ts
+++ b/packages/shared/src/analysis/orchestrator.ts
@@ -1,0 +1,75 @@
+/**
+ * 分析層 (ADR-0009) の orchestrator。
+ *
+ * 分析器群を走らせて `AnalysisReport` を組み立てるだけの薄い器。
+ * 分析器を差し替えれば分析内容を丸ごと入れ替えられる (既定は `defaultAnalyzers`)。
+ */
+
+import type {
+  AnalysisInput,
+  AnalysisReport,
+  AnalysisSeverity,
+  AnalysisSignal,
+  Analyzer,
+} from './types.js';
+import { defaultAnalyzers } from './analyzers/index.js';
+
+/** severity 別の要確認寄与の重み。`info` は寄与しない。 */
+const SEVERITY_WEIGHT: Record<AnalysisSeverity, number> = {
+  info: 0,
+  notice: 0.5,
+  review: 1,
+};
+
+function clamp01(n: number): number {
+  if (Number.isNaN(n)) return 0;
+  if (n < 0) return 0;
+  if (n > 1) return 1;
+  return n;
+}
+
+/**
+ * 1 signal の「要確認」寄与度 = severity 重み × score × confidence。
+ * (暫定の集約式。本格的な重み付けは後続。)
+ */
+function signalContribution(signal: AnalysisSignal): number {
+  return (
+    SEVERITY_WEIGHT[signal.severity] *
+    clamp01(signal.score) *
+    clamp01(signal.confidence)
+  );
+}
+
+/**
+ * 分析器群を走らせて `AnalysisReport` を組み立てる (ADR-0009)。
+ *
+ * - `analyzers` を差し替えれば分析内容を丸ごと入れ替えられる (既定は `defaultAnalyzers`)。
+ * - ある分析器が throw しても他を止めない (best-effort / graceful)。
+ * - `reviewPriority` は signal 寄与度の **最大値** (一本でも強い手掛かりがあれば優先)。
+ *   **判定ではない**。
+ */
+export async function runAnalysis(
+  input: AnalysisInput,
+  analyzers: readonly Analyzer[] = defaultAnalyzers
+): Promise<AnalysisReport> {
+  const signals: AnalysisSignal[] = [];
+  const analyzerVersions: Record<string, string> = {};
+
+  for (const analyzer of analyzers) {
+    analyzerVersions[analyzer.id] = analyzer.version;
+    try {
+      const produced = await analyzer.analyze(input);
+      for (const signal of produced) signals.push(signal);
+    } catch {
+      // 分析は best-effort。1 つの分析器の失敗で全体を落とさない。
+      // (失敗自体を signal 化するかは後続課題。)
+    }
+  }
+
+  const reviewPriority = signals.reduce(
+    (max, signal) => Math.max(max, signalContribution(signal)),
+    0
+  );
+
+  return { analyzerVersions, signals, reviewPriority };
+}

--- a/packages/shared/src/analysis/types.ts
+++ b/packages/shared/src/analysis/types.ts
@@ -1,0 +1,76 @@
+/**
+ * 分析層 (ADR-0009) の契約。
+ *
+ * 検証 (`verifyProofFile` → `FullVerificationResult`、暗号的整合性) と **直交** する、
+ * 人間らしさ / 異常度の post-hoc 分析。差し替え・追加・改良しやすいよう
+ * 「`Analyzer` を差すだけ」の最小契約にしてある。**アルゴリズムの中身は後続**
+ * (本ファイルはあくまで器の型定義)。
+ *
+ * 重要な不変条件:
+ * - 分析は **判定 (pass/fail) を出さない**。出すのは手掛かり (signal) と
+ *   人間レビュー優先度 (reviewPriority) のみ。最終判断は監督 / 採点者。
+ * - proof には焼き込まない (後付け・再実行可能な成果物)。
+ */
+
+import type { ExportedProof } from '../types/proof.js';
+import type { FullVerificationResult } from '../verification.js';
+
+/** 分析の観点 (ADR-0009 の初期 4 次元)。新しい観点は将来ここに足す。 */
+export type AnalysisDimension =
+  | 'automation' // 合成入力検出
+  | 'keystroke-content-consistency' // 打鍵動態 ↔ 内容の整合
+  | 'transcription-topology' // 構築の形 (線形転写 vs 著述)
+  | 'focus-burst-correlation'; // 離脱 ↔ バーストの相関
+
+/** signal の重大度。`info` は要確認度に寄与しない (純粋な情報)。 */
+export type AnalysisSeverity = 'info' | 'notice' | 'review';
+
+/** 証拠: 該当 event (範囲) を指す。人間が当該箇所を検分できるよう付けることを推奨。 */
+export interface EvidenceRef {
+  fromEventIndex: number;
+  toEventIndex?: number;
+  note?: string;
+}
+
+/** 1 つの分析所見。判定ではなく「人間が見るべき手掛かり」。 */
+export interface AnalysisSignal {
+  analyzerId: string;
+  dimension: AnalysisDimension;
+  /** 異常度 0..1。 */
+  score: number;
+  /** 確信度 0..1。 */
+  confidence: number;
+  severity: AnalysisSeverity;
+  /** 証拠の event 参照。空配列も可だが付けることを推奨。 */
+  evidence: EvidenceRef[];
+  /** 人間向けの一文サマリ。 */
+  summary: string;
+}
+
+/** Analyzer への入力: 検証済み proof と暗号判定 (直交) の組。 */
+export interface AnalysisInput {
+  proof: ExportedProof;
+  verification: FullVerificationResult;
+}
+
+/**
+ * 差し替え可能な分析器。これを実装して `runAnalysis` に渡すだけで増減できる。
+ *
+ * - 純粋・冪等であること (同じ入力 → 同じ signal)。
+ * - throw しても orchestrator が握り潰して他の分析器を止めない。
+ * - 感度の高い本物の分析器は採点者側に private で足す想定 (ADR-0009)。
+ */
+export interface Analyzer {
+  readonly id: string;
+  readonly version: string;
+  analyze(input: AnalysisInput): AnalysisSignal[] | Promise<AnalysisSignal[]>;
+}
+
+/** 分析レポート。判定 (pass/fail) は含めない。 */
+export interface AnalysisReport {
+  /** 走らせた分析器の id → version (出自記録・再現性)。 */
+  analyzerVersions: Record<string, string>;
+  signals: AnalysisSignal[];
+  /** 0..1 の「要確認」優先度。**判定ではない**。 */
+  reviewPriority: number;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -146,6 +146,18 @@ export {
 // タイピングパターン分析
 export { TypingPatternAnalyzer } from './typingPattern/index.js';
 
+// 分析層 (ADR-0009): 検証と直交する pluggable な分析フレームワーク (器のみ)
+export { runAnalysis, defaultAnalyzers } from './analysis/index.js';
+export type {
+  AnalysisDimension,
+  AnalysisSeverity,
+  EvidenceRef,
+  AnalysisSignal,
+  AnalysisInput,
+  Analyzer,
+  AnalysisReport,
+} from './analysis/index.js';
+
 // ユーティリティ関数
 export { escapeHtml } from './utils/index.js';
 

--- a/packages/verify-cli/src/output.ts
+++ b/packages/verify-cli/src/output.ts
@@ -18,7 +18,11 @@ function c(color: keyof typeof COLORS, text: string): string {
   return useColors ? `${COLORS[color]}${text}${COLORS.reset}` : text;
 }
 
-import type { VerificationMode, SignedCheckpointsVerificationResult } from '@typedcode/shared';
+import type {
+  VerificationMode,
+  SignedCheckpointsVerificationResult,
+  AnalysisReport,
+} from '@typedcode/shared';
 
 export interface VerificationOutput {
   valid: boolean;
@@ -36,6 +40,8 @@ export interface VerificationOutput {
   mode?: VerificationMode;
   poswSkipped?: boolean;
   signedCheckpoints?: SignedCheckpointsVerificationResult;
+  /** 分析層 (ADR-0009) の advisory レポート。判定ではない。 */
+  analysis?: AnalysisReport;
 }
 
 export function formatResult(result: VerificationOutput): string {
@@ -107,6 +113,29 @@ export function formatResult(result: VerificationOutput): string {
       }
     } else {
       lines.push(`Anchoring:   ${c('red', 'FAILED')} ${sc.reason ?? ''}`);
+    }
+  }
+
+  // 分析層 (ADR-0009): 検証とは別軸の advisory。判定ではないことを明示する。
+  const analysis = result.analysis;
+  if (analysis) {
+    lines.push('');
+    lines.push(c('cyan', '--- Analysis (advisory) ---'));
+    lines.push(c('dim', 'Heuristic, not a verdict — for human review only.'));
+    if (analysis.signals.length === 0) {
+      lines.push('No analysis signals.');
+    } else {
+      const pct = (analysis.reviewPriority * 100).toFixed(0);
+      lines.push(`Review priority: ${pct}%`);
+      for (const s of analysis.signals) {
+        const tag =
+          s.severity === 'review'
+            ? c('yellow', 'REVIEW')
+            : s.severity === 'notice'
+              ? c('yellow', 'NOTICE')
+              : c('dim', 'INFO');
+        lines.push(`  [${tag}] ${s.dimension}: ${s.summary}`);
+      }
     }
   }
 

--- a/packages/verify-cli/src/verify.ts
+++ b/packages/verify-cli/src/verify.ts
@@ -5,10 +5,12 @@
 
 import {
   verifyProofFile,
+  runAnalysis,
   type ProofFile,
   type VerificationProgressCallback,
   type VerificationMode,
   type FullVerificationResult,
+  type AnalysisReport,
 } from '@typedcode/shared';
 import { ProgressBar } from './progress.js';
 
@@ -31,6 +33,8 @@ export interface CLIVerificationResult {
   mode: VerificationMode;
   poswSkipped: boolean;
   signedCheckpoints: FullVerificationResult['signedCheckpoints'];
+  /** 分析層 (ADR-0009) の advisory レポート。判定ではない。 */
+  analysis: AnalysisReport;
 }
 
 export async function verifyProof(
@@ -54,6 +58,10 @@ export async function verifyProof(
   const result = await verifyProofFile(proof, onProgress, { mode });
 
   progressBar.complete();
+
+  // 分析層 (ADR-0009): 検証と直交する post-hoc 分析。既定の分析器は方向性を示す
+  // プレースホルダのみ。advisory であって判定ではない (verifyProofFile の valid とは別軸)。
+  const analysis = await runAnalysis({ proof, verification: result });
 
   // Calculate statistics
   const pasteEvents = events.filter((e) => e.inputType === 'insertFromPaste').length;
@@ -80,5 +88,6 @@ export async function verifyProof(
     mode,
     poswSkipped: result.poswSkipped ?? false,
     signedCheckpoints: result.signedCheckpoints,
+    analysis,
   };
 }


### PR DESCRIPTION
## 概要

ADR-0007 が「分析は別 ADR・後段で pluggable」と切った、その分析層の **framework** を確定する ADR。捕捉済み信号を消費して生成 AI 利用を**間接判定**する。

**中心判断：分析層は暗号検証と直交する pluggable framework。**

- **直交**：`verifyProofFile / FullVerificationResult`（暗号的整合性）は不変。分析は `(ExportedProof, FullVerificationResult)` を消費する新規 consumer。VALID と分析スコアは独立軸
- **post-hoc / オフライン / クリティカルパス外**：採点時に export 済み proof に対して走る（エディタ内ライブには走らせない）
- **契約**：`analyze((proof, verification)) → AnalysisSignal[]`、orchestrator が合成 → `AnalysisReport`。各 signal = dimension / score / confidence / severity / **証拠(event 参照)**
- **判定しない**：advisory signal ＋証拠 ＋`reviewPriority`（要確認優先度）のみ。自動 pass/fail なし。最終判断は監督/採点者（誤検知の致命性・デュープロセス）
- **配置/開示**：契約・型・orchestrator は shared／開示可の分析器は verify＋CLI／閾値・重みが感度高いものは**採点者側 private**（web verify には非配布）。**proof には焼かない**（後付け・再実行可能、`analyzerVersion` で出自記録）
- **初期分析器セット = 4 次元**（自動化判定 / keystroke↔content 整合 / 転写トポロジー / focus↔バースト相関）。各アルゴは**後続 spec/ADR**（進化＆evasion 感度のため本 ADR では決めない）

## 却下した案

- **検証に統合**（analyzer を `verifyProofFile` に組込み `valid` に反映）→ 暗号と確率を混同、誤検知が「検証失敗」に化ける、差し替え不能
- **verify/CLI に直書き** → 重複・pluggable でない・進化のたび両改修

## 効能

- 暗号検証の純度を保ったまま分析を差し替え/追加可能
- ADR-0007 の全捕捉が活き、**古い proof も将来の改良分析器（ML 含む）で再評価可能**
- 感度高ロジック非配布で **evasion 耐性**（公開クライアントの非対称性を利用）
- verify の空 `TypingPatternCard` 等、既存の散在 advisory（`isPureTyping`/bulk-insert 疑い/`postHocSuspected`）に正式な受け皿

## スタック

develop 直結（ADR-0006/0007/0008 はマージ済み）。これで設計フェーズの ADR-0006〜0009 が出揃う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)