### PR TITLE
feat(editor): 試験モードの DL 導線を明快化 + 問題パネルのリサイズ/クローズ (ADR-0010 詰め)

### DIFF
--- a/packages/editor/CLAUDE.md
+++ b/packages/editor/CLAUDE.md
@@ -60,7 +60,7 @@ ProofExporter.export()
 - **Monaco の `onDidChangeModelContent` イベントは ICustomEvent ではない**: `InputDetector` で paste を判定するときの DOM event は `editor.onDidPaste` 経由で取る (Monaco の paste は contentChange と paste の 2 段)
 - **IndexedDB のバージョンマイグレーション**: スキーマを変えるときは `STORAGE_FORMAT_VERSION` を bump し、`shared` のマイグレーション関数を更新する
 - **ビルド時に注入される `__GIT_COMMIT__` 等**: dev サーバでは undefined になることがあるので、参照側でフォールバックを持つ
-- **試験モードは sticky (ADR-0010)**: `?exam=1` で入ると `localStorage['typedcode-exam-mode']` に保存され、**URL から `?exam` が消えても・リロードしても試験モードのまま**。`ctx.examMode` が真の間は問題タブを 1 つ生成し、`TabManager.setExamLock(true)` で `createTab`/`closeTab` を源流ロック (add-tab/close ボタンは CSS で非表示)。**確実な解除は `?reset`** (localStorage.clear)。提出時の解除は full ADR-0006 で実装予定
+- **試験モードは sticky (ADR-0010)**: `?exam=1` で入ると `localStorage['typedcode-exam-mode']` に保存され、**URL から `?exam` が消えても・リロードしても試験モードのまま**。`ctx.examMode` が真の間は問題タブを 1 つ生成し、`TabManager.setExamLock(true)` で `createTab`/`closeTab` を源流ロック (add-tab/close ボタンは CSS で非表示)。提出は **Moodle で行うため TypedCode 側に「提出」操作は持たない**。ダウンロードは**問題パネルの「ログをダウンロード」ボタンに一本化** (`#download-log-btn` → `proofExporter.exportAllTabsAsZip()`、証明 + コードの ZIP) し、受験者がそれを Moodle に提出する。一本化のため**左の汎用 DL メニュー `#download-menu-btn` は exam モードで CSS 非表示**。問題パネルは右端ドラッグでリサイズ・× で閉じる・**左 Activity Bar** の `#toggle-problem-btn` で再表示 (VSCode 風。トグルは exam モードのみ表示)。**sticky の解除は `?reset`** (全 localStorage.clear)
 
 ## i18n
 

--- a/packages/editor/index.html
+++ b/packages/editor/index.html
@@ -155,6 +155,11 @@
               </button>
             </div>
           </div>
+          <div class="activitybar-divider"></div>
+          <!-- 問題パネルのトグル (試験モードのみ表示。CSS で casual 非表示) -->
+          <button class="activitybar-item" id="toggle-problem-btn" data-i18n-title="exam.toggleProblem" title="Toggle Problem">
+            <i class="fas fa-book-open"></i>
+          </button>
         </div>
         <div class="activitybar-bottom">
           <div class="activitybar-menu-container">
@@ -202,11 +207,21 @@
         <div class="workbench-upper">
           <!-- Problem Panel (Exam Mode, 左) — ?exam=1 のときのみ表示 -->
           <div id="problem-panel">
+            <div id="problem-resize-handle" class="problem-resize-handle"></div>
             <div class="problem-header">
               <h2><i class="fas fa-graduation-cap"></i> <span data-i18n="exam.title">Exam Mode</span></h2>
+              <button id="close-problem-btn" class="problem-control-btn" data-i18n-title="common.close" title="Close">
+                <i class="fas fa-times"></i>
+              </button>
             </div>
             <div class="problem-content">
               <div id="problem-body" class="problem-body" data-i18n="exam.problemPlaceholder">Exam mode. The problem will appear here.</div>
+            </div>
+            <div class="problem-footer">
+              <p class="exam-submit-note" data-i18n="exam.submitNote">When you finish, download the log and submit it in Moodle.</p>
+              <button id="download-log-btn" class="download-log-btn">
+                <i class="fas fa-download"></i> <span data-i18n="exam.downloadButton">Download log</span>
+              </button>
             </div>
           </div>
           <div class="editor-container">

