### PR TITLE
feat(editor): ADR-0011 PR2 — モード能力を配線・課題モードでスクショ off

### DIFF
--- a/packages/editor/src/app/StaticEventListeners.ts
+++ b/packages/editor/src/app/StaticEventListeners.ts
@@ -149,7 +149,7 @@ export function setupStaticEventListeners(ctx: AppContext): void {
   // 新規タブ追加ボタン
   const addTabBtn = document.getElementById('add-tab-btn');
   addTabBtn?.addEventListener('click', async () => {
-    if (ctx.examMode) return; // 試験モードでは新規タブ不可 (ADR-0010)
+    if (ctx.capabilities.tabLock) return; // タブ固定モード (試験) では新規タブ不可 (ADR-0010/0011)
     if (!ctx.tabManager) return;
 
     if (isTurnstileConfigured()) {

--- a/packages/editor/src/core/mode.ts
+++ b/packages/editor/src/core/mode.ts
@@ -56,17 +56,22 @@ const EXAM: ModeCapabilities = {
 };
 
 /**
+ * 課題モード (assignment): 持ち帰り・プライバシー重視。CASUAL から **screenshots を off** に
+ * する (自宅画面のキャプチャを避ける。ADR-0011)。封印なし・問題配布 UX は後続 PR。
+ */
+const ASSIGNMENT: ModeCapabilities = { ...CASUAL, screenshots: false };
+
+/**
  * 能力マトリクス (ADR-0011)。
  *
- * **class/assignment の値は当面 casual と同一 (PR1 では非アクティブ)**。PR2 で授業/課題の
- * 能力に差し替える予定:
- *   - class      → 監督下・封印なし (screenshots 任意, fullscreen 任意, tabLock 緩, problemPanel)
- *   - assignment → 持ち帰り (screenshots:false=スクショ off, fullscreen:false, problemPanel, preExportBestEffort)
+ * - **class は当面 casual と同一** (監督は教室の物理的在室で担保。fullscreen 任意・問題表示は後続 PR)。
+ * - **assignment は screenshots off** (上記)。
+ * - **exam** だけが封印問題・根束縛・厳格な能力 (tabLock/fullscreen/preExport best-effort) を持つ。
  */
 export const MODE_CAPABILITIES: Record<EditorMode, ModeCapabilities> = {
   casual: CASUAL,
   class: CASUAL,
-  assignment: CASUAL,
+  assignment: ASSIGNMENT,
   exam: EXAM,
 };
 

--- a/packages/editor/src/main.ts
+++ b/packages/editor/src/main.ts
@@ -278,14 +278,13 @@ const ctx: AppContext = {
 
 // proof に生成時のモードを記録する (ADR-0011: 自己申告ラベル、全モード共通)。
 ctx.proofExporter.setMode(ctx.mode);
+// export 前認証の best-effort 化はモード能力で決まる (ADR-0006: exam のみ。サーバを critical path に置かない)。
+ctx.proofExporter.setExamMode(ctx.capabilities.preExportBestEffort);
 
-// 試験モード: 問題パネル (スタブ) を表示する。casual モードでは何もしない。
+// 封印問題モード (exam): 問題パネルを表示し DL を一本化する。他モードでは何もしない。
 // Monaco は automaticLayout: true なのでパネル出現に伴う再レイアウトは自動。
 if (ctx.examMode) {
   document.body.classList.add('exam-mode');
-  // 試験モードでは export 前認証を best-effort 化 (ADR-0006: サーバを critical path に
-  // 置かない。Workers 不達でも提出 ZIP を生成できるようにする)。
-  ctx.proofExporter.setExamMode(true);
   // ProblemPanel.initialize() がリサイズ/クローズ/トグルを内部で配線する。
   if (ctx.problemPanel.initialize()) {
     ctx.problemPanel.show();
@@ -490,7 +489,7 @@ function initializeTerminal(): void {
   const newFileBtn = document.getElementById('new-file-btn');
   newFileBtn?.addEventListener('click', async () => {
     ctx.mainMenuDropdown.close();
-    if (ctx.examMode) return; // 試験モードでは新規ファイル不可 (ADR-0010)
+    if (ctx.capabilities.tabLock) return; // タブ固定モード (試験) では新規ファイル不可 (ADR-0010/0011)
     if (!ctx.tabManager) return;
 
     if (isTurnstileConfigured()) {
@@ -876,7 +875,11 @@ async function initializeApp(): Promise<void> {
   const isReload = sessionStorage.getItem('typedcode-session-active') === 'true';
   const hasExistingSession = await sessionService.hasExistingSession();
 
-  if (ScreenshotTracker.isSupported()) {
+  if (!ctx.capabilities.screenshots) {
+    // このモードでは画面キャプチャを使わない (課題モード = 自宅・プライバシー。ADR-0011)。
+    // 画面共有の選択ダイアログも出さず、screenshot tracker を作らない。
+    console.log('[TypedCode] Screenshots disabled for mode:', ctx.mode);
+  } else if (ScreenshotTracker.isSupported()) {
     // ScreenshotTrackerはSessionStorageServiceを使用してスクリーンショットを保存
     const screenshotTracker = new ScreenshotTracker(sessionService);
 
@@ -1177,8 +1180,8 @@ async function initializeApp(): Promise<void> {
     recordTermsAcceptance();
   }
 
-  // 試験モード: 初期問題タブ確定後、タブの追加・削除を源流でロックする (ADR-0010)。
-  if (ctx.examMode) {
+  // タブ固定モード (試験): 初期問題タブ確定後、タブの追加・削除を源流でロックする (ADR-0010/0011)。
+  if (ctx.capabilities.tabLock) {
     ctx.tabManager?.setExamLock(true);
   }
 
@@ -1225,9 +1228,9 @@ async function initializeApp(): Promise<void> {
   initializeLogViewer(ctx);
   initializeEventRecorder();
 
-  // 試験モード: フルスクリーン追跡 + 警告バナー (ADR-0008)。eventRecorder 準備後に配線する。
+  // フルスクリーン追跡 + 警告バナー (ADR-0008、能力 fullscreenTracking)。eventRecorder 準備後に配線する。
   // 警告バナーの「フルスクリーンで受験」ボタンが開始ジェスチャ (requestFullscreen は要 user gesture)。
-  if (ctx.examMode) {
+  if (ctx.capabilities.fullscreenTracking) {
     ctx.fullscreenTracker.setRecordCallback((event) => {
       void ctx.eventRecorder?.recordToAllTabs(event);
     });


### PR DESCRIPTION
## 概要

ADR-0011 **PR2**。散在する `ctx.examMode` ゲートを **モード能力 (`ctx.capabilities`)** 経由にし、課題モードに固有の能力を与える。**唯一の挙動変更は assignment のスクショ無効化**（プライバシー）。PR1 ([#82](https://github.com/shinyaoguri/typedcode/pull/82)) で入れた能力モデルを「生きた」配線にする。

## 変更

- **`mode.ts`**: `ASSIGNMENT` プリセット（`CASUAL` から `screenshots: false`）。class は当面 casual。
- **`main.ts`**:
  - 画面キャプチャ初期化を `capabilities.screenshots` でゲート → **課題は画面共有ダイアログを出さず screenshot tracker も作らない**。
  - pre-export best-effort を `capabilities.preExportBestEffort` 駆動（exam のみ）。
  - 新規ファイル抑止・タブ固定を `capabilities.tabLock`、fullscreen を `capabilities.fullscreenTracking` に配線。
- **`StaticEventListeners.ts`**: 新規タブ抑止を `capabilities.tabLock` に配線。
- 封印問題固有（`body.exam-mode`・問題パネル・解錠フロー）は `examMode` のまま。

## 回帰なし

`tabLock`/`fullscreenTracking`/`preExportBestEffort` は **exam のみ true** なので exam の挙動は不変、casual も不変。**変わるのは assignment のスクショ off のみ**。

## 検証

- typecheck 全 workspace green。
- **localhost e2e (Playwright)**:
  - `/assignment` → 利用規約 → **画面共有ダイアログ無しでエディタへ直行**、ログ `Screenshots disabled for mode: assignment`、`examModeClass=false`、casual 風（DL メニューあり）。
  - `/exam` → **画面共有ダイアログあり**、`examModeClass=true`（スクショ・試験モード維持＝回帰なし）。

## スコープ外 (後続 PR)

- per-mode storage 名前空間化（モード間でセッション共存）。
- class の能力差分（fullscreen 任意・問題表示）。
- 問題配布 UX（署名記述子）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
