### PR TITLE
feat: 試験モードの fullscreen 要求・警告・記録 (ADR-0008 実装)

### DIFF
--- a/docs/system-spec.md
+++ b/docs/system-spec.md
@@ -92,13 +92,13 @@ TypedCode は、ブラウザ上のコードエディタにおける編集操作 
 
 ### 4.1. イベント (Event) の収集
 
-エディタ上の操作はすべて「イベント」として記録される。26 種類のイベントタイプがある:
+エディタ上の操作はすべて「イベント」として記録される。27 種類のイベントタイプがある:
 
 **カテゴリ別**:
 - **コンテンツ変更**: `contentChange`, `contentSnapshot`, `externalInput`, `templateInjection`
 - **カーソル/選択**: `cursorPositionChange`, `selectionChange`
 - **キー入力**: `keyDown`, `keyUp`, `mousePositionChange`
-- **ウィンドウ**: `focusChange`, `visibilityChange`, `windowResize`
+- **ウィンドウ**: `focusChange`, `visibilityChange`, `windowResize`, `fullscreenChange` (試験モードのフルスクリーン状態。ADR-0008)
 - **システム**: `editorInitialized`, `networkStatusChange`
 - **環境/自動化**: `environmentProbe` (起動時ワンショット。`navigator.webdriver` と自動化グローバル痕跡。ADR-0007 / ADR-0009 の automation 分析器が消費)
 - **認証**: `humanAttestation`, `preExportAttestation`, `termsAccepted`

--- a/packages/editor/index.html
+++ b/packages/editor/index.html
@@ -96,6 +96,12 @@
       </div>
     </div>
 
+    <!-- Fullscreen Warning Banner (Exam Mode, ADR-0008) — 非フルスクリーン時のみ表示 -->
+    <div id="fullscreen-warning-banner">
+      <span class="fullscreen-warning-text" data-i18n="exam.fullscreenWarning">You are outside fullscreen.</span>
+      <button id="enter-fullscreen-btn" class="fullscreen-warning-btn" data-i18n="exam.enterFullscreen">Enter fullscreen</button>
+    </div>
+
     <!-- Block Notification -->
     <div id="block-notification" class="hidden">
       <span id="block-message"></span>

--- a/packages/editor/src/core/AppContext.ts
+++ b/packages/editor/src/core/AppContext.ts
@@ -36,6 +36,7 @@ import type { MainMenuDropdown } from '../ui/components/MainMenuDropdown.js';
 import type { TerminalPanel } from '../ui/components/TerminalPanel.js';
 import type { BrowserPreviewPanel } from '../ui/components/BrowserPreviewPanel.js';
 import type { ProblemPanel } from '../ui/components/ProblemPanel.js';
+import type { FullscreenTracker } from '../tracking/FullscreenTracker.js';
 import type { WelcomeScreen } from '../ui/components/WelcomeScreen.js';
 import type { TitlebarClock } from '../ui/components/TitlebarClock.js';
 
@@ -99,6 +100,8 @@ export interface AppContext {
   browserPreviewPanel: BrowserPreviewPanel;
   /** 試験モードの問題表示パネル (ADR-0006 最小骨組み・スタブ) */
   problemPanel: ProblemPanel;
+  /** 試験モードのフルスクリーン追跡・警告バナー (ADR-0008) */
+  fullscreenTracker: FullscreenTracker;
 
   // Flags
   skipBeforeUnload: boolean;

--- a/packages/editor/src/i18n/translations/en.ts
+++ b/packages/editor/src/i18n/translations/en.ts
@@ -503,9 +503,15 @@ export const en: TranslationKeys = {
     clearing: 'Clearing data...',
   },
 
-  // Exam mode (ADR-0006)
+  // Exam mode (ADR-0006 / ADR-0008)
   exam: {
     title: 'Exam Mode',
     problemPlaceholder: 'Exam mode. The problem will appear in this panel (problem distribution coming later).',
+    fullscreenWarning: '⚠ You are outside fullscreen. Recording continues, but this state is logged in your exam record.',
+    enterFullscreen: 'Enter fullscreen',
+    fsEntered: 'Entered fullscreen',
+    fsExited: 'Exited fullscreen',
+    fsDenied: 'Fullscreen request denied',
+    fsUnavailable: 'Fullscreen unavailable',
   },
 };

