### PR TITLE
feat(editor): 試験オーサリング seam — shared 暗号コアを再利用する .tcexam 生成純関数 (#80)

### DIFF
--- a/packages/editor/src/authoring/__tests__/examPackageAuthoring.test.ts
+++ b/packages/editor/src/authoring/__tests__/examPackageAuthoring.test.ts
@@ -1,0 +1,187 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  canonicalizeStartToken,
+  computeExamPackageHash,
+  decryptExamPackage,
+  verifyExamPackageSignature,
+  type ExamAuthorityKey,
+  type ExamPackageSigner,
+} from '@typedcode/shared';
+import {
+  createExamPackage,
+  formatProctorTokenForDisplay,
+  generateProctorToken,
+  importAuthoritySigner,
+  type CreateExamPackageParams,
+} from '../examPackageAuthoring.js';
+
+const KEY_ID = 'exam-test-author';
+
+/** ECDSA P-256 鍵を生成し、私的 JWK / 公開 JWK の両方を返す (出題者鍵の代理)。 */
+async function generateAuthorityKeyPair(): Promise<{
+  privateJwk: JsonWebKey;
+  publicJwk: JsonWebKey;
+}> {
+  const pair = await crypto.subtle.generateKey(
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    true,
+    ['sign', 'verify']
+  );
+  const privateJwk = await crypto.subtle.exportKey('jwk', pair.privateKey);
+  const publicJwk = await crypto.subtle.exportKey('jwk', pair.publicKey);
+  return { privateJwk, publicJwk };
+}
+
+function baseParams(overrides: Partial<CreateExamPackageParams> = {}): CreateExamPackageParams {
+  return {
+    problemText: '# 問題1\n\n標準入力から2つの整数を読み、和を出力せよ。',
+    examId: '2026-spring-cs101-final',
+    problemId: 'p1',
+    languages: ['c', 'python'],
+    releaseTime: '2026-06-10T01:00:00.000Z',
+    deadline: '2026-06-10T04:00:00.000Z',
+    proctorToken: 'ABCD-EFGH',
+    ...overrides,
+  };
+}
+
+describe('generateProctorToken', () => {
+  it('produces a token of the requested length using only Crockford Base32 characters', () => {
+    const token = generateProctorToken(12);
+    expect(token).toHaveLength(12);
+    expect(token).toMatch(/^[0-9A-HJKMNP-TV-Z]+$/);
+  });
+
+  it('defaults to 8 characters', () => {
+    expect(generateProctorToken()).toHaveLength(8);
+  });
+
+  it('rejects a non-positive length', () => {
+    expect(() => generateProctorToken(0)).toThrow();
+    expect(() => generateProctorToken(-3)).toThrow();
+  });
+});
+
+describe('formatProctorTokenForDisplay', () => {
+  it('groups a canonicalized token into 4-character chunks for slide display', () => {
+    expect(formatProctorTokenForDisplay('abcdefgh')).toBe('ABCD-EFGH');
+  });
+
+  it('leaves a chunk shorter than 4 without a trailing separator', () => {
+    expect(formatProctorTokenForDisplay('ABCDEF')).toBe('ABCD-EF');
+  });
+});
+
+describe('importAuthoritySigner', () => {
+  it('imports a P-256 private JWK string into a signer without embedding the public key by default', async () => {
+    const { privateJwk } = await generateAuthorityKeyPair();
+    const signer = await importAuthoritySigner(JSON.stringify(privateJwk), KEY_ID);
+    expect(signer.keyId).toBe(KEY_ID);
+    expect(signer.publicKeyJwk).toBeUndefined();
+  });
+
+  it('embeds only the public components (no secret scalar d) when asked', async () => {
+    const { privateJwk } = await generateAuthorityKeyPair();
+    const signer = await importAuthoritySigner(privateJwk, KEY_ID, { embedPublicKey: true });
+    expect(signer.publicKeyJwk).toBeDefined();
+    expect(signer.publicKeyJwk).not.toHaveProperty('d');
+    expect(signer.publicKeyJwk?.x).toBe(privateJwk.x);
+    expect(signer.publicKeyJwk?.y).toBe(privateJwk.y);
+  });
+
+  it('rejects a JWK that is not an EC P-256 private key', async () => {
+    const { publicJwk } = await generateAuthorityKeyPair();
+    // public JWK has no "d" → not a signing key
+    await expect(importAuthoritySigner(publicJwk, KEY_ID)).rejects.toThrow();
+  });
+
+  it('rejects malformed JSON', async () => {
+    await expect(importAuthoritySigner('{not json', KEY_ID)).rejects.toThrow();
+  });
+});
+
+describe('createExamPackage', () => {
+  let signer: ExamPackageSigner;
+  let registry: readonly ExamAuthorityKey[];
+
+  beforeAll(async () => {
+    const { privateJwk, publicJwk } = await generateAuthorityKeyPair();
+    signer = await importAuthoritySigner(privateJwk, KEY_ID);
+    registry = [
+      {
+        keyId: KEY_ID,
+        algorithm: 'ECDSA-P256',
+        publicKeyJwk: publicJwk,
+        status: 'active',
+        validFrom: '2026-01-01T00:00:00.000Z',
+      },
+    ];
+  });
+
+  it('produces a manifest whose signature verifies against the authority registry', async () => {
+    const { manifest } = await createExamPackage(baseParams(), signer);
+    const result = await verifyExamPackageSignature(manifest, registry);
+    expect(result.valid).toBe(true);
+  });
+
+  it('seals the problem so the proctor token decrypts back to the original plaintext', async () => {
+    const params = baseParams();
+    const { manifest, proctorToken } = await createExamPackage(params, signer);
+    const decrypted = await decryptExamPackage(manifest, proctorToken);
+    expect(decrypted.ok).toBe(true);
+    expect(decrypted.ok && decrypted.plaintext).toBe(params.problemText);
+  });
+
+  it('returns the canonicalized proctor token actually used for KDF', async () => {
+    const { proctorToken } = await createExamPackage(baseParams({ proctorToken: 'ab-cd-ef-gh' }), signer);
+    expect(proctorToken).toBe(canonicalizeStartToken('ab-cd-ef-gh'));
+  });
+
+  it('reports a packageHash equal to the canonical hash recomputed from the manifest', async () => {
+    const { manifest, packageHash } = await createExamPackage(baseParams(), signer);
+    expect(packageHash).toBe(await computeExamPackageHash(manifest));
+  });
+
+  it('refuses to decrypt under a wrong proctor token', async () => {
+    const { manifest } = await createExamPackage(baseParams({ proctorToken: 'CORRECT0' }), signer);
+    const decrypted = await decryptExamPackage(manifest, 'WRONG000');
+    expect(decrypted.ok).toBe(false);
+  });
+
+  it('trims and drops empty entries from the allowed languages', async () => {
+    const { manifest } = await createExamPackage(baseParams({ languages: [' c ', '', 'python'] }), signer);
+    expect(manifest.allowed.languages).toEqual(['c', 'python']);
+  });
+
+  it('uses a fresh random salt per package so two builds of the same input differ', async () => {
+    const a = await createExamPackage(baseParams(), signer);
+    const b = await createExamPackage(baseParams(), signer);
+    expect(a.manifest.kdf.salt).not.toBe(b.manifest.kdf.salt);
+    expect(a.packageHash).not.toBe(b.packageHash);
+  });
+
+  it('rejects an empty problem body', async () => {
+    await expect(createExamPackage(baseParams({ problemText: '' }), signer)).rejects.toThrow();
+  });
+
+  it('rejects when no allowed language survives trimming', async () => {
+    await expect(createExamPackage(baseParams({ languages: ['', '  '] }), signer)).rejects.toThrow();
+  });
+
+  it('rejects a release time that is not strictly before the deadline', async () => {
+    await expect(
+      createExamPackage(
+        baseParams({ releaseTime: '2026-06-10T04:00:00.000Z', deadline: '2026-06-10T04:00:00.000Z' }),
+        signer
+      )
+    ).rejects.toThrow();
+  });
+
+  it('rejects an unparseable release time', async () => {
+    await expect(createExamPackage(baseParams({ releaseTime: 'not-a-date' }), signer)).rejects.toThrow();
+  });
+
+  it('rejects a proctor token with no Crockford characters', async () => {
+    await expect(createExamPackage(baseParams({ proctorToken: '---' }), signer)).rejects.toThrow();
+  });
+});

