### PR TITLE
feat: 分析器 2 次元 (転写トポロジー / focus↔バースト) — ADR-0009

### DIFF
--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -36,7 +36,7 @@
 | `attestation.ts` | 人間認証クライアント |
 | `fileProcessing/` | ZIP / JSON 解析 |
 | `types.ts` (実体は `types/`) | 全公開型 |
-| `analysis/` | 分析層フレームワーク (ADR-0009)。`runAnalysis` + 差し替え可能な `Analyzer`。検証と**直交**する advisory のみ。器のみで中身はプレースホルダ |
+| `analysis/` | 分析層フレームワーク (ADR-0009)。`runAnalysis` + 差し替え可能な `Analyzer` 群 (automation / transcription-topology / focus-burst の第一次ヒューリスティック + pureTyping)。検証と**直交**する advisory のみ・判定しない |
 
 ## 型定義の運用
 

--- a/packages/shared/src/__tests__/focusBurstAnalyzer.test.ts
+++ b/packages/shared/src/__tests__/focusBurstAnalyzer.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { focusBurstAnalyzer } from '../analysis/analyzers/focusBurstAnalyzer.js';
+import type { AnalysisInput } from '../analysis/types.js';
+
+function input(events: unknown[]): AnalysisInput {
+  return {
+    proof: { proof: { events } } as unknown as AnalysisInput['proof'],
+    verification: {
+      valid: true,
+      metadataValid: true,
+      chainValid: true,
+      isPureTyping: true,
+    } as AnalysisInput['verification'],
+  };
+}
+
+const blur = (t: number) => ({ type: 'focusChange', timestamp: t, data: { focused: false } });
+const focus = (t: number) => ({ type: 'focusChange', timestamp: t, data: { focused: true } });
+const insert = (t: number, chars: number) => ({
+  type: 'contentChange',
+  timestamp: t,
+  insertLength: chars,
+});
+
+describe('focusBurstAnalyzer', () => {
+  it('flags a large input burst right after a long absence', async () => {
+    const events = [blur(0), focus(20_000), insert(21_000, 250)];
+    const signals = await focusBurstAnalyzer.analyze(input(events));
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.dimension).toBe('focus-burst-correlation');
+    expect(signals[0]?.evidence[0]?.fromEventIndex).toBe(1);
+  });
+
+  it('stays silent for a short absence', async () => {
+    const events = [blur(0), focus(5_000), insert(6_000, 250)];
+    const signals = await focusBurstAnalyzer.analyze(input(events));
+    expect(signals).toHaveLength(0);
+  });
+
+  it('stays silent when the post-return burst is small', async () => {
+    const events = [blur(0), focus(20_000), insert(21_000, 20)];
+    const signals = await focusBurstAnalyzer.analyze(input(events));
+    expect(signals).toHaveLength(0);
+  });
+
+  it('ignores inserts that fall outside the post-return window', async () => {
+    const events = [blur(0), focus(20_000), insert(100_000, 500)];
+    const signals = await focusBurstAnalyzer.analyze(input(events));
+    expect(signals).toHaveLength(0);
+  });
+});

