### PR TITLE
feat(shared): ADR-0012 Phase1+2a — 試験バンドル codec ＋ grader/verifier v2 対応

### DIFF
--- a/packages/shared/src/__tests__/examBundle.test.ts
+++ b/packages/shared/src/__tests__/examBundle.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EXAM_BUNDLE_SCHEMA,
+  parseExamBundle,
+  decodeExamPlaintext,
+  encodeExamBundle,
+  computeBundleProblemHash,
+  computeExamChainRoot,
+} from '../exam/index.js';
+import type { ExamBundle } from '../types/exam.js';
+
+function sampleBundle(): ExamBundle {
+  return {
+    schema: EXAM_BUNDLE_SCHEMA,
+    problems: [
+      { problemId: 'p1', statement: '# 問題1\n和を出力せよ。', starter: { filename: 'p1.c', language: 'c', content: '/* TODO */\n' } },
+      { problemId: 'p2', statement: '# 問題2\n積を出力せよ。' },
+    ],
+  };
+}
+
+describe('parseExamBundle', () => {
+  it('accepts a well-formed bundle and normalizes it to the known shape', () => {
+    const bundle = parseExamBundle(sampleBundle());
+    expect(bundle?.problems).toHaveLength(2);
+    expect(bundle?.problems[1]!.starter).toBeUndefined();
+  });
+
+  it('rejects a payload without the bundle schema', () => {
+    expect(parseExamBundle({ problems: [{ problemId: 'p1', statement: 'x' }] })).toBeNull();
+  });
+
+  it('rejects an empty problem list', () => {
+    expect(parseExamBundle({ schema: EXAM_BUNDLE_SCHEMA, problems: [] })).toBeNull();
+  });
+
+  it('rejects duplicate problemIds within a bundle', () => {
+    const dup = { schema: EXAM_BUNDLE_SCHEMA, problems: [
+      { problemId: 'p1', statement: 'a' },
+      { problemId: 'p1', statement: 'b' },
+    ] };
+    expect(parseExamBundle(dup)).toBeNull();
+  });
+
+  it('rejects a problem missing problemId or statement', () => {
+    expect(parseExamBundle({ schema: EXAM_BUNDLE_SCHEMA, problems: [{ statement: 'x' }] })).toBeNull();
+    expect(parseExamBundle({ schema: EXAM_BUNDLE_SCHEMA, problems: [{ problemId: 'p1' }] })).toBeNull();
+  });
+
+  it('rejects a malformed starter', () => {
+    const bad = { schema: EXAM_BUNDLE_SCHEMA, problems: [{ problemId: 'p1', statement: 'x', starter: { filename: 'a.c' } }] };
+    expect(parseExamBundle(bad)).toBeNull();
+  });
+});
+
+describe('decodeExamPlaintext', () => {
+  it('decodes an encoded bundle as kind=bundle', () => {
+    const decoded = decodeExamPlaintext(encodeExamBundle(sampleBundle()));
+    expect(decoded.kind).toBe('bundle');
+    expect(decoded.kind === 'bundle' && decoded.bundle.problems).toHaveLength(2);
+  });
+
+  it('treats raw markdown (non-JSON) as a legacy single problem', () => {
+    const decoded = decodeExamPlaintext('# 問題\n標準入力から…');
+    expect(decoded.kind).toBe('legacy');
+    expect(decoded.kind === 'legacy' && decoded.statement).toBe('# 問題\n標準入力から…');
+  });
+
+  it('treats JSON without the bundle schema as legacy (backward compatible)', () => {
+    const json = JSON.stringify({ hello: 'world' });
+    const decoded = decodeExamPlaintext(json);
+    expect(decoded.kind).toBe('legacy');
+    expect(decoded.kind === 'legacy' && decoded.statement).toBe(json);
+  });
+});
+
+describe('encodeExamBundle', () => {
+  it('round-trips through decode preserving problems and starters', () => {
+    const decoded = decodeExamPlaintext(encodeExamBundle(sampleBundle()));
+    if (decoded.kind !== 'bundle') throw new Error('expected bundle');
+    expect(decoded.bundle.problems[0]).toEqual(sampleBundle().problems[0]);
+  });
+
+  it('is deterministic regardless of problem object key order', () => {
+    const a: ExamBundle = { schema: EXAM_BUNDLE_SCHEMA, problems: [{ problemId: 'p1', statement: 's' }] };
+    const b = { schema: EXAM_BUNDLE_SCHEMA, problems: [{ statement: 's', problemId: 'p1' }] } as ExamBundle;
+    expect(encodeExamBundle(a)).toBe(encodeExamBundle(b));
+  });
+});
+
+describe('computeBundleProblemHash', () => {
+  it('is stable across CRLF vs LF newlines', async () => {
+    const lf = await computeBundleProblemHash({ problemId: 'p1', statement: 'a\nb' });
+    const crlf = await computeBundleProblemHash({ problemId: 'p1', statement: 'a\r\nb' });
+    expect(lf).toBe(crlf);
+  });
+
+  it('changes when the problemId changes (relabeling is detectable)', async () => {
+    const h1 = await computeBundleProblemHash({ problemId: 'p1', statement: 'same' });
+    const h2 = await computeBundleProblemHash({ problemId: 'p2', statement: 'same' });
+    expect(h1).not.toBe(h2);
+  });
+
+  it('changes when the starter content changes', async () => {
+    const base = { problemId: 'p1', statement: 's', starter: { filename: 'a.c', language: 'c', content: 'x' } };
+    const changed = { ...base, starter: { ...base.starter, content: 'y' } };
+    expect(await computeBundleProblemHash(base)).not.toBe(await computeBundleProblemHash(changed));
+  });
+});
+
+describe('computeExamChainRoot (v2 binding)', () => {
+  const fp = 'a'.repeat(64);
+  const nonce = 'b'.repeat(64);
+  const pkg = 'c'.repeat(64);
+  const token = 'ABCD1234';
+  const pch = 'd'.repeat(64);
+
+  it('omitting problemContentHash is byte-identical to the v1 formula', async () => {
+    const v1 = await computeExamChainRoot(fp, nonce, pkg, token);
+    const v1Explicit = await computeExamChainRoot(fp, nonce, pkg, token, undefined);
+    expect(v1Explicit).toBe(v1);
+  });
+
+  it('binding a per-problem hash (v2) differs from v1', async () => {
+    const v1 = await computeExamChainRoot(fp, nonce, pkg, token);
+    const v2 = await computeExamChainRoot(fp, nonce, pkg, token, pch);
+    expect(v2).not.toBe(v1);
+  });
+
+  it('differs per problem within the same package and token', async () => {
+    const a = await computeExamChainRoot(fp, nonce, pkg, token, 'd'.repeat(64));
+    const b = await computeExamChainRoot(fp, nonce, pkg, token, 'e'.repeat(64));
+    expect(a).not.toBe(b);
+  });
+});