--- a/packages/editor/src/i18n/translations/en.ts
+++ b/packages/editor/src/i18n/translations/en.ts
@@ -513,5 +513,8 @@ export const en: TranslationKeys = {
     fsExited: 'Exited fullscreen',
     fsDenied: 'Fullscreen request denied',
     fsUnavailable: 'Fullscreen unavailable',
+    submitNote: 'When you finish: 1) download the log (ZIP) with the button below, then 2) submit it in Moodle.',
+    downloadButton: 'Download log',
+    toggleProblem: 'Toggle Problem Panel',
   },
 };

--- a/packages/editor/src/i18n/translations/ja.ts
+++ b/packages/editor/src/i18n/translations/ja.ts
@@ -513,5 +513,8 @@ export const ja: TranslationKeys = {
     fsExited: 'フルスクリーン解除',
     fsDenied: 'フルスクリーン要求が拒否されました',
     fsUnavailable: 'フルスクリーン非対応',
+    submitNote: '解答が終わったら ① 下のボタンでログ（ZIP）をダウンロード → ② Moodle に提出してください。',
+    downloadButton: 'ログをダウンロード',
+    toggleProblem: '問題パネルの表示切替',
   },
 };

--- a/packages/editor/src/i18n/types.ts
+++ b/packages/editor/src/i18n/types.ts
@@ -539,5 +539,8 @@ export interface TranslationKeys {
     fsExited: string;
     fsDenied: string;
     fsUnavailable: string;
+    submitNote: string;
+    downloadButton: string;
+    toggleProblem: string;
   };
 }