--- a/packages/shared/src/__tests__/transcriptionTopologyAnalyzer.test.ts
+++ b/packages/shared/src/__tests__/transcriptionTopologyAnalyzer.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { transcriptionTopologyAnalyzer } from '../analysis/analyzers/transcriptionTopologyAnalyzer.js';
+import type { AnalysisInput } from '../analysis/types.js';
+
+function input(events: unknown[]): AnalysisInput {
+  return {
+    proof: { proof: { events } } as unknown as AnalysisInput['proof'],
+    verification: {
+      valid: true,
+      metadataValid: true,
+      chainValid: true,
+      isPureTyping: true,
+    } as AnalysisInput['verification'],
+  };
+}
+
+/** n 件の contentChange を作り、先頭 deletions 件を削除イベントにする。 */
+function contentEvents(n: number, deletions: number): unknown[] {
+  return Array.from({ length: n }, (_, i) => ({
+    type: 'contentChange',
+    inputType: i < deletions ? 'deleteContentBackward' : 'insertText',
+    insertLength: 1,
+  }));
+}
+
+describe('transcriptionTopologyAnalyzer', () => {
+  it('flags an almost-zero revision rate over substantial editing', async () => {
+    const signals = await transcriptionTopologyAnalyzer.analyze(input(contentEvents(200, 1)));
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.dimension).toBe('transcription-topology');
+    expect(signals[0]?.severity).toBe('notice');
+  });
+
+  it('stays silent when revisions are present', async () => {
+    const signals = await transcriptionTopologyAnalyzer.analyze(input(contentEvents(200, 40)));
+    expect(signals).toHaveLength(0);
+  });
+
+  it('stays silent on a sample too small to judge', async () => {
+    const signals = await transcriptionTopologyAnalyzer.analyze(input(contentEvents(50, 0)));
+    expect(signals).toHaveLength(0);
+  });
+});

--- a/packages/shared/src/analysis/analyzers/focusBurstAnalyzer.ts
+++ b/packages/shared/src/analysis/analyzers/focusBurstAnalyzer.ts
@@ -1,0 +1,72 @@
+/**
+ * focus-burst-correlation 分析器 (ADR-0009)。
+ *
+ * [第一次ヒューリスティック] 長い離脱 → 復帰直後の大量入力を見る。
+ *
+ * 「離席して (ChatGPT 等を見て) 戻り、まとめて打ち込む」形を狙う。focusChange の blur→focus 対で
+ * 離脱が長く、復帰後の一定窓に挿入文字数が多い場合に手掛かりを出す。「考えて戻って一気に書く」
+ * 正規ケースも該当し得るため confidence は中程度。本格版は visibility/idle との突合や打鍵動態との
+ * 相関まで見る (後続)。
+ *
+ * 出力は advisory のみ — 判定はしない。
+ */
+
+import type { AnalysisInput, AnalysisSignal, Analyzer } from '../types.js';
+import type { FocusChangeData } from '../../types/events.js';
+
+const ID = 'focus-burst';
+/** これ以上の離脱を「長い離脱」とみなす (ms)。 */
+const MIN_BLUR_MS = 15_000;
+/** 復帰後この窓の挿入量を見る (ms)。 */
+const BURST_WINDOW_MS = 20_000;
+/** 復帰後の窓でこれ以上の挿入文字数なら手掛かりとする。 */
+const BURST_CHARS = 200;
+
+export const focusBurstAnalyzer: Analyzer = {
+  id: ID,
+  version: '0.1.0',
+  analyze(input: AnalysisInput): AnalysisSignal[] {
+    const events = input.proof.proof.events;
+    const signals: AnalysisSignal[] = [];
+
+    let blurAt: number | null = null;
+    for (let i = 0; i < events.length; i++) {
+      const e = events[i]!;
+      if (e.type !== 'focusChange') continue;
+
+      const focused = (e.data as FocusChangeData | null)?.focused === true;
+      if (!focused) {
+        blurAt = e.timestamp;
+        continue;
+      }
+      if (blurAt === null) continue;
+
+      const blurMs = e.timestamp - blurAt;
+      blurAt = null;
+      if (blurMs < MIN_BLUR_MS) continue;
+
+      // 復帰直後の窓に挿入された文字数を集計
+      const windowEnd = e.timestamp + BURST_WINDOW_MS;
+      let burst = 0;
+      for (let j = i + 1; j < events.length; j++) {
+        const f = events[j]!;
+        if (f.timestamp > windowEnd) break;
+        if (f.type === 'contentChange') burst += f.insertLength ?? 0;
+      }
+      if (burst < BURST_CHARS) continue;
+
+      const awaySec = Math.round(blurMs / 1000);
+      signals.push({
+        analyzerId: ID,
+        dimension: 'focus-burst-correlation',
+        score: Math.min(1, burst / (BURST_CHARS * 4)),
+        confidence: 0.45,
+        severity: 'notice',
+        evidence: [{ fromEventIndex: i, note: `~${awaySec}s away, then ${burst} chars` }],
+        summary: `Large input burst (${burst} chars) immediately after a ~${awaySec}s absence`,
+      });
+    }
+
+    return signals;
+  },
+};

