### PR TITLE
feat(editor): 試験モードのタブ固定とリロード復帰 (ADR-0010 実装)

### DIFF
--- a/packages/editor/CLAUDE.md
+++ b/packages/editor/CLAUDE.md
@@ -60,6 +60,7 @@ ProofExporter.export()
 - **Monaco の `onDidChangeModelContent` イベントは ICustomEvent ではない**: `InputDetector` で paste を判定するときの DOM event は `editor.onDidPaste` 経由で取る (Monaco の paste は contentChange と paste の 2 段)
 - **IndexedDB のバージョンマイグレーション**: スキーマを変えるときは `STORAGE_FORMAT_VERSION` を bump し、`shared` のマイグレーション関数を更新する
 - **ビルド時に注入される `__GIT_COMMIT__` 等**: dev サーバでは undefined になることがあるので、参照側でフォールバックを持つ
+- **試験モードは sticky (ADR-0010)**: `?exam=1` で入ると `localStorage['typedcode-exam-mode']` に保存され、**URL から `?exam` が消えても・リロードしても試験モードのまま**。`ctx.examMode` が真の間は問題タブを 1 つ生成し、`TabManager.setExamLock(true)` で `createTab`/`closeTab` を源流ロック (add-tab/close ボタンは CSS で非表示)。**確実な解除は `?reset`** (localStorage.clear)。提出時の解除は full ADR-0006 で実装予定
 
 ## i18n
 