--- a/packages/editor/src/main.ts
+++ b/packages/editor/src/main.ts
@@ -267,9 +267,15 @@ const ctx: AppContext = {
 // Monaco は automaticLayout: true なのでパネル出現に伴う再レイアウトは自動。
 if (ctx.examMode) {
   document.body.classList.add('exam-mode');
+  // ProblemPanel.initialize() がリサイズ/クローズ/トグルを内部で配線する。
   if (ctx.problemPanel.initialize()) {
     ctx.problemPanel.show();
   }
+  // 提出用ログのダウンロード導線を問題パネルのボタンに一本化する (左の汎用DLメニューは exam で非表示)。
+  // 提出は Moodle で行うため TypedCode 側に「提出」操作は持たない。全タブ ZIP (証明 + コード) を出すだけ。
+  document.getElementById('download-log-btn')?.addEventListener('click', () => {
+    void ctx.proofExporter.exportAllTabsAsZip();
+  });
 }
 
 // ========================================

--- a/packages/editor/src/styles/components/_problem-panel.css
+++ b/packages/editor/src/styles/components/_problem-panel.css
@@ -6,8 +6,13 @@
   flex-direction: column;
   min-width: 0;
   overflow: hidden;
+  position: relative;
   border-right: 1px solid var(--border-color, #333);
   background: var(--bg-secondary, #1e1e1e);
+}
+
+#problem-panel.resizing {
+  transition: none;
 }
 
 #problem-panel.visible {
@@ -17,10 +22,45 @@
 .problem-header {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 6px;
   padding: 8px 12px;
   flex: 0 0 auto;
   border-bottom: 1px solid var(--border-color, #333);
+}
+
+/* ヘッダの×ボタン (パネルを閉じる) */
+.problem-control-btn {
+  flex: 0 0 auto;
+  padding: 2px 6px;
+  background: transparent;
+  color: inherit;
+  border: none;
+  opacity: 0.6;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.problem-control-btn:hover {
+  opacity: 1;
+}
+
+/* 右端のリサイズハンドル (左パネルなので右端をドラッグ) */
+.problem-resize-handle {
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 4px;
+  height: 100%;
+  background: transparent;
+  cursor: col-resize;
+  z-index: 10;
+  transition: background-color 0.2s;
+}
+
+.problem-resize-handle:hover,
+.problem-resize-handle.dragging {
+  background: var(--accent-primary, #2d6cdf);
 }
 
 .problem-header h2 {
@@ -46,11 +86,62 @@
   opacity: 0.85;
 }
 
+.problem-footer {
+  flex: 0 0 auto;
+  padding: 10px 12px;
+  border-top: 1px solid var(--border-color, #333);
+}
+
+.exam-submit-note {
+  margin: 0 0 8px;
+  font-size: 12px;
+  line-height: 1.5;
+  opacity: 0.8;
+}
+
+/* 提出用ログのダウンロード — exam の完了アクションなので目立たせる。 */
+.download-log-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  padding: 10px 12px;
+  background: #2d6cdf;
+  color: #fff;
+  border: none;
+  border-radius: 5px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.download-log-btn:hover {
+  background: #3b7bf0;
+}
+
 /* 試験モード: タブの追加・削除 UI を隠す (ADR-0010, 1問1タブ固定)。
    源流の TabManager ロックが本体で、これは UI アフォーダンスを消すため。 */
 body.exam-mode .add-tab-btn,
 body.exam-mode .tab-close-btn {
   display: none !important;
+}
+
+/* 試験モード: ダウンロードは問題パネルのボタンに一本化するため、左の汎用DLメニューは隠す。 */
+body.exam-mode #download-menu-btn {
+  display: none !important;
+}
+
+/* 問題パネルのトグルは試験モードのみ表示 (casual には問題パネルが無い)。 */
+body:not(.exam-mode) #toggle-problem-btn {
+  display: none;
+}
+
+/* 問題パネルが開いている時のアクティブ表示。
+   アイコン色 (白) と縦バーの土台は既存の .activitybar-item.active に任せ、
+   バーの色だけ accent にする (白アイコンが背景と同化しないよう自前の色上書きはしない)。 */
+#toggle-problem-btn.active::before {
+  background: var(--accent-primary, #0078d4);
 }
 
 /* フルスクリーン警告バナー (ADR-0008) — 非ブロッキングの常時帯。

--- a/packages/editor/src/ui/components/ProblemPanel.ts
+++ b/packages/editor/src/ui/components/ProblemPanel.ts
@@ -1,31 +1,72 @@
 /**
- * ProblemPanel - 試験モードの問題表示パネル (ADR-0006 最小骨組み)
+ * ProblemPanel - 試験モードの問題表示パネル (ADR-0006 最小骨組み + ADR-0010 詰め)
  *
  * 現状はスタブ。問題の配布元 (封印問題パッケージ + 監督コードによる復号・チェーン束縛) は
- * full ADR-0006 で実装する。ここでは「試験モードでは左に問題パネルが出る」という骨組みだけを
- * 用意する。casual モードでは生成も表示もされない (モード差は機能のみ、の原則)。
+ * full ADR-0006 で実装する。casual モードでは生成も表示もされない (モード差は機能のみ)。
+ *
+ * UX: 既存の preview/log パネルと同じ作法で、右端ドラッグで幅をリサイズ・×で閉じる・
+ * タイトルバーのトグルで再表示できる。
  */
 export class ProblemPanel {
   private panel: HTMLElement | null = null;
   private body: HTMLElement | null = null;
+  private resizeHandle: HTMLElement | null = null;
+  private editorContainer: HTMLElement | null = null;
+  private toggleBtn: HTMLElement | null = null;
 
-  /** DOM 要素を捕捉する。`#problem-panel` が無ければ false。 */
+  private isResizing = false;
+  private startX = 0;
+  private startWidth = 0;
+  private readonly boundMouseMove: (e: MouseEvent) => void;
+  private readonly boundMouseUp: () => void;
+
+  constructor() {
+    this.boundMouseMove = this.handleResizeMouseMove.bind(this);
+    this.boundMouseUp = this.handleResizeMouseUp.bind(this);
+  }
+
+  /** DOM 捕捉 + リサイズ/クローズ/トグルの配線。`#problem-panel` が無ければ false。 */
   initialize(): boolean {
     this.panel = document.getElementById('problem-panel');
     this.body = document.getElementById('problem-body');
-    return this.panel !== null;
+    this.resizeHandle = document.getElementById('problem-resize-handle');
+    this.editorContainer = document.querySelector<HTMLElement>('.editor-container');
+    this.toggleBtn = document.getElementById('toggle-problem-btn');
+    if (!this.panel) return false;
+
+    document.getElementById('close-problem-btn')?.addEventListener('click', () => this.hide());
+    this.toggleBtn?.addEventListener('click', () => this.toggle());
+    this.setupResizeHandle();
+    this.updateToggleState();
+    return true;
   }
 
   show(): void {
     this.panel?.classList.add('visible');
+    this.updateToggleState();
   }
 
   hide(): void {
-    this.panel?.classList.remove('visible');
+    if (!this.panel) return;
+    this.panel.classList.remove('visible');
+    // リサイズで付与したインラインスタイルをクリア (再表示時は CSS 既定幅に戻す)。
+    this.panel.style.flex = '';
+    this.panel.style.minWidth = '';
+    this.updateToggleState();
+  }
+
+  toggle(): void {
+    if (this.isVisible) this.hide();
+    else this.show();
   }
 
   get isVisible(): boolean {
     return this.panel?.classList.contains('visible') ?? false;
+  }
+
+  /** Activity Bar のトグルアイコンに開閉状態を反映する (VSCode 風の左バー + 明色)。 */
+  private updateToggleState(): void {
+    this.toggleBtn?.classList.toggle('active', this.isVisible);
   }
 
   /**
@@ -34,5 +75,48 @@ export class ProblemPanel {
    */
   setProblemText(text: string): void {
     if (this.body) this.body.textContent = text;
+  }
+
+  private setupResizeHandle(): void {
+    if (!this.resizeHandle || !this.panel) return;
+    this.resizeHandle.addEventListener('mousedown', (e: MouseEvent) => {
+      if (!this.isVisible || !this.panel) return;
+      e.preventDefault();
+      this.isResizing = true;
+      this.startX = e.clientX;
+      this.startWidth = this.panel.offsetWidth;
+      this.panel.classList.add('resizing');
+      this.editorContainer?.classList.add('resizing');
+      this.resizeHandle?.classList.add('dragging');
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+    });
+    document.addEventListener('mousemove', this.boundMouseMove);
+    document.addEventListener('mouseup', this.boundMouseUp);
+  }
+
+  private handleResizeMouseMove(e: MouseEvent): void {
+    if (!this.isResizing || !this.panel) return;
+    const container = this.panel.parentElement;
+    if (!container) return;
+    const containerWidth = container.clientWidth;
+    // 左パネル: ハンドルは右端なので、マウスを右に動かす (deltaX > 0) と幅が広がる。
+    const deltaX = e.clientX - this.startX;
+    const newWidth = this.startWidth + deltaX;
+    const minWidth = 200;
+    const maxWidth = containerWidth * 0.6;
+    const clamped = Math.max(minWidth, Math.min(maxWidth, newWidth));
+    this.panel.style.flex = `0 0 ${clamped}px`;
+    this.panel.style.minWidth = `${clamped}px`;
+  }
+
+  private handleResizeMouseUp(): void {
+    if (!this.isResizing) return;
+    this.isResizing = false;
+    this.panel?.classList.remove('resizing');
+    this.editorContainer?.classList.remove('resizing');
+    this.resizeHandle?.classList.remove('dragging');
+    document.body.style.cursor = '';
+    document.body.style.userSelect = '';
   }
 }


### PR DESCRIPTION
## 概要

UI 改善（方向 A）。提出は **Moodle**（TypedCode に「提出」操作は無い）。完了アクション（ログ ZIP のダウンロード → Moodle 提出）を**分かりやすく一本化**した。

## ① ダウンロード導線の明快化・一本化

- **問題パネル下部に目立つ「ログをダウンロード」ボタン**（⬇アイコン＋ラベル）＋「① DL → ② Moodle 提出」の案内
- `#download-log-btn` → `proofExporter.exportAllTabsAsZip()`（証明＋コードの ZIP）
- 受験者の視線内（問題パネル）に集約。**左の汎用 DL メニュー（`#download-menu-btn`）は exam モードで非表示**にして一本化

## ② 問題パネルのリサイズ/クローズ（preview/log と同じ作法）

- **右端ドラッグで幅をリサイズ** / ヘッダの **× で閉じる** / titlebar の**問題トグル**（exam のみ表示）で再表示

## 動作確認

`?exam=1`：
- 問題パネル下部に青い「⬇ ログをダウンロード」ボタン → 押下で ZIP ダウンロード
- 左の縦アイコン列から汎用ダウンロードアイコンが消えている（一本化）
- 右端ドラッグでリサイズ / × で閉じ → titlebar の本アイコンで再表示

## 検証

- typecheck clean（全ワークスペース）、editor build OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)