### PR TITLE
feat(editor): 試験モードの最小骨組み (ADR-0006 minimal skeleton)

### DIFF
--- a/packages/editor/index.html
+++ b/packages/editor/index.html
@@ -194,6 +194,15 @@
       <main class="workbench">
         <!-- Upper Area: Editor + Log Viewer -->
         <div class="workbench-upper">
+          <!-- Problem Panel (Exam Mode, 左) — ?exam=1 のときのみ表示 -->
+          <div id="problem-panel">
+            <div class="problem-header">
+              <h2><i class="fas fa-graduation-cap"></i> <span data-i18n="exam.title">Exam Mode</span></h2>
+            </div>
+            <div class="problem-content">
+              <div id="problem-body" class="problem-body" data-i18n="exam.problemPlaceholder">Exam mode. The problem will appear here.</div>
+            </div>
+          </div>
           <div class="editor-container">
             <!-- Editor Tabs -->
             <div class="editor-tabs-container">

--- a/packages/editor/src/core/AppContext.ts
+++ b/packages/editor/src/core/AppContext.ts
@@ -35,6 +35,7 @@ import type { DownloadDropdown } from '../ui/components/DownloadDropdown.js';
 import type { MainMenuDropdown } from '../ui/components/MainMenuDropdown.js';
 import type { TerminalPanel } from '../ui/components/TerminalPanel.js';
 import type { BrowserPreviewPanel } from '../ui/components/BrowserPreviewPanel.js';
+import type { ProblemPanel } from '../ui/components/ProblemPanel.js';
 import type { WelcomeScreen } from '../ui/components/WelcomeScreen.js';
 import type { TitlebarClock } from '../ui/components/TitlebarClock.js';
 
@@ -96,9 +97,13 @@ export interface AppContext {
   mainMenuDropdown: MainMenuDropdown;
   terminalPanel: TerminalPanel;
   browserPreviewPanel: BrowserPreviewPanel;
+  /** 試験モードの問題表示パネル (ADR-0006 最小骨組み・スタブ) */
+  problemPanel: ProblemPanel;
 
   // Flags
   skipBeforeUnload: boolean;
+  /** 試験モードか (?exam=1)。casual との差は機能のみ (ADR-0006/0007)。 */
+  examMode: boolean;
 
   // Welcome Screen
   welcomeScreen: WelcomeScreen | null;

--- a/packages/editor/src/i18n/translations/en.ts
+++ b/packages/editor/src/i18n/translations/en.ts
@@ -502,4 +502,10 @@ export const en: TranslationKeys = {
     resuming: 'Resuming session...',
     clearing: 'Clearing data...',
   },
+
+  // Exam mode (ADR-0006)
+  exam: {
+    title: 'Exam Mode',
+    problemPlaceholder: 'Exam mode. The problem will appear in this panel (problem distribution coming later).',
+  },
 };

--- a/packages/editor/src/i18n/translations/ja.ts
+++ b/packages/editor/src/i18n/translations/ja.ts
@@ -502,4 +502,10 @@ export const ja: TranslationKeys = {
     resuming: 'セッションを再開中...',
     clearing: 'データをクリア中...',
   },
+
+  // 試験モード (ADR-0006)
+  exam: {
+    title: '試験モード',
+    problemPlaceholder: '試験モードです。問題はこの欄に表示されます（問題の配布は今後実装予定）。',
+  },
 };

--- a/packages/editor/src/i18n/types.ts
+++ b/packages/editor/src/i18n/types.ts
@@ -528,4 +528,10 @@ export interface TranslationKeys {
     resuming: string;
     clearing: string;
   };
+
+  // Exam mode (ADR-0006)
+  exam: {
+    title: string;
+    problemPlaceholder: string;
+  };
 }

--- a/packages/editor/src/main.ts
+++ b/packages/editor/src/main.ts
@@ -34,6 +34,11 @@ if (urlParams.get('fresh') === '1') {
   window.history.replaceState({}, '', cleanUrl);
 }
 
+// Exam mode (ADR-0006 最小骨組み): ?exam=1 で試験モードに入る。
+// 現状は問題パネル (スタブ) を出すだけ。封印問題パッケージ / 監督コード / チェーン束縛は
+// full ADR-0006 で実装する。URL は意図的にクリーンにしない (リロードで試験モードを維持)。
+const examMode = urlParams.get('exam') === '1' || urlParams.get('exam') === 'true';
+
 import * as monaco from 'monaco-editor';
 import './styles/main.css';
 import { Fingerprint, setSharedDebug } from '@typedcode/shared';
@@ -78,6 +83,7 @@ import { RuntimeManager } from './execution/RuntimeManager.js';
 import { TabUIController } from './ui/tabs/TabUIController.js';
 import { LogViewerPanel } from './ui/components/LogViewerPanel.js';
 import { BrowserPreviewPanel } from './ui/components/BrowserPreviewPanel.js';
+import { ProblemPanel } from './ui/components/ProblemPanel.js';
 import { EventRecorder, SessionContentRegistry } from './core/index.js';
 import type { AppContext } from './core/AppContext.js';
 import { t, getI18n, initDOMi18n } from './i18n/index.js';