--- a/packages/editor/src/app/StaticEventListeners.ts
+++ b/packages/editor/src/app/StaticEventListeners.ts
@@ -149,6 +149,7 @@ export function setupStaticEventListeners(ctx: AppContext): void {
   // 新規タブ追加ボタン
   const addTabBtn = document.getElementById('add-tab-btn');
   addTabBtn?.addEventListener('click', async () => {
+    if (ctx.examMode) return; // 試験モードでは新規タブ不可 (ADR-0010)
     if (!ctx.tabManager) return;
 
     if (isTurnstileConfigured()) {

--- a/packages/editor/src/main.ts
+++ b/packages/editor/src/main.ts
@@ -34,10 +34,22 @@ if (urlParams.get('fresh') === '1') {
   window.history.replaceState({}, '', cleanUrl);
 }
 
-// Exam mode (ADR-0006 最小骨組み): ?exam=1 で試験モードに入る。
-// 現状は問題パネル (スタブ) を出すだけ。封印問題パッケージ / 監督コード / チェーン束縛は
-// full ADR-0006 で実装する。URL は意図的にクリーンにしない (リロードで試験モードを維持)。
-const examMode = urlParams.get('exam') === '1' || urlParams.get('exam') === 'true';
+// Exam mode (ADR-0006 / ADR-0010): ?exam=1 で試験モードに入る。
+// sticky: 一度入ったら localStorage に保存し、リロードや URL から ?exam が消えても維持する
+// (ADR-0010 — URL 改竄で抜けられないようにする)。?reset での localStorage.clear() が確実な解除経路。
+// 封印問題パッケージ / 監督コード / チェーン束縛 / 提出時の解除は full ADR-0006 で実装する。
+const EXAM_MODE_STORAGE_KEY = 'typedcode-exam-mode';
+const examFromUrl = urlParams.get('exam') === '1' || urlParams.get('exam') === 'true';
+let examMode = examFromUrl;
+try {
+  if (examFromUrl) {
+    localStorage.setItem(EXAM_MODE_STORAGE_KEY, '1');
+  } else if (localStorage.getItem(EXAM_MODE_STORAGE_KEY) === '1') {
+    examMode = true;
+  }
+} catch {
+  /* localStorage 不可環境では URL のみで判定 */
+}
 
 import * as monaco from 'monaco-editor';
 import './styles/main.css';
@@ -451,6 +463,7 @@ function initializeTerminal(): void {
   const newFileBtn = document.getElementById('new-file-btn');
   newFileBtn?.addEventListener('click', async () => {
     ctx.mainMenuDropdown.close();
+    if (ctx.examMode) return; // 試験モードでは新規ファイル不可 (ADR-0010)
     if (!ctx.tabManager) return;
 
     if (isTurnstileConfigured()) {
@@ -1063,6 +1076,12 @@ async function initializeApp(): Promise<void> {
 
   hideInitOverlay();
 
+  // 試験モード: タブが無ければ welcome の代わりに問題タブを 1 つ生成する (ADR-0010, 1問1タブ)。
+  // リロード時は復元済みタブがあるためここは走らない。問題ソースの実体は full ADR-0006 で。
+  if (ctx.examMode && !ctx.tabManager?.hasAnyTabs()) {
+    await ctx.tabManager?.createTab('answer.c', 'c', '');
+  }
+
   // タブがない場合はウェルカム画面を表示、ある場合は通常のエディタ表示
   if (!ctx.tabManager?.hasAnyTabs()) {
     showWelcomeScreen(ctx);
@@ -1082,6 +1101,11 @@ async function initializeApp(): Promise<void> {
 
     // 利用規約同意をハッシュチェーンに記録
     recordTermsAcceptance();
+  }
+
+  // 試験モード: 初期問題タブ確定後、タブの追加・削除を源流でロックする (ADR-0010)。
+  if (ctx.examMode) {
+    ctx.tabManager?.setExamLock(true);
   }
 
   // 全タブ閉じた時にウェルカム画面を表示するコールバックを設定

--- a/packages/editor/src/styles/components/_problem-panel.css
+++ b/packages/editor/src/styles/components/_problem-panel.css
@@ -45,3 +45,10 @@
   word-break: break-word;
   opacity: 0.85;
 }
+
+/* 試験モード: タブの追加・削除 UI を隠す (ADR-0010, 1問1タブ固定)。
+   源流の TabManager ロックが本体で、これは UI アフォーダンスを消すため。 */
+body.exam-mode .add-tab-btn,
+body.exam-mode .tab-close-btn {
+  display: none !important;
+}

--- a/packages/editor/src/ui/tabs/TabManager.ts
+++ b/packages/editor/src/ui/tabs/TabManager.ts
@@ -116,6 +116,8 @@ export class TabManager {
   private tabOrder: string[] = [];
   private activeTabId: string | null = null;
   private tabSwitches: TabSwitchEvent[] = [];
+  /** 試験モードのタブロック (ADR-0010): true の間 createTab/closeTab を源流で拒否する。 */
+  private examLocked = false;
   /** 復元中フラグ。復元時に switchTab が発火する合成スイッチイベントを
    *  IndexedDB に二重永続化しないために使う。 */
   private isRestoring = false;
@@ -246,12 +248,21 @@ export class TabManager {
    * Turnstileが設定されている場合、認証結果をevent #0として記録（成功・失敗問わず）
    * @returns 常にTabState（認証失敗でもタブ作成は続行）
    */
+  /** 試験モードのタブロックを設定する (ADR-0010)。初期問題タブ生成後に有効化する。 */
+  setExamLock(locked: boolean): void {
+    this.examLocked = locked;
+  }
+
   async createTab(
     filename: string = 'untitled',
     language: string = 'c',
     content: string = '',
     options?: CreateTabOptions
   ): Promise<TabState | null> {
+    if (this.examLocked) {
+      console.warn('[TypedCode] Tab creation is locked (exam mode)');
+      return null;
+    }
     const id = generateUUID();
     const createdAt = Date.now();
 
@@ -354,6 +365,10 @@ export class TabManager {
    * タブを閉じる
    */
   closeTab(tabId: string): boolean {
+    if (this.examLocked) {
+      console.warn('[TypedCode] Tab close is locked (exam mode)');
+      return false;
+    }
     const tab = this.tabs.get(tabId);
     if (!tab) return false;
 


### PR DESCRIPTION
## 概要

方向性議論で確定した **ADR-0010** を、骨組み（#74）の上に実装。あなたの2つの要望：①リロードで復帰 ②1問1タブ・新規タブ禁止 を満たす。**proof フォーマットは一切不変。**

## 入れたもの

- **sticky 復帰**：`?exam=1` で `localStorage['typedcode-exam-mode']` に保存 → **URL から `?exam` が消えても・リロードしても試験モード維持**（URL 改竄で抜けられない）。答案は既存のタブ自動復元に乗る。**確実な解除は `?reset`**
- **1問1タブ**：試験モードでタブが無ければ welcome の代わりに**問題タブを1つ生成**（リロード時は復元済みタブがあるので生成しない）
- **追加・削除禁止**：`TabManager.setExamLock(true)` で `createTab`/`closeTab` を**源流で遮断**（全経路カバー）。add-tab/close ボタンは CSS 非表示、add-tab/new-file ハンドラも `ctx.examMode` でガード

## 動作確認

`npm run dev:editor` →
- `http://localhost:5173/?exam=1` → 問題パネル＋答案タブ1つ、**「＋」と「×」が消える**
- **リロード** → `?exam` 無しでも試験モード維持・答案も残る
- `http://localhost:5173/?reset` → 試験モード解除（通常に戻る）

## 先送り（ADR-0010 / full ADR-0006 に既述）

- 多問題化時の **#0 Turnstile 連打回避**（試験タブ認証のネット非依存化）
- **提出時の試験モード解除**（今は `?reset` が唯一の確実な解除）
- 問題ソースの実体化（封印パッケージ）／問題パネルの**マルチ問題追従**（1問なので現状は自明）

## 検証

- typecheck clean（全ワークスペース）、editor build OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)