--- a/packages/shared/src/analysis/analyzers/index.ts
+++ b/packages/shared/src/analysis/analyzers/index.ts
@@ -1,21 +1,34 @@
 /**
  * 既定で公開してよい (= 開示しても evasion を大きく助けない) 分析器。
  *
- * - `automation`: 自動化ブラウザの環境 tell を見る最初の本物の分析器 (ADR-0009)。
- * - `pureTyping`: 既存 advisory (`isPureTyping`) を signal に折り込むプレースホルダ。
+ * ADR-0009 の次元の第一次ヒューリスティック + 既存 advisory の折り込み:
+ * - `automation`             : 自動化ブラウザの環境 tell (webdriver / 自動化グローバル / headless renderer)
+ * - `transcription-topology` : 修正 (削除) の少なさ
+ * - `focus-burst`            : 長い離脱 → 復帰直後の大量入力
+ * - `pureTyping`             : 既存 `isPureTyping` advisory の折り込み
  *
- * 感度の高い本物の分析器 (転写トポロジー / keystroke↔content 等) は採点者側に private で
- * 足す想定。差し替え方: `runAnalysis(input, [myAnalyzer, ...defaultAnalyzers])`。
+ * いずれも **第一次ヒューリスティックで低 confidence・advisory のみ**。感度の高い本物の分析器
+ * (重み/閾値を秘匿したいもの) は採点者側に private で足す想定。
+ * 差し替え方: `runAnalysis(input, [myAnalyzer, ...defaultAnalyzers])`。
+ *
+ * NOTE: keystroke↔content 整合は「挿入文字数 ÷ 打鍵数」の比率では IME 予測変換/補完を
+ * 測ってしまい日本語ユーザを誤検知するため見送り。タイミング/合成構造ベースの本格版を別途設計する。
  */
 
 import type { Analyzer } from '../types.js';
 import { automationAnalyzer } from './automationAnalyzer.js';
+import { transcriptionTopologyAnalyzer } from './transcriptionTopologyAnalyzer.js';
+import { focusBurstAnalyzer } from './focusBurstAnalyzer.js';
 import { pureTypingAnalyzer } from './pureTypingAnalyzer.js';
 
 export const defaultAnalyzers: readonly Analyzer[] = [
   automationAnalyzer,
+  transcriptionTopologyAnalyzer,
+  focusBurstAnalyzer,
   pureTypingAnalyzer,
 ];
 
 export { automationAnalyzer } from './automationAnalyzer.js';
+export { transcriptionTopologyAnalyzer } from './transcriptionTopologyAnalyzer.js';
+export { focusBurstAnalyzer } from './focusBurstAnalyzer.js';
 export { pureTypingAnalyzer } from './pureTypingAnalyzer.js';