--- a/packages/shared/src/__tests__/examBundleBinding.test.ts
+++ b/packages/shared/src/__tests__/examBundleBinding.test.ts
@@ -1,0 +1,173 @@
+/**
+ * ADR-0012 (N問バンドル + B-2 root) の grader 検証テスト。
+ *
+ * - verifyExamBinding が v2 proof を「署名 → packageHash → root(v2) → per-problem 内容ハッシュ」で通す
+ * - verifyInitialHashRoot が v2 root (末尾に problemContentHash を連結) を受理する
+ * - 問題ラベル付け替え / v2 主張だが平文が非バンドル / 未知 problemId を弾く
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  verifyInitialHashRoot,
+  verifyExamBinding,
+  buildExamProofBlock,
+  computeExamPackageHash,
+  computeExamChainRoot,
+  computeBundleProblemHash,
+  encodeExamBundle,
+  EXAM_BUNDLE_SCHEMA,
+  EXAM_ROOT_BINDING_V2,
+  computeHash,
+  deterministicStringify,
+  type ExamBundle,
+  type ExamPackageManifest,
+  type ExamProofBlock,
+  type ExamAuthorityKey,
+} from '../index.js';
+import { makeExamAuthority, buildSamplePackage } from './fixtures/examFixtures.js';
+
+interface FabricatedExamProof {
+  typingProofData: { deviceId: string; initialHashNonce: string; initialEventChainHash: string };
+  proof: { events: Array<{ previousHash: string }>; finalHash: string };
+  fingerprint: { hash: string; components: Record<string, string> };
+  exam: ExamProofBlock;
+}
+
+type BindingArg = Parameters<typeof verifyExamBinding>[0];
+type RootArg = Parameters<typeof verifyInitialHashRoot>[0];
+
+function sampleBundle(): ExamBundle {
+  return {
+    schema: EXAM_BUNDLE_SCHEMA,
+    problems: [
+      { problemId: 'p1', statement: '# 問題1\n和を出力せよ。', starter: { filename: 'p1.c', language: 'c', content: '/* TODO */\n' } },
+      { problemId: 'p2', statement: '# 問題2\n積を出力せよ。' },
+    ],
+  };
+}
+
+interface BundleProofFixture {
+  proof: FabricatedExamProof;
+  manifest: ExamPackageManifest;
+  registry: readonly ExamAuthorityKey[];
+}
+
+/**
+ * 1つのバンドルパッケージを封印し、その中の problemIndex 番目の問題に束縛した v2 proof を捏造する
+ * (= その問題のタブの proof に相当)。
+ */
+async function makeBundleProof(
+  problemIndex: number,
+  overrides: { problemIdInBlock?: string; bundle?: ExamBundle } = {}
+): Promise<BundleProofFixture> {
+  const { signer, registry } = await makeExamAuthority();
+  const bundle = overrides.bundle ?? sampleBundle();
+  const { manifest, token } = await buildSamplePackage(signer, { plaintext: encodeExamBundle(bundle) });
+
+  const packageHash = await computeExamPackageHash(manifest);
+  const problem = bundle.problems[problemIndex]!;
+  const problemContentHash = await computeBundleProblemHash(problem);
+
+  const components = { lang: 'en-US', tz: 'UTC' };
+  const fpHash = await computeHash(deterministicStringify(components));
+  const nonce = '7'.repeat(64);
+  // v2 root: 末尾に per-problem ハッシュを連結。
+  const root = await computeExamChainRoot(fpHash, nonce, packageHash, token, problemContentHash);
+
+  const exam: ExamProofBlock = {
+    ...buildExamProofBlock({
+      examId: manifest.examId,
+      problemId: overrides.problemIdInBlock ?? problem.problemId,
+      variant: manifest.variant,
+      packageHash,
+      problemContentHash,
+      startToken: token,
+    }),
+    rootBinding: EXAM_ROOT_BINDING_V2,
+  };
+
+  const proof: FabricatedExamProof = {
+    typingProofData: { deviceId: fpHash, initialHashNonce: nonce, initialEventChainHash: root },
+    proof: { events: [{ previousHash: root }], finalHash: root },
+    fingerprint: { hash: fpHash, components },
+    exam,
+  };
+  return { proof, manifest, registry };
+}
+
+describe('verifyInitialHashRoot (v2 bundle branch)', () => {
+  it('accepts a v2 root bound to packageHash + startToken + per-problem hash', async () => {
+    const { proof } = await makeBundleProof(0);
+    const result = await verifyInitialHashRoot(proof as unknown as RootArg);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a v2 proof whose per-problem hash in the block was altered (root no longer matches)', async () => {
+    const { proof } = await makeBundleProof(0);
+    const altered = { ...proof, exam: { ...proof.exam, problemContentHash: 'f'.repeat(64) } };
+    const result = await verifyInitialHashRoot(altered as unknown as RootArg);
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe('verifyExamBinding (v2 bundle)', () => {
+  it('passes every step for a consistent v2 bundle proof bound to one problem', async () => {
+    const { proof, manifest, registry } = await makeBundleProof(0);
+    const result = await verifyExamBinding(proof as unknown as BindingArg, manifest, {
+      examAuthorityRegistry: registry,
+    });
+    expect(result.packageSignatureValid).toBe(true);
+    expect(result.packageHashMatches).toBe(true);
+    expect(result.rootMatches).toBe(true);
+    expect(result.problemContentHashMatches).toBe(true);
+    expect(result.valid).toBe(true);
+  });
+
+  it('verifies the second problem of the same bundle independently', async () => {
+    const { proof, manifest, registry } = await makeBundleProof(1);
+    const result = await verifyExamBinding(proof as unknown as BindingArg, manifest, {
+      examAuthorityRegistry: registry,
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a proof whose block problemId does not exist in the bundle', async () => {
+    // root は p1 のハッシュで作るが block の problemId を未知 idに差し替える → 内容照合で fail。
+    const { proof, manifest, registry } = await makeBundleProof(0, { problemIdInBlock: 'does-not-exist' });
+    const result = await verifyExamBinding(proof as unknown as BindingArg, manifest, {
+      examAuthorityRegistry: registry,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('does-not-exist');
+  });
+
+  it('rejects a v2 proof when the decrypted plaintext is not a bundle (legacy markdown)', async () => {
+    // 平文を生 markdown にして封印するが、proof は v2 を主張する。
+    const { signer, registry } = await makeExamAuthority();
+    const { manifest, token } = await buildSamplePackage(signer, { plaintext: '# 生 markdown 問題' });
+    const packageHash = await computeExamPackageHash(manifest);
+    const fakeProblemHash = 'a'.repeat(64);
+    const components = { lang: 'en-US', tz: 'UTC' };
+    const fpHash = await computeHash(deterministicStringify(components));
+    const nonce = '7'.repeat(64);
+    const root = await computeExamChainRoot(fpHash, nonce, packageHash, token, fakeProblemHash);
+    const exam: ExamProofBlock = {
+      ...buildExamProofBlock({
+        examId: manifest.examId, problemId: 'p1', variant: null,
+        packageHash, problemContentHash: fakeProblemHash, startToken: token,
+      }),
+      rootBinding: EXAM_ROOT_BINDING_V2,
+    };
+    const proof = {
+      typingProofData: { deviceId: fpHash, initialHashNonce: nonce, initialEventChainHash: root },
+      proof: { events: [{ previousHash: root }], finalHash: root },
+      fingerprint: { hash: fpHash, components },
+      exam,
+    };
+    const result = await verifyExamBinding(proof as unknown as BindingArg, manifest, {
+      examAuthorityRegistry: registry,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('not an exam bundle');
+  });
+});

--- a/packages/shared/src/exam/examBundle.ts
+++ b/packages/shared/src/exam/examBundle.ts
@@ -1,0 +1,125 @@
+/**
+ * 封印平文の構造化版 — N問バンドルの符号化 / 復号 / per-problem ハッシュ (ADR-0012)。
+ *
+ * 役割: 1つの `.tcexam` に N 問をバンドルする平文ペイロード (`tcexam-exam/1`) の
+ * **単一真実源**。authoring の封印前 (`encodeExamBundle`) と editor / grader の解錠後
+ * (`decodeExamPlaintext`) が同じ符号化・正準化を共有する (`buildExamPackage` と同じ方針)。
+ *
+ * 不変条件:
+ * - **後方互換**: 構造化されていない平文 (旧来の生 Markdown) は `legacy` として扱う。
+ *   schema 判別に失敗したものはすべて legacy 問題文に畳む。
+ * - **正準化**: per-problem ハッシュ (`computeBundleProblemHash`) は改行コードを正規化し
+ *   キー順序を決定化した上で計算する。これを root v2 (ADR-0012 B-2) と proof.exam に焼くので、
+ *   editor / grader 間で 1 bit でもズレると束縛検証が壊れる。
+ *
+ * 暗号コア (KDF/AES/署名/packageHash) には触れない。封印・署名は examPackage.ts のまま。
+ */
+
+import type {
+  ExamBundle,
+  ExamBundleProblem,
+  DecodedExamPlaintext,
+} from '../types/exam.js';
+import type { TemplateFileDefinition } from '../types/template.js';
+import { computeHash, deterministicStringify } from '../utils/hashUtils.js';
+
+/** 封印平文の構造化 schema 識別子 (ADR-0012)。 */
+export const EXAM_BUNDLE_SCHEMA = 'tcexam-exam/1' as const;
+
+/** 改行コードを LF へ正規化 (CRLF / CR → LF)。ハッシュの安定化に使う。 */
+function normalizeNewlines(s: string): string {
+  return s.replace(/\r\n?/g, '\n');
+}
+
+const isStr = (v: unknown): v is string => typeof v === 'string';
+const isNonEmptyStr = (v: unknown): v is string => typeof v === 'string' && v.length > 0;
+const isObj = (v: unknown): v is Record<string, unknown> =>
+  !!v && typeof v === 'object' && !Array.isArray(v);
+
+/** untrusted な starter (任意) を検証する。形が不正なら null、未指定なら undefined を返す。 */
+function parseStarter(input: unknown): TemplateFileDefinition | null | undefined {
+  if (input === undefined) return undefined;
+  if (!isObj(input)) return null;
+  if (!isNonEmptyStr(input.filename) || !isNonEmptyStr(input.language) || !isStr(input.content)) {
+    return null;
+  }
+  return { filename: input.filename, language: input.language, content: input.content };
+}
+
+/**
+ * untrusted な JSON を `ExamBundle` として構造検証する。形が不正なら null。
+ * 真正性 (署名) は verifyExamPackageSignature、内容束縛は per-problem ハッシュが別途担う。
+ */
+export function parseExamBundle(input: unknown): ExamBundle | null {
+  if (!isObj(input) || input.schema !== EXAM_BUNDLE_SCHEMA) return null;
+  if (!Array.isArray(input.problems) || input.problems.length === 0) return null;
+
+  const problems: ExamBundleProblem[] = [];
+  const seenIds = new Set<string>();
+  for (const raw of input.problems) {
+    if (!isObj(raw)) return null;
+    if (!isNonEmptyStr(raw.problemId) || !isStr(raw.statement)) return null;
+    if (seenIds.has(raw.problemId)) return null; // problemId はバンドル内で一意
+    seenIds.add(raw.problemId);
+    const starter = parseStarter(raw.starter);
+    if (starter === null) return null;
+    const problem: ExamBundleProblem = { problemId: raw.problemId, statement: raw.statement };
+    if (starter) problem.starter = starter;
+    problems.push(problem);
+  }
+  return { schema: EXAM_BUNDLE_SCHEMA, problems };
+}
+
+/**
+ * 復号後平文を解釈する (ADR-0012)。`tcexam-exam/1` バンドルとして妥当なら `bundle`、
+ * それ以外 (非 JSON / schema 不一致 / 構造不正) は旧来の単一 Markdown 問題として `legacy` に畳む。
+ */
+export function decodeExamPlaintext(plaintext: string): DecodedExamPlaintext {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(plaintext);
+  } catch {
+    return { kind: 'legacy', statement: plaintext };
+  }
+  const bundle = parseExamBundle(parsed);
+  if (!bundle) return { kind: 'legacy', statement: plaintext };
+  return { kind: 'bundle', bundle };
+}
+
+/** 1問を正準形 (改行正規化済み・キー決定的) に整える。ハッシュと封印の入力に使う。 */
+function canonicalProblem(problem: ExamBundleProblem): ExamBundleProblem {
+  const canonical: ExamBundleProblem = {
+    problemId: problem.problemId,
+    statement: normalizeNewlines(problem.statement),
+  };
+  if (problem.starter) {
+    canonical.starter = {
+      filename: problem.starter.filename,
+      language: problem.starter.language,
+      content: normalizeNewlines(problem.starter.content),
+    };
+  }
+  return canonical;
+}
+
+/**
+ * 封印する平文文字列を組み立てる (ADR-0012)。`encode` 後の文字列を AES-256-GCM で暗号化する。
+ * 各問を正準化した上で決定的シリアライズするので、同一バンドルは常に同一平文になる
+ * (problemContentHash の安定性と再現性のため)。
+ */
+export function encodeExamBundle(bundle: ExamBundle): string {
+  const canonical: ExamBundle = {
+    schema: EXAM_BUNDLE_SCHEMA,
+    problems: bundle.problems.map(canonicalProblem),
+  };
+  return deterministicStringify(canonical);
+}
+
+/**
+ * per-problem の内容ハッシュ (ADR-0012)。`SHA-256(deterministicStringify(canonical(problem)))`。
+ * **problemId を含む**ので問題ラベルの付け替えはハッシュ不一致で露見する。各タブの proof.exam に
+ * 記録し、root v2 (B-2) に焼く。改行差で揺れないよう正準化してから計算する。
+ */
+export async function computeBundleProblemHash(problem: ExamBundleProblem): Promise<string> {
+  return computeHash(deterministicStringify(canonicalProblem(problem)));
+}

--- a/packages/shared/src/exam/examPackage.ts
+++ b/packages/shared/src/exam/examPackage.ts
@@ -33,7 +33,8 @@ import {
   findExamAuthorityKey,
   type ExamAuthorityKey,
 } from '../examAuthorityKeys/index.js';
-import { EXAM_PACKAGE_FORMAT_VERSION, EXAM_PROOF_VERSION, EXAM_ROOT_BINDING } from '../version.js';
+import { EXAM_PACKAGE_FORMAT_VERSION, EXAM_PROOF_VERSION, EXAM_ROOT_BINDING, EXAM_ROOT_BINDING_V2 } from '../version.js';
+import { decodeExamPlaintext, computeBundleProblemHash } from './examBundle.js';
 
 // ============================================================================
 // バイト列ユーティリティ (DOM/Node 非依存)
@@ -563,19 +564,46 @@ export async function verifyExamBinding(
     return { ...result, reason: 'Recomputed packageHash does not match proof.exam.packageHash' };
   }
 
-  // 3. root 再計算 (fp, nonce, packageHash, startToken) = initialEventChainHash → T0 以降に開始
-  const recomputedRoot = await computeExamChainRoot(fingerprintHash, nonce, packageHash, exam.startToken);
+  // root 束縛バージョン: v2 (ADR-0012, N問バンドル) は root と内容ハッシュを per-problem で検証する。
+  // 旧 proof は rootBinding 未設定 = v1 とみなし、従来どおり (whole-plaintext) で検証する。
+  const isV2 = exam.rootBinding === EXAM_ROOT_BINDING_V2;
+
+  // 3. root 再計算 → initialEventChainHash → T0 以降に開始。
+  //    v1: SHA256(fp ‖ nonce ‖ packageHash ‖ startToken)。
+  //    v2: 末尾に per-problem problemContentHash を連結し「この封印の・この問題」に束縛 (B-2)。
+  const recomputedRoot = await computeExamChainRoot(
+    fingerprintHash,
+    nonce,
+    packageHash,
+    exam.startToken,
+    isV2 ? exam.problemContentHash : undefined
+  );
   result.rootMatches = recomputedRoot === expectedRoot;
   if (!result.rootMatches) {
     return { ...result, reason: 'Recomputed exam chain root does not match proof initialEventChainHash' };
   }
 
-  // 4. startToken で復号 → 平文 SHA-256 = proof.exam.problemContentHash → 答案はこの問題のもの
+  // 4. startToken で復号 → 内容ハッシュ = proof.exam.problemContentHash → 答案はこの問題のもの。
+  //    v2: バンドルを decode し proof.exam.problemId で該当問題を引いて per-problem ハッシュを照合。
+  //    v1: 平文全体の SHA-256 (従来挙動)。
   const decrypted = await decryptExamPackage(manifest, exam.startToken);
   if (!decrypted.ok) {
     return { ...result, reason: `Decryption failed: ${decrypted.reason}` };
   }
-  const contentHash = await computeProblemContentHash(decrypted.plaintext);
+  let contentHash: string;
+  if (isV2) {
+    const decoded = decodeExamPlaintext(decrypted.plaintext);
+    if (decoded.kind !== 'bundle') {
+      return { ...result, reason: 'Proof claims v2 root binding but decrypted plaintext is not an exam bundle' };
+    }
+    const problem = decoded.bundle.problems.find((p) => p.problemId === exam.problemId);
+    if (!problem) {
+      return { ...result, reason: `Bundle has no problem with id ${exam.problemId}` };
+    }
+    contentHash = await computeBundleProblemHash(problem);
+  } else {
+    contentHash = await computeProblemContentHash(decrypted.plaintext);
+  }
   result.problemContentHashMatches = contentHash === exam.problemContentHash;
   if (!result.problemContentHashMatches) {
     return { ...result, reason: 'Decrypted problemContentHash does not match proof.exam.problemContentHash' };

--- a/packages/shared/src/exam/examPackage.ts
+++ b/packages/shared/src/exam/examPackage.ts
@@ -176,18 +176,26 @@ export async function computeProblemContentHash(plaintext: string): Promise<stri
 }
 
 /**
- * exam モードのチェーン根 (genesis = 監督コード入力 = T0)。
- * root = SHA-256(fingerprintHash ‖ localNonce ‖ packageHash ‖ startToken)。
- * casual の `SHA-256(fingerprintHash + nonce)` と同じ平文連結スタイル
- * (各値は固定長 hex / Crockford トークンで境界の曖昧さはない)。editor と verifier 共有の唯一の root ヘルパ。
+ * exam モードのチェーン根 (genesis = 監督コード入力 = T0)。editor と verifier 共有の唯一の root ヘルパ。
+ *
+ * - **v1** (単一問題、ADR-0006): root = SHA-256(fingerprintHash ‖ localNonce ‖ packageHash ‖ startToken)。
+ * - **v2** (N問バンドル、ADR-0012 B-2): 末尾に per-problem `problemContentHash` を連結し、
+ *   各タブの genesis を「この封印の・この問題」に束縛する。
+ *   root = SHA-256(… ‖ startToken ‖ problemContentHash)。
+ *
+ * `problemContentHash` 省略時は **v1 とバイト一致**する (後方互換)。各値は固定長 hex /
+ * Crockford トークンなので連結の境界は曖昧にならない (startToken は大文字 Crockford、
+ * problemContentHash は小文字 hex で、同じ連結は同じ (token, hash) からしか生じない)。
  */
 export async function computeExamChainRoot(
   fingerprintHash: string,
   localNonce: string,
   packageHash: string,
-  startToken: string
+  startToken: string,
+  problemContentHash?: string
 ): Promise<string> {
-  return computeHash(fingerprintHash + localNonce + packageHash + startToken);
+  const suffix = problemContentHash ?? '';
+  return computeHash(fingerprintHash + localNonce + packageHash + startToken + suffix);
 }
 
 // ============================================================================

--- a/packages/shared/src/exam/index.ts
+++ b/packages/shared/src/exam/index.ts
@@ -18,6 +18,14 @@ export {
   DEFAULT_EXAM_KDF_PARAMS,
 } from './examPackage.js';
 
+export {
+  EXAM_BUNDLE_SCHEMA,
+  parseExamBundle,
+  decodeExamPlaintext,
+  encodeExamBundle,
+  computeBundleProblemHash,
+} from './examBundle.js';
+
 export type {
   ExamDecryptResult,
   ExamPackageSigner,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -93,6 +93,11 @@ export {
   verifyExamBinding,
   buildExamProofBlock,
   DEFAULT_EXAM_KDF_PARAMS,
+  EXAM_BUNDLE_SCHEMA,
+  parseExamBundle,
+  decodeExamPlaintext,
+  encodeExamBundle,
+  computeBundleProblemHash,
 } from './exam/index.js';
 
 export type {
@@ -115,6 +120,7 @@ export {
   EXAM_PACKAGE_FORMAT_VERSION,
   EXAM_PROOF_VERSION,
   EXAM_ROOT_BINDING,
+  EXAM_ROOT_BINDING_V2,
   MIN_SUPPORTED_VERSION,
   parseVersion,
   compareVersions,

--- a/packages/shared/src/types/exam.ts
+++ b/packages/shared/src/types/exam.ts
@@ -9,6 +9,7 @@
  */
 
 import type { SignedCheckpointAlgorithm } from './signedCheckpoint.js';
+import type { TemplateFileDefinition } from './template.js';
 
 /** Argon2id KDF パラメータ */
 export interface ExamKdfParams {
@@ -86,6 +87,43 @@ export interface ExamSessionContext {
   /** 監督コード (正準形) */
   startToken: string;
 }
+
+// ============================================================================
+// 封印平文の構造化版 — N問バンドル (ADR-0012)
+// ============================================================================
+
+/** 封印平文の構造化 schema 識別子 (ADR-0012)。`problems[]` を持つ試験バンドル。 */
+export type ExamBundleSchema = 'tcexam-exam/1';
+
+/**
+ * バンドル内の1問 (ADR-0012)。**1問 = 1タブ**で展開される。
+ * `starter` は任意の単一スターターコードファイル (無ければ空タブ)。1問複数ファイルは現状非対応。
+ */
+export interface ExamBundleProblem {
+  problemId: string;
+  /** 問題文 (Markdown) */
+  statement: string;
+  /** スターターコード (任意)。`TemplateFileDefinition` を再利用 (テンプレート機能と共通)。 */
+  starter?: TemplateFileDefinition;
+}
+
+/**
+ * 封印される平文の構造化版 (ADR-0012)。1つの `.tcexam` に N 問をバンドルし、
+ * 解錠時に各 `problems[i]` を1タブへ展開する。`packageHash`(署名) が全体を覆い、
+ * 各タブの束縛は per-problem `problemContentHash` (root v2) が担う。
+ */
+export interface ExamBundle {
+  schema: ExamBundleSchema;
+  problems: ExamBundleProblem[];
+}
+
+/**
+ * 復号後平文を解釈した結果 (ADR-0012)。後方互換のため、構造化されていない平文は
+ * 旧来の単一 Markdown 問題 (`legacy`) として扱う。
+ */
+export type DecodedExamPlaintext =
+  | { kind: 'bundle'; bundle: ExamBundle }
+  | { kind: 'legacy'; statement: string };
 
 /**
  * proof の `exam` ブロック (exam モード時のみ、ADR-0006 §4)。

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -80,7 +80,7 @@ export type {
   SignedCheckpointsVerificationResult,
 } from './proof.js';
 
-// 試験モード関連 (ADR-0006)
+// 試験モード関連 (ADR-0006, ADR-0012)
 export type {
   ExamKdfParams,
   ExamKdf,
@@ -89,6 +89,10 @@ export type {
   ExamPackageSigningCore,
   ExamSessionContext,
   ExamProofBlock,
+  ExamBundleSchema,
+  ExamBundleProblem,
+  ExamBundle,
+  DecodedExamPlaintext,
 } from './exam.js';
 
 // テンプレート関連

--- a/packages/shared/src/verification.ts
+++ b/packages/shared/src/verification.ts
@@ -23,7 +23,7 @@ export {
 
 import { deterministicStringify, computeHash } from './utils/hashUtils.js';
 import { computeExamChainRoot } from './exam/examPackage.js';
-import { POSW_ITERATIONS } from './version.js';
+import { POSW_ITERATIONS, EXAM_ROOT_BINDING_V2 } from './version.js';
 import {
   verifyProofSignedCheckpoints,
 } from './signedCheckpoints.js';
@@ -132,13 +132,15 @@ export async function verifyInitialHashRoot(
 
   // 試験モード: root に packageHash と startToken を束ねる (ADR-0006 §3)。
   // package 自体の署名・復号・内容ハッシュ照合は verifyExamBinding が担う。ここでは
-  // proof 自己完結で「root が宣言された packageHash + startToken から計算されている」ことだけ確認する。
+  // proof 自己完結で「root が宣言された packageHash + startToken (v2 は + problemContentHash)
+  // から計算されている」ことだけ確認する。v2 = N問バンドル (ADR-0012 B-2)、それ以外は v1。
   const computedInitialHash = proof.exam
     ? await computeExamChainRoot(
         fingerprintHash,
         nonce,
         proof.exam.packageHash,
-        proof.exam.startToken
+        proof.exam.startToken,
+        proof.exam.rootBinding === EXAM_ROOT_BINDING_V2 ? proof.exam.problemContentHash : undefined
       )
     : await computeHash(fingerprintHash + nonce);
   if (computedInitialHash !== expectedInitialHash) {

--- a/packages/shared/src/version.ts
+++ b/packages/shared/src/version.ts
@@ -21,6 +21,13 @@ export const EXAM_PROOF_VERSION = 1 as const;
 /** チェーン根束縛の方式バージョン (ADR-0006)。root = SHA256(fp ‖ nonce ‖ packageHash ‖ startToken) */
 export const EXAM_ROOT_BINDING = 'v1' as const;
 
+/**
+ * N問バンドル (ADR-0012 B-2) の root 束縛バージョン。
+ * root = SHA256(fp ‖ nonce ‖ packageHash ‖ startToken ‖ problemContentHash)。
+ * v1 の末尾に per-problem ハッシュを連結し、各タブを「この封印の・この問題」に束縛する。
+ */
+export const EXAM_ROOT_BINDING_V2 = 'v2' as const;
+
 /** ストレージフォーマットバージョン (localStorage用、整数) */
 export const STORAGE_FORMAT_VERSION = 1 as const;
 


### PR DESCRIPTION
## 概要

ADR-0012（[#89](https://github.com/shinyaoguri/typedcode/pull/89)）の **shared 側（Phase 1 + 2a）**：N問バンドル（problem = tab）の **produce（codec）と verify（grader）を加算的**に実装する。editor の多タブ配線は後続 Phase 2b。**v1 単一問題の root/束縛/検証経路はバイト一致・無回帰**。

## Phase 1 — codec / root primitive

- **types/exam.ts**: `ExamBundle` / `ExamBundleProblem` / `ExamBundleSchema` / `DecodedExamPlaintext`。`starter` は `TemplateFileDefinition` 再利用。
- **exam/examBundle.ts（新規）**: 封印平文 `tcexam-exam/1` の**単一真実源**
  - `parseExamBundle`（構造検証・problemId 一意）/ `decodeExamPlaintext`（bundle/legacy 判別=後方互換）/ `encodeExamBundle`（改行正規化+決定的シリアライズ）/ `computeBundleProblemHash`（**problemId 込み**の per-problem 正準ハッシュ）
- **computeExamChainRoot**: optional `problemContentHash`（省略=v1 バイト一致、指定=v2 末尾連結）。`EXAM_ROOT_BINDING_V2='v2'`。

## Phase 2a — grader / verifier v2

- **verifyExamBinding**: `rootBinding==='v2'` で root を per-problem ハッシュ込み再計算（B-2）＋復号平文を decode し `problemId` で問題を引いて per-problem ハッシュ照合。v2 主張だが非バンドル / 未知 problemId は reject。v1 は従来どおり。
- **verification.ts**: `verifyInitialHashRoot` の exam root 再計算も v2 対応。

## 検証

- shared **270 tests** pass（新規 23：codec 17 + grader v2 6。**既存 exam root parity 含め無回帰**）
- 全 workspace `tsc --noEmit` green

## 後続（ADR-0012 残フェーズ）

- **Phase 2b（editor）**: 解錠を `TemplateImporter` 再利用で N タブ exam 束縛（root v2 を `generateExamInitialHash`/`initializeExam` で生成・per-problem hash 記録・ProblemPanel per-tab・源流ロック N タブ化・リロード復帰）
- **Phase 3（/author）**: N 問入力

Refs #80, ADR-0012（#89）

🤖 Generated with [Claude Code](https://claude.com/claude-code)