--- a/packages/editor/src/i18n/translations/ja.ts
+++ b/packages/editor/src/i18n/translations/ja.ts
@@ -503,9 +503,15 @@ export const ja: TranslationKeys = {
     clearing: 'データをクリア中...',
   },
 
-  // 試験モード (ADR-0006)
+  // 試験モード (ADR-0006 / ADR-0008)
   exam: {
     title: '試験モード',
     problemPlaceholder: '試験モードです。問題はこの欄に表示されます（問題の配布は今後実装予定）。',
+    fullscreenWarning: '⚠ フルスクリーン外で受験中です。記録は継続されますが、この状態は試験ログに残ります。',
+    enterFullscreen: 'フルスクリーンで受験',
+    fsEntered: 'フルスクリーン開始',
+    fsExited: 'フルスクリーン解除',
+    fsDenied: 'フルスクリーン要求が拒否されました',
+    fsUnavailable: 'フルスクリーン非対応',
   },
 };

--- a/packages/editor/src/i18n/types.ts
+++ b/packages/editor/src/i18n/types.ts
@@ -529,9 +529,15 @@ export interface TranslationKeys {
     clearing: string;
   };
 
-  // Exam mode (ADR-0006)
+  // Exam mode (ADR-0006 / ADR-0008)
   exam: {
     title: string;
     problemPlaceholder: string;
+    fullscreenWarning: string;
+    enterFullscreen: string;
+    fsEntered: string;
+    fsExited: string;
+    fsDenied: string;
+    fsUnavailable: string;
   };
 }

--- a/packages/editor/src/main.ts
+++ b/packages/editor/src/main.ts
@@ -96,6 +96,7 @@ import { TabUIController } from './ui/tabs/TabUIController.js';
 import { LogViewerPanel } from './ui/components/LogViewerPanel.js';
 import { BrowserPreviewPanel } from './ui/components/BrowserPreviewPanel.js';
 import { ProblemPanel } from './ui/components/ProblemPanel.js';
+import { FullscreenTracker } from './tracking/FullscreenTracker.js';
 import { EventRecorder, SessionContentRegistry } from './core/index.js';
 import type { AppContext } from './core/AppContext.js';
 import { t, getI18n, initDOMi18n } from './i18n/index.js';