--- a/packages/editor/src/authoring/examPackageAuthoring.ts
+++ b/packages/editor/src/authoring/examPackageAuthoring.ts
@@ -1,0 +1,203 @@
+/**
+ * 試験モード (ADR-0006) の **出題者オーサリング seam** — 平文問題から署名済み封印
+ * パッケージ (`.tcexam`) を生成する純粋コア。
+ *
+ * 役割: editor アプリ内（将来の `/author` UI / 対話 CLI）が共有する「問題 → .tcexam」の
+ * 単一導線。**暗号は一切再実装せず** shared の `buildExamPackage` /
+ * `computeExamPackageHash` / `canonicalizeStartToken` を直接呼ぶ。これにより
+ * `packages/workers/scripts/make-exam-package.mjs` が抱える canonical core / signing core の
+ * 手写し複製 (= shared と必ず一致させる保守負債) を将来的に解消できる土台にする。
+ *
+ * 本モジュールは DOM 非依存・純関数。鍵・問題文・時刻はすべて引数で受け取り、UI 状態や
+ * ストレージには触れない (テスト容易性と再利用性のため)。WebCrypto (`crypto.subtle` /
+ * `crypto.getRandomValues`) のみに依存し、browser / Node (vitest) 双方で動く。
+ */
+
+import {
+  buildExamPackage,
+  computeExamPackageHash,
+  canonicalizeStartToken,
+  arrayBufferToHex,
+  DEFAULT_EXAM_KDF_PARAMS,
+  EXAM_PACKAGE_FORMAT_VERSION,
+  type ExamKdf,
+  type ExamKdfParams,
+  type ExamPackageBuildInput,
+  type ExamPackageManifest,
+  type ExamPackageSigner,
+} from '@typedcode/shared';
+
+/** Crockford Base32 アルファベット (I L O U を除外 = 32 文字)。監督コード生成に使う。 */
+const CROCKFORD = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+/** 監督コードの既定長 (文字数)。8 字 Crockford = 40 bit のエントロピー。 */
+export const DEFAULT_PROCTOR_TOKEN_LENGTH = 8;
+
+/** release → deadline の既定ウィンドウ (3 時間)。deadline 未指定時に release から算出。 */
+export const DEFAULT_EXAM_WINDOW_MS = 3 * 60 * 60 * 1000;
+
+/**
+ * 暗号学的乱数で Crockford Base32 の監督コードを生成する。
+ * `256 % 32 === 0` なのでモジュロバイアスは無い。返り値は既に正準形 (大文字・区切り無し)。
+ */
+export function generateProctorToken(length: number = DEFAULT_PROCTOR_TOKEN_LENGTH): string {
+  if (!Number.isInteger(length) || length <= 0) {
+    throw new Error('Proctor token length must be a positive integer');
+  }
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  let out = '';
+  for (let i = 0; i < length; i++) {
+    out += CROCKFORD[bytes[i]! % 32];
+  }
+  return out;
+}
+
+/**
+ * 監督コードをスライド掲示用に 4 文字ごとへグルーピングする (`ABCD-EFGH`)。
+ * 表示専用。KDF / root / proof 保存には必ず正準形 (`canonicalizeStartToken`) を使う。
+ */
+export function formatProctorTokenForDisplay(token: string): string {
+  const canonical = canonicalizeStartToken(token);
+  return canonical.replace(/(.{4})(?=.)/g, '$1-');
+}
+
+/**
+ * 出題者の私的 JWK を WebCrypto 署名鍵に取り込み、`buildExamPackage` 用の signer を作る。
+ * `embedPublicKey` を立てると long-term verifiability 用に公開鍵 (`{kty,crv,x,y}`) を
+ * manifest 同梱できる (信頼源は常に registry。同梱鍵は控え)。
+ */
+export async function importAuthoritySigner(
+  jwk: JsonWebKey | string,
+  keyId: string,
+  options: { embedPublicKey?: boolean } = {}
+): Promise<ExamPackageSigner> {
+  if (!keyId) {
+    throw new Error('keyId is required');
+  }
+  let parsed: JsonWebKey;
+  try {
+    parsed = typeof jwk === 'string' ? (JSON.parse(jwk) as JsonWebKey) : jwk;
+  } catch {
+    throw new Error('Signing key JWK is not valid JSON');
+  }
+  if (!parsed || parsed.kty !== 'EC' || parsed.crv !== 'P-256' || !parsed.d) {
+    throw new Error('Signing key must be an EC P-256 private JWK (with a "d" parameter)');
+  }
+
+  let privateKey: CryptoKey;
+  try {
+    privateKey = await crypto.subtle.importKey(
+      'jwk',
+      parsed,
+      { name: 'ECDSA', namedCurve: 'P-256' },
+      false,
+      ['sign']
+    );
+  } catch {
+    throw new Error('Failed to import signing key (malformed P-256 private JWK)');
+  }
+
+  const signer: ExamPackageSigner = { keyId, privateKey };
+  if (options.embedPublicKey) {
+    // 公開成分のみを抽出 (秘密スカラ d は同梱しない)。
+    signer.publicKeyJwk = { kty: parsed.kty, crv: parsed.crv, x: parsed.x, y: parsed.y };
+  }
+  return signer;
+}
+
+/** `createExamPackage` の入力。時刻は ISO 文字列、言語は許可リスト。 */
+export interface CreateExamPackageParams {
+  /** 平文の問題本文 (Markdown 想定)。封印される。 */
+  problemText: string;
+  examId: string;
+  problemId: string;
+  /** per-student variant。単一問題運用は null。 */
+  variant?: string | null;
+  /** 許可言語 (空白除去・空要素除去してから封印)。 */
+  languages: string[];
+  /** 試験開始 T0 (ISO)。 */
+  releaseTime: string;
+  /** 提出期限 T1 (ISO)。 */
+  deadline: string;
+  /** 監督コード。生・区切り入りでも可 (内部で正準化)。 */
+  proctorToken: string;
+  /** Argon2id パラメータ。既定は ADR-0006 の 64MiB/3iters/1lane。 */
+  kdfParams?: ExamKdfParams;
+}
+
+/** `createExamPackage` の結果。manifest + 確認用 packageHash + 実際に使った正準監督コード。 */
+export interface CreatedExamPackage {
+  manifest: ExamPackageManifest;
+  /** SHA-256(canonical core)。proof.exam.packageHash と突合する確認値。 */
+  packageHash: string;
+  /** KDF/復号に実際に使われた正準形の監督コード (T0 に解禁する値)。 */
+  proctorToken: string;
+}
+
+/**
+ * 平文問題を封印して署名済み `.tcexam` manifest を作る (オーサリングの単一導線)。
+ * salt / IV は毎回ランダム生成し、暗号・署名・packageHash はすべて shared に委譲する。
+ *
+ * @throws 入力が不正 (空の問題文 / 言語なし / 時刻不正 / release ≥ deadline / 空の監督コード) なとき。
+ */
+export async function createExamPackage(
+  params: CreateExamPackageParams,
+  signer: ExamPackageSigner
+): Promise<CreatedExamPackage> {
+  const problemText = params.problemText;
+  if (!problemText || problemText.length === 0) {
+    throw new Error('problemText must not be empty');
+  }
+  if (!params.examId || !params.problemId) {
+    throw new Error('examId and problemId are required');
+  }
+
+  const languages = params.languages.map((l) => l.trim()).filter((l) => l.length > 0);
+  if (languages.length === 0) {
+    throw new Error('At least one allowed language is required');
+  }
+
+  const releaseMs = Date.parse(params.releaseTime);
+  const deadlineMs = Date.parse(params.deadline);
+  if (!Number.isFinite(releaseMs)) {
+    throw new Error('releaseTime is not a valid ISO date');
+  }
+  if (!Number.isFinite(deadlineMs)) {
+    throw new Error('deadline is not a valid ISO date');
+  }
+  if (releaseMs >= deadlineMs) {
+    throw new Error('releaseTime must be strictly before deadline');
+  }
+
+  const proctorToken = canonicalizeStartToken(params.proctorToken);
+  if (proctorToken.length === 0) {
+    throw new Error('proctorToken must contain at least one Crockford Base32 character');
+  }
+
+  // salt は毎回ランダム 16 byte (KDF 出力をパッケージ間で非相関にする)。
+  const salt = new Uint8Array(16);
+  crypto.getRandomValues(salt);
+  const kdf: ExamKdf = {
+    algorithm: 'argon2id',
+    salt: arrayBufferToHex(salt),
+    params: params.kdfParams ?? { ...DEFAULT_EXAM_KDF_PARAMS },
+  };
+
+  const input: ExamPackageBuildInput = {
+    formatVersion: EXAM_PACKAGE_FORMAT_VERSION,
+    examId: params.examId,
+    problemId: params.problemId,
+    variant: params.variant ?? null,
+    kdf,
+    releaseTime: params.releaseTime,
+    deadline: params.deadline,
+    allowed: { languages },
+    keyId: signer.keyId,
+    algorithm: 'ECDSA-P256',
+  };
+
+  const manifest = await buildExamPackage(input, problemText, proctorToken, signer);
+  const packageHash = await computeExamPackageHash(manifest);
+  return { manifest, packageHash, proctorToken };
+}