@@ -224,9 +230,11 @@ const ctx: AppContext = {
   mainMenuDropdown: new MainMenuDropdown(),
   terminalPanel: new TerminalPanel(),
   browserPreviewPanel: new BrowserPreviewPanel(),
+  problemPanel: new ProblemPanel(),
 
   // Flags
   skipBeforeUnload: false,
+  examMode,
 
   // Welcome Screen
   welcomeScreen: null as WelcomeScreen | null,
@@ -240,6 +248,15 @@ const ctx: AppContext = {
   // Session Content Registry (for internal paste detection)
   contentRegistry: new SessionContentRegistry(),
 };
+
+// 試験モード: 問題パネル (スタブ) を表示する。casual モードでは何もしない。
+// Monaco は automaticLayout: true なのでパネル出現に伴う再レイアウトは自動。
+if (ctx.examMode) {
+  document.body.classList.add('exam-mode');
+  if (ctx.problemPanel.initialize()) {
+    ctx.problemPanel.show();
+  }
+}
 
 // ========================================
 // 初期化オーバーレイ

--- a/packages/editor/src/styles/components/_problem-panel.css
+++ b/packages/editor/src/styles/components/_problem-panel.css
@@ -1,0 +1,47 @@
+/* Problem Panel (試験モード / ADR-0006 最小骨組み)
+   左サイドの問題表示パネル。casual モードでは非表示 (.visible が付かない)。 */
+#problem-panel {
+  display: none;
+  flex: 0 0 340px;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+  border-right: 1px solid var(--border-color, #333);
+  background: var(--bg-secondary, #1e1e1e);
+}
+
+#problem-panel.visible {
+  display: flex;
+}
+
+.problem-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  flex: 0 0 auto;
+  border-bottom: 1px solid var(--border-color, #333);
+}
+
+.problem-header h2 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.problem-content {
+  flex: 1 1 auto;
+  overflow: auto;
+  padding: 12px;
+}
+
+.problem-body {
+  font-size: 13px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+  opacity: 0.85;
+}

--- a/packages/editor/src/styles/main.css
+++ b/packages/editor/src/styles/main.css
@@ -23,6 +23,7 @@
 @import './components/_terminal.css';
 @import './components/_log-viewer.css';
 @import './components/_browser-preview.css';
+@import './components/_problem-panel.css';
 @import './components/_modals.css';
 @import './components/_notifications.css';
 @import './components/_welcome.css';

--- a/packages/editor/src/ui/components/ProblemPanel.ts
+++ b/packages/editor/src/ui/components/ProblemPanel.ts
@@ -1,0 +1,38 @@
+/**
+ * ProblemPanel - 試験モードの問題表示パネル (ADR-0006 最小骨組み)
+ *
+ * 現状はスタブ。問題の配布元 (封印問題パッケージ + 監督コードによる復号・チェーン束縛) は
+ * full ADR-0006 で実装する。ここでは「試験モードでは左に問題パネルが出る」という骨組みだけを
+ * 用意する。casual モードでは生成も表示もされない (モード差は機能のみ、の原則)。
+ */
+export class ProblemPanel {
+  private panel: HTMLElement | null = null;
+  private body: HTMLElement | null = null;
+
+  /** DOM 要素を捕捉する。`#problem-panel` が無ければ false。 */
+  initialize(): boolean {
+    this.panel = document.getElementById('problem-panel');
+    this.body = document.getElementById('problem-body');
+    return this.panel !== null;
+  }
+
+  show(): void {
+    this.panel?.classList.add('visible');
+  }
+
+  hide(): void {
+    this.panel?.classList.remove('visible');
+  }
+
+  get isVisible(): boolean {
+    return this.panel?.classList.contains('visible') ?? false;
+  }
+
+  /**
+   * 問題本文を設定する。将来は封印パッケージの復号結果を渡す。
+   * 現状はスタブのため text として安全に挿入する (HTML 注入はしない)。
+   */
+  setProblemText(text: string): void {
+    if (this.body) this.body.textContent = text;
+  }
+}


### PR DESCRIPTION
## 概要

`?exam=1` で**試験モード**に入り、左に**問題表示パネル（スタブ）**を出す**最小骨組み**。これから載せる exam 限定挙動（次の **fullscreen** 等）の土台になる。**casual モードは従来どおり変化なし**（モード差は機能のみ、の原則）。

## 入れたもの

- `main.ts`：`?exam=1`/`true` を解析 → `ctx.examMode`。exam 時は `body.exam-mode` ＋ `ProblemPanel` を表示（Monaco は `automaticLayout` なので再レイアウト自動）
- `ProblemPanel`：最小パネル（`show`/`hide`/`setProblemText`）。**問題ソースはスタブ**
- `index.html`：`#problem-panel` を `workbench-upper` の左に追加
- `_problem-panel.css` / `main.css`：既存パネル（preview/log）に倣った左サイドパネル
- `AppContext`：`examMode` フラグ ＋ `problemPanel`
- i18n：`exam` セクション（ja/en/types）

## 先送り（full ADR-0006）

封印問題パッケージ・監督コード復号・チェーン束縛・proof の `exam` ブロックは未実装。**本 PR は proof フォーマットを一切触らない**（トリガは暫定で URL パラメータ。最終形は Moodle 配布の封印パッケージ）。

## 検証

- typecheck clean（全ワークスペース）、editor build OK
- 動作確認方法：`npm run dev:editor` → `http://localhost:5173/?exam=1` で左に問題パネル、`?exam` 無しで従来表示

## 次

ADR-0008 fullscreen（`ctx.examMode` をゲートに、要求＋常時警告＋`fullscreenChange` 記録）を次の PR で。

🤖 Generated with [Claude Code](https://claude.com/claude-code)