@@ -243,6 +244,7 @@ const ctx: AppContext = {
   terminalPanel: new TerminalPanel(),
   browserPreviewPanel: new BrowserPreviewPanel(),
   problemPanel: new ProblemPanel(),
+  fullscreenTracker: new FullscreenTracker(),
 
   // Flags
   skipBeforeUnload: false,
@@ -1150,6 +1152,15 @@ async function initializeApp(): Promise<void> {
   // Phase 6: LogViewerとEventRecorderの初期化
   initializeLogViewer(ctx);
   initializeEventRecorder();
+
+  // 試験モード: フルスクリーン追跡 + 警告バナー (ADR-0008)。eventRecorder 準備後に配線する。
+  // 警告バナーの「フルスクリーンで受験」ボタンが開始ジェスチャ (requestFullscreen は要 user gesture)。
+  if (ctx.examMode) {
+    ctx.fullscreenTracker.setRecordCallback((event) => {
+      void ctx.eventRecorder?.recordToAllTabs(event);
+    });
+    ctx.fullscreenTracker.initialize();
+  }
 
   // Phase 7: ターミナルとコード実行の初期化
   initializeTerminal();

--- a/packages/editor/src/styles/components/_problem-panel.css
+++ b/packages/editor/src/styles/components/_problem-panel.css
@@ -52,3 +52,40 @@ body.exam-mode .add-tab-btn,
 body.exam-mode .tab-close-btn {
   display: none !important;
 }
+
+/* フルスクリーン警告バナー (ADR-0008) — 非ブロッキングの常時帯。
+   非フルスクリーン時のみ .visible が付く。 */
+#fullscreen-warning-banner {
+  display: none;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 14px;
+  flex: 0 0 auto;
+  background: #6b4a00;
+  color: #ffe8a3;
+  font-size: 13px;
+  border-bottom: 1px solid var(--border-color, #333);
+}
+
+#fullscreen-warning-banner.visible {
+  display: flex;
+}
+
+.fullscreen-warning-text {
+  flex: 1 1 auto;
+}
+
+.fullscreen-warning-btn {
+  flex: 0 0 auto;
+  padding: 4px 12px;
+  background: #ffce54;
+  color: #3a2a00;
+  border: none;
+  border-radius: 4px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.fullscreen-warning-btn:hover {
+  background: #ffd874;
+}

--- a/packages/editor/src/tracking/FullscreenTracker.ts
+++ b/packages/editor/src/tracking/FullscreenTracker.ts
@@ -7,6 +7,11 @@
  *
  * requestFullscreen() はユーザー操作 (transient activation) を要するため、警告バナーの
  * 「フルスクリーンで受験」ボタンが開始ジェスチャを兼ねる (ADR-0008「開始ボタンに紐付け」)。
+ *
+ * macOS の注意: ネイティブ全画面 (緑ボタン / メニューバーの全画面解除) は HTML Fullscreen API の
+ * `fullscreenchange` を発火せず `document.fullscreenElement` が残留することがある。そのため
+ * (1) `(display-mode: fullscreen)` メディアクエリ (2) `resize` も併せて監視し、(3) 残留時は実寸で
+ * 全画面かを確認する、という多重検出で「全画面を抜けたのにバナーが出ない」を防ぐ。
  */
 
 import type { FullscreenChangeData, RecordEventInput } from '@typedcode/shared';
@@ -18,13 +23,16 @@ export class FullscreenTracker {
   private record: FullscreenRecordCallback | null = null;
   private banner: HTMLElement | null = null;
   private enterBtn: HTMLElement | null = null;
-  /** requestFullscreen() 起因の fullscreenchange を 'request' として区別するためのフラグ。 */
+  private displayModeMql: MediaQueryList | null = null;
+  /** requestFullscreen() 起因の遷移を 'request' として区別するためのフラグ。 */
   private pendingRequest = false;
+  /** 直近に確定した実効フルスクリーン状態 (二重記録の抑止に使う)。 */
+  private currentFs = false;
   private boundOnChange: () => void;
   private boundOnClick: () => void;
 
   constructor() {
-    this.boundOnChange = this.onFullscreenChange.bind(this);
+    this.boundOnChange = this.handleStateChange.bind(this);
     this.boundOnClick = () => {
       void this.requestFullscreen();
     };
@@ -39,71 +47,93 @@ export class FullscreenTracker {
     this.banner = document.getElementById('fullscreen-warning-banner');
     this.enterBtn = document.getElementById('enter-fullscreen-btn');
     this.enterBtn?.addEventListener('click', this.boundOnClick);
-    document.addEventListener('fullscreenchange', this.boundOnChange);
-    this.recordInitial();
-    this.updateBanner();
-  }
 
-  /** 開始時プローブ (現在状態と可用性を記録)。 */
-  recordInitial(): void {
-    this.emit('initial', null);
+    // (1) HTML Fullscreen API。(2) ネイティブ全画面も拾う表示モード変化。(3) 取りこぼし対策の resize。
+    document.addEventListener('fullscreenchange', this.boundOnChange);
+    this.displayModeMql = window.matchMedia('(display-mode: fullscreen)');
+    this.displayModeMql.addEventListener('change', this.boundOnChange);
+    window.addEventListener('resize', this.boundOnChange);
+
+    this.currentFs = this.isFullscreen();
+    this.emit('initial', null, this.currentFs);
+    this.updateBanner();
   }
 
   /** ユーザー操作からフルスクリーンを要求する (バナーのボタン)。 */
   async requestFullscreen(): Promise<void> {
     if (!this.isAvailable()) {
-      this.emit('request', false);
+      this.emit('request', false, false);
       return;
     }
     if (this.isFullscreen()) return;
     this.pendingRequest = true;
     try {
       await document.documentElement.requestFullscreen();
-      // 成功時は fullscreenchange が発火し、そこで reason='request' granted=true を記録する。
+      // 成功時は状態変化ハンドラ側で reason='request' granted=true を記録する。
     } catch {
       this.pendingRequest = false;
-      this.emit('request', false); // 拒否 / 失敗
+      this.emit('request', false, false); // 拒否 / 失敗
       this.updateBanner();
     }
   }
 
   dispose(): void {
     document.removeEventListener('fullscreenchange', this.boundOnChange);
+    this.displayModeMql?.removeEventListener('change', this.boundOnChange);
+    window.removeEventListener('resize', this.boundOnChange);
     this.enterBtn?.removeEventListener('click', this.boundOnClick);
-  }
-
-  private isFullscreen(): boolean {
-    return document.fullscreenElement !== null;
   }
 
   private isAvailable(): boolean {
     return document.fullscreenEnabled;
   }
 
-  private onFullscreenChange(): void {
-    if (this.pendingRequest) {
-      this.pendingRequest = false;
-      this.emit('request', this.isFullscreen());
-    } else {
-      this.emit('change', null);
+  /**
+   * 実効フルスクリーン判定。HTML API / 表示モード / 実寸を組み合わせ、macOS の
+   * `fullscreenElement` 残留にも耐える。
+   */
+  private isFullscreen(): boolean {
+    if (this.displayModeMql?.matches) return true;
+    if (document.fullscreenElement !== null) {
+      // fullscreenElement が残留しても、実寸が全画面でなければ「抜けた」とみなす。
+      return this.looksFullscreenBySize();
+    }
+    return false;
+  }
+
+  /** ウィンドウが画面全体を覆っているか (CSS px 同士の比較なので DPR の影響は受けない)。 */
+  private looksFullscreenBySize(): boolean {
+    return (
+      window.innerWidth >= screen.width - 2 && window.innerHeight >= screen.height - 2
+    );
+  }
+
+  private handleStateChange(): void {
+    const fs = this.isFullscreen();
+    if (fs !== this.currentFs) {
+      this.currentFs = fs;
+      if (this.pendingRequest) {
+        this.pendingRequest = false;
+        this.emit('request', fs, fs);
+      } else {
+        this.emit('change', null, fs);
+      }
     }
     this.updateBanner();
   }
 
   /** 非フルスクリーン中はバナーを表示、フルスクリーン中は隠す。 */
   private updateBanner(): void {
-    if (!this.banner) return;
-    if (this.isFullscreen()) {
-      this.banner.classList.remove('visible');
-    } else {
-      this.banner.classList.add('visible');
-    }
+    this.banner?.classList.toggle('visible', !this.currentFs);
   }
 
-  private emit(reason: FullscreenChangeData['reason'], requestGranted: boolean | null): void {
-    const denied = reason === 'request' && requestGranted === false;
+  private emit(
+    reason: FullscreenChangeData['reason'],
+    requestGranted: boolean | null,
+    fullscreen: boolean
+  ): void {
     const data: FullscreenChangeData = {
-      fullscreen: denied ? false : this.isFullscreen(),
+      fullscreen,
       available: this.isAvailable(),
       reason,
       requestGranted,

--- a/packages/editor/src/tracking/FullscreenTracker.ts
+++ b/packages/editor/src/tracking/FullscreenTracker.ts
@@ -1,0 +1,123 @@
+/**
+ * FullscreenTracker - 試験モードのフルスクリーン要求・記録・警告バナー (ADR-0008)
+ *
+ * exam モードは fullscreen を **要求するが強制しない**。非フルスクリーンでも全機能を使えるが、
+ * その間は常時警告バナーを出し、ボタンでフルスクリーンに復帰できる。フルスクリーン状態
+ * (grant/deny・enter/exit・unavailable) は `fullscreenChange` イベントとしてチェーンに記録する。
+ *
+ * requestFullscreen() はユーザー操作 (transient activation) を要するため、警告バナーの
+ * 「フルスクリーンで受験」ボタンが開始ジェスチャを兼ねる (ADR-0008「開始ボタンに紐付け」)。
+ */
+
+import type { FullscreenChangeData, RecordEventInput } from '@typedcode/shared';
+import { t } from '../i18n/index.js';
+
+export type FullscreenRecordCallback = (event: RecordEventInput) => void;
+
+export class FullscreenTracker {
+  private record: FullscreenRecordCallback | null = null;
+  private banner: HTMLElement | null = null;
+  private enterBtn: HTMLElement | null = null;
+  /** requestFullscreen() 起因の fullscreenchange を 'request' として区別するためのフラグ。 */
+  private pendingRequest = false;
+  private boundOnChange: () => void;
+  private boundOnClick: () => void;
+
+  constructor() {
+    this.boundOnChange = this.onFullscreenChange.bind(this);
+    this.boundOnClick = () => {
+      void this.requestFullscreen();
+    };
+  }
+
+  setRecordCallback(cb: FullscreenRecordCallback): void {
+    this.record = cb;
+  }
+
+  /** DOM 捕捉 + リスナ配線 + 初期状態記録。試験モード開始時に呼ぶ。 */
+  initialize(): void {
+    this.banner = document.getElementById('fullscreen-warning-banner');
+    this.enterBtn = document.getElementById('enter-fullscreen-btn');
+    this.enterBtn?.addEventListener('click', this.boundOnClick);
+    document.addEventListener('fullscreenchange', this.boundOnChange);
+    this.recordInitial();
+    this.updateBanner();
+  }
+
+  /** 開始時プローブ (現在状態と可用性を記録)。 */
+  recordInitial(): void {
+    this.emit('initial', null);
+  }
+
+  /** ユーザー操作からフルスクリーンを要求する (バナーのボタン)。 */
+  async requestFullscreen(): Promise<void> {
+    if (!this.isAvailable()) {
+      this.emit('request', false);
+      return;
+    }
+    if (this.isFullscreen()) return;
+    this.pendingRequest = true;
+    try {
+      await document.documentElement.requestFullscreen();
+      // 成功時は fullscreenchange が発火し、そこで reason='request' granted=true を記録する。
+    } catch {
+      this.pendingRequest = false;
+      this.emit('request', false); // 拒否 / 失敗
+      this.updateBanner();
+    }
+  }
+
+  dispose(): void {
+    document.removeEventListener('fullscreenchange', this.boundOnChange);
+    this.enterBtn?.removeEventListener('click', this.boundOnClick);
+  }
+
+  private isFullscreen(): boolean {
+    return document.fullscreenElement !== null;
+  }
+
+  private isAvailable(): boolean {
+    return document.fullscreenEnabled;
+  }
+
+  private onFullscreenChange(): void {
+    if (this.pendingRequest) {
+      this.pendingRequest = false;
+      this.emit('request', this.isFullscreen());
+    } else {
+      this.emit('change', null);
+    }
+    this.updateBanner();
+  }
+
+  /** 非フルスクリーン中はバナーを表示、フルスクリーン中は隠す。 */
+  private updateBanner(): void {
+    if (!this.banner) return;
+    if (this.isFullscreen()) {
+      this.banner.classList.remove('visible');
+    } else {
+      this.banner.classList.add('visible');
+    }
+  }
+
+  private emit(reason: FullscreenChangeData['reason'], requestGranted: boolean | null): void {
+    const denied = reason === 'request' && requestGranted === false;
+    const data: FullscreenChangeData = {
+      fullscreen: denied ? false : this.isFullscreen(),
+      available: this.isAvailable(),
+      reason,
+      requestGranted,
+    };
+    this.record?.({
+      type: 'fullscreenChange',
+      data,
+      description: this.describe(data),
+    });
+  }
+
+  private describe(d: FullscreenChangeData): string {
+    if (!d.available) return t('exam.fsUnavailable');
+    if (d.reason === 'request' && d.requestGranted === false) return t('exam.fsDenied');
+    return d.fullscreen ? t('exam.fsEntered') : t('exam.fsExited');
+  }
+}

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -33,7 +33,8 @@ export type EventType =
   | 'sessionResumed' // セッション再開（リロードまたはIndexedDBからの復旧）
   | 'copyOperation' // コピー操作（監査用）
   | 'screenShareOptOut' // 画面共有オプトアウト
-  | 'environmentProbe'; // 環境/自動化プローブ（起動時ワンショット, ADR-0007）
+  | 'environmentProbe' // 環境/自動化プローブ（起動時ワンショット, ADR-0007）
+  | 'fullscreenChange'; // フルスクリーン状態変化（試験モード, ADR-0008）
 
 /** 入力タイプ */
 export type InputType =
@@ -142,6 +143,24 @@ export interface EnvironmentProbeData {
   webdriver: boolean | null;
   /** 検出した自動化由来のグローバル名（cdc_*, __playwright 等）。無ければ空配列。 */
   automationGlobals: string[];
+}
+
+/**
+ * フルスクリーン状態変化データ（試験モード, ADR-0008）。
+ *
+ * exam モードは fullscreen を要求するが強制しない (非フルスクリーンでも使える)。
+ * grant/deny・enter/exit・unavailable を本イベントで全部表現する。非フルスクリーン
+ * 滞在時間などは連続イベントのタイムスタンプ差で派生計算する (本体には持たない)。
+ */
+export interface FullscreenChangeData {
+  /** 遷移後の現在状態 (document.fullscreenElement !== null)。 */
+  fullscreen: boolean;
+  /** Fullscreen API が利用可能か (document.fullscreenEnabled)。graceful absence の事実記録。 */
+  available: boolean;
+  /** きっかけ: initial=開始時プローブ / request=requestFullscreen()結果 / change=自発遷移(Esc等)。 */
+  reason: 'initial' | 'request' | 'change';
+  /** reason==='request' のとき grant/deny。それ以外は null。 */
+  requestGranted: boolean | null;
 }
 
 /** セッション再開データ */

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -21,6 +21,7 @@ export type {
   NetworkStatusData,
   SessionResumedData,
   EnvironmentProbeData,
+  FullscreenChangeData,
   KeystrokeDynamicsData,
   DetectedEventType,
   DetectedEventData,

--- a/packages/shared/src/types/proof.ts
+++ b/packages/shared/src/types/proof.ts
@@ -17,6 +17,7 @@ import type {
   NetworkStatusData,
   SessionResumedData,
   EnvironmentProbeData,
+  FullscreenChangeData,
 } from './events.js';
 import type {
   ScreenshotCaptureData,
@@ -48,7 +49,7 @@ export interface PoSWData {
 export interface RecordEventInput {
   type: EventType;
   inputType?: InputType | null;
-  data?: string | CursorPositionData | SelectionData | MousePositionData | VisibilityChangeData | FocusChangeData | KeystrokeDynamicsData | WindowSizeData | NetworkStatusData | SessionResumedData | HumanAttestationEventData | TermsAcceptedData | ScreenshotCaptureData | ScreenShareStartData | ScreenShareStopData | ScreenShareOptOutData | TemplateInjectionEventData | EnvironmentProbeData | null;
+  data?: string | CursorPositionData | SelectionData | MousePositionData | VisibilityChangeData | FocusChangeData | KeystrokeDynamicsData | WindowSizeData | NetworkStatusData | SessionResumedData | HumanAttestationEventData | TermsAcceptedData | ScreenshotCaptureData | ScreenShareStartData | ScreenShareStopData | ScreenShareOptOutData | TemplateInjectionEventData | EnvironmentProbeData | FullscreenChangeData | null;
   rangeOffset?: number | null;
   rangeLength?: number | null;
   range?: TextRange | null;
@@ -68,7 +69,7 @@ export interface EventHashData {
   timestamp: number;
   type: EventType;
   inputType: InputType | null;
-  data: string | CursorPositionData | SelectionData | MousePositionData | VisibilityChangeData | FocusChangeData | KeystrokeDynamicsData | WindowSizeData | NetworkStatusData | SessionResumedData | HumanAttestationEventData | TermsAcceptedData | ScreenshotCaptureData | ScreenShareStartData | ScreenShareStopData | ScreenShareOptOutData | TemplateInjectionEventData | EnvironmentProbeData | null;
+  data: string | CursorPositionData | SelectionData | MousePositionData | VisibilityChangeData | FocusChangeData | KeystrokeDynamicsData | WindowSizeData | NetworkStatusData | SessionResumedData | HumanAttestationEventData | TermsAcceptedData | ScreenshotCaptureData | ScreenShareStartData | ScreenShareStopData | ScreenShareOptOutData | TemplateInjectionEventData | EnvironmentProbeData | FullscreenChangeData | null;
   rangeOffset: number | null;
   rangeLength: number | null;
   range: TextRange | null;

--- a/packages/shared/src/types/storage.ts
+++ b/packages/shared/src/types/storage.ts
@@ -16,6 +16,7 @@ import type {
   NetworkStatusData,
   SessionResumedData,
   EnvironmentProbeData,
+  FullscreenChangeData,
 } from './events.js';
 import type {
   ScreenshotCaptureData,
@@ -53,6 +54,7 @@ export type PendingEventDataType =
   | ScreenShareOptOutData
   | TemplateInjectionEventData
   | EnvironmentProbeData
+  | FullscreenChangeData
   | null;
 
 // ============================================================================

--- a/packages/verify/src/types/chartVisibility.ts
+++ b/packages/verify/src/types/chartVisibility.ts
@@ -44,6 +44,7 @@ export const EVENT_CATEGORY_MAP: Record<EventType, EventCategory> = {
   focusChange: 'window',
   visibilityChange: 'window',
   windowResize: 'window',
+  fullscreenChange: 'window',
   // System
   editorInitialized: 'system',
   networkStatusChange: 'system',
@@ -90,7 +91,7 @@ export const EVENT_CATEGORIES: CategoryInfo[] = [
     id: 'window',
     labelKey: 'charts.categories.window',
     icon: 'fa-window-maximize',
-    events: ['focusChange', 'visibilityChange', 'windowResize'],
+    events: ['focusChange', 'visibilityChange', 'windowResize', 'fullscreenChange'],
   },
   {
     id: 'system',


### PR DESCRIPTION
## 概要

ADR-0008 を実装。exam モードで **fullscreen を要求するが強制しない**。非フルスクリーンでも全機能を使えるが**常時警告バナー**を出し、状態を **`fullscreenChange` イベント**としてチェーンに記録する。**proof フォーマットは後方互換**（新イベント型のみ・`PROOF_FORMAT_VERSION` 据え置き）。

## 捕捉（shared）

- 新イベント型 **`fullscreenChange`** ＋ `FullscreenChangeData { fullscreen, available, reason: 'initial'|'request'|'change', requestGranted }`
- grant/deny・enter/exit・unavailable を全表現。非フルスクリーン滞在時間はイベント時刻差で派生（非保存）
- 4 union ＋ 再エクスポート ＋ verify の網羅マップ ＋ system-spec（26→27）を更新

## 挙動（editor, exam モード限定）

- `FullscreenTracker`：起動時 `initial` 記録 → `fullscreenchange` を `change`/`request` で記録 → `requestFullscreen()`
- **警告バナー**：非フルスクリーン時のみ常時表示の**非ブロッキング帯**＋「フルスクリーンで受験」ボタン。**ボタンが開始ジェスチャ**を兼ねる（`requestFullscreen` は要 user gesture）
- **強制しない・判定しない**（ADR-0008）：編集ロックも開始不可もしない。casual モードは無関係

## 動作確認

`npm run dev:editor` → `http://localhost:5173/?exam=1`：
- 上部に**フルスクリーン警告バナー**＋「フルスクリーンで受験」ボタン
- ボタン押下 → フルスクリーン化、バナー消える
- **Esc で抜ける** → バナー再表示。各遷移が `fullscreenChange` としてログ/proof に残る

## 検証

- typecheck clean（全ワークスペース）、shared **202 tests pass**、editor build OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)