--- a/packages/shared/src/analysis/analyzers/transcriptionTopologyAnalyzer.ts
+++ b/packages/shared/src/analysis/analyzers/transcriptionTopologyAnalyzer.ts
@@ -1,0 +1,45 @@
+/**
+ * transcription-topology 分析器 (ADR-0009)。
+ *
+ * [第一次ヒューリスティック] 修正 (削除) が極端に少なくないかを見る。
+ *
+ * 原文を著述するときは試行錯誤で削除が混じる。外部ソースを見ながら打ち直す「転写」は
+ * 削除がほぼ出ない傾向がある。content イベントに占める削除系 inputType の比率が極端に低い
+ * 場合に弱い手掛かりを出す。慎重で手戻りの少ない人も低くなり得るため confidence は低い。
+ * 本格的な構築トポロジー分析 (rangeOffset の前後跳躍・挿入順序の形) は後続。
+ *
+ * 出力は advisory のみ — 判定はしない。
+ */
+
+import type { AnalysisInput, AnalysisSignal, Analyzer } from '../types.js';
+
+const ID = 'transcription-topology';
+/** これ未満の編集数では試料が小さすぎるので判定しない。 */
+const MIN_CONTENT_EVENTS = 100;
+/** 削除比率がこれ未満なら「修正がほぼ無い」とみなす。 */
+const LOW_REVISION_RATIO = 0.02;
+
+export const transcriptionTopologyAnalyzer: Analyzer = {
+  id: ID,
+  version: '0.1.0',
+  analyze(input: AnalysisInput): AnalysisSignal[] {
+    const content = input.proof.proof.events.filter((e) => e.type === 'contentChange');
+    if (content.length < MIN_CONTENT_EVENTS) return [];
+
+    const deletions = content.filter((e) => e.inputType?.startsWith('delete') ?? false).length;
+    const revisionRatio = deletions / content.length;
+    if (revisionRatio >= LOW_REVISION_RATIO) return [];
+
+    return [
+      {
+        analyzerId: ID,
+        dimension: 'transcription-topology',
+        score: 0.4,
+        confidence: 0.3,
+        severity: 'notice',
+        evidence: [],
+        summary: `Very low revision rate (${(revisionRatio * 100).toFixed(1)}% deletions over ${content.length} edits): transcription-like`,
+      },
+    ];
+  },
+};

--- a/packages/shared/src/analysis/index.ts
+++ b/packages/shared/src/analysis/index.ts
@@ -19,5 +19,7 @@ export { runAnalysis } from './orchestrator.js';
 export {
   defaultAnalyzers,
   automationAnalyzer,
+  transcriptionTopologyAnalyzer,
+  focusBurstAnalyzer,
   pureTypingAnalyzer,
 } from './analyzers/index.js';


### PR DESCRIPTION
## 概要

ADR-0009 の 4 次元のうち **automation 以外で IME に堅牢な2つ**を **第一次ヒューリスティック**として追加。すべて**既に捕捉済みのデータだけ**で動くので **追加捕捉ゼロ・新イベント型なし・proof フォーマット不変**（shared に analyzer を足すだけ）。

| 分析器 | 次元 | 見るもの |
|---|---|---|
| `transcription-topology` | transcription-topology | 削除（修正）比率の低さ（転写は手戻りが少ない傾向） |
| `focus-burst` | focus-burst-correlation | 長い離脱 → 復帰直後の大量入力（離席して戻り一気に打ち込む形） |

## keystroke-content を見送った理由（日本語対応）

当初は `keystroke-content`（挿入文字数 ÷ 打鍵数）も入れていたが、レビューで**日本語の予測変換/Tab補完を誤検知する設計欠陥**が判明したため**外した**：

- 基本の変換（ローマ字+Space確定）は打鍵が全部数えられるので比率 ≤ 1 で安全
- だが**比率が 1 を超える唯一の経路 = 複数文字の一括挿入 = IME 予測変換・補完**（paste は ADR-0005 で禁止済み）。つまりこの比率は実質「予測変換/補完の使用量」を測っており、AI 不正と区別できない
- 日本語ファーストのツールで予測変換を多用する正規受験者を誤検知する方向 → 低 confidence では済まない欠陥
- `AnalysisDimension` の `keystroke-content-consistency` は taxonomy として残し、IME を踏まえた**本格版（比率でなくタイミング/合成構造ベース）を後で別途設計**

## 立て付け

- すべて **低 confidence・advisory のみ・判定しない**（ADR-0009）。誤検知し得るノイズ源を docstring に明記
- 本格版は差し替え前提（pluggable）。`verify-cli` の `--- Analysis (advisory) ---` に自動表示

## 検証

- shared **202 tests pass**／typecheck clean（全ワークスペース）

🤖 Generated with [Claude Code](https://claude.com/claude-code)