### PR DESCRIPTION
## 概要

教員向け問題作成 (#80) の**土台**として、editor アプリ内に「平文問題 → 署名済み `.tcexam`」の純関数 seam を新設する。将来の `/author` UI と対話 CLI が共有する単一導線。**暗号は一切再実装せず** shared の `buildExamPackage` / `computeExamPackageHash` / `canonicalizeStartToken` を直接呼ぶ。

## 設計判断（前提の反転）

当初は複製のある `make-exam-package.mjs` を shared 呼び出しに作り直す想定だったが、調査で**前提が反転**:

- shared は build 出力を持たず entry が raw TS (`src/index.ts`)。内部 import が `.js` 拡張子（実体 `.ts`）なので **Node 単独は shared を解決できない**（CLAUDE.md 既知の「verify-cli も node 直実行でコケる」と同根）。これが `.mjs` が canonical/signing core を手写し複製している根本原因。
- 一方 **editor (Vite) は既に shared をネイティブ import できる**（`.js`→`.ts` 解決）。

→ shared 再利用の**最低リスク**な置き場は editor アプリ内。複製ゼロ・build 改変ゼロ・#80 GUI の土台そのもの。

## 変更

- \`packages/editor/src/authoring/examPackageAuthoring.ts\` — 純関数 seam（DOM 非依存・WebCrypto のみ）
  - \`generateProctorToken\`（Crockford Base32・モジュロバイアスなし）
  - \`formatProctorTokenForDisplay\`（\`ABCD-EFGH\` グルーピング・表示専用）
  - \`importAuthoritySigner\`（P-256 私的 JWK→signer。公開鍵同梱は \`{kty,crv,x,y}\` のみ＝秘密スカラ d を除外）
  - \`createExamPackage\`（salt/IV 毎回ランダム・入力検証つき封印）
- \`__tests__/examPackageAuthoring.test.ts\` — **21 ケース**。鍵生成→封印→\`verifyExamPackageSignature\` / \`decryptExamPackage\` で **shared の検証経路をそのまま通すラウンドトリップ parity** を含む

## スコープ外（follow-up）

- \`make-exam-package.mjs\` は当面残置。seam への寄せは shared ビルド整備後の follow-up。
- 次 PR で本 seam の上に \`/author\` UI（鍵読込→問題入力→.tcexam＋監督コード DL）を載せる。

## 検証

- editor **46 tests**（25 既存 + 21 新）pass
- \`tsc --noEmit\` clean

Refs #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)