### PR TITLE
docs(adr-0013): 試験スケジュールを advisory とし manifest フォーマットは据え置く (Accepted)

### DIFF
--- a/docs/adr/0013-exam-schedule-advisory-keep-manifest-format.md
+++ b/docs/adr/0013-exam-schedule-advisory-keep-manifest-format.md
@@ -1,0 +1,58 @@
+# ADR-0013: 試験スケジュール (releaseTime/deadline) を advisory とし、manifest フォーマットは据え置く
+
+- **Status**: Accepted
+- **Date**: 2026-06-09
+- **Deciders**: (PR 上の合意者 / レビュアー)
+- **PR / Commit**: #NN
+
+## Context
+
+`.tcexam` manifest (ADR-0006, §4.7) は `releaseTime` (試験開始 T0) と `deadline` (提出期限 T1) を持ち、両者は **signing core に含まれ署名・packageHash に焼かれる**。
+
+オーサリング運用を見直した結果、**開始/締切の管理は Moodle 側で行い、TypedCode 側は「いつ解いたか」(proof のタイムスタンプ・署名チェックポイントの serverTimestamp) を記録できれば十分**という方針が確定した (`/author` UI からスケジュール入力欄を撤去済み)。
+
+ここで「manifest からも release/deadline を消す (フォーマットを変える) べきか」を検討する。両フィールドの実際の用途は非対称:
+
+- **`releaseTime`**: スケジュール表示だけでなく **出題者鍵の有効性アンカー**。`checkExamKeyValidityAtRelease` が「`releaseTime` 時点で鍵が有効/未失効だったか」(validFrom / validUntil / revokedAt) を判定する。これは**スケジュールと独立した正当な意味**を持ち、実体は **issued-at (パッケージ発行時刻)**。
+- **`deadline`**: 用途は `verifyExamBinding` の **advisory な time-box のみ** (`withinWindow` は grader が提出時刻を渡したときだけ判定し、それ以外は無視。失格条件にはしない)。**純粋にスケジュール専用**。
+
+## Considered Options
+
+### Option A: フォーマット据え置き（★採用）
+`releaseTime`/`deadline` を必須のまま残し、UI は内部既定 (releaseTime=生成時刻, deadline=オープン=遠い未来) を入れる。意味づけを文書で確定する。
+- Pros: **横断的変更ゼロ**。`releaseTime` の鍵有効性アンカーを失わない。verifier は optional 分岐を持たず単純なまま。既存 `.tcexam` と完全互換。
+- Cons: `deadline` が advisory な vestigial フィールドとして残る。「オープン」を遠い未来 (`2999-12-31`) のセンチネルで表すのは多少の匂い。
+
+### Option B: `deadline` を optional 化する (formatVersion 2)
+- Pros: 「スケジュールは Moodle が正」を型でも表現でき意味論が綺麗。
+- Cons: **signing core 変更 → `EXAM_PACKAGE_FORMAT_VERSION` bump**、`verifyExamBinding` / `parseExamPackageManifest` / verify(web) / verify-cli / 後方互換の横断改修。得られるのは advisory な 1 フィールドの除去のみで、**リスク/便益が見合わない**。`releaseTime` は鍵アンカーとして引き続き必須。
+
+## Decision
+
+**Option A を採る。** manifest フォーマットは変更しない。意味づけを以下に確定する:
+
+- **`releaseTime` = パッケージ発行時刻 (issued-at) かつ出題者鍵有効性アンカー。** 必須。`/author` は生成時刻を入れる。
+- **`deadline` = advisory な提出窓の上限。** 必須だが**規範ではない** — 実際の開始/締切の管理は **Moodle が唯一の正**。Moodle 管理時は **オープン (遠い未来) を入れる** (`/author` は `2999-12-31T23:59:59.999Z`)。`verifyExamBinding` の time-box は引き続き advisory (失格条件にしない)。
+- 「いつ解いたか」は proof 側 (イベントのタイムスタンプ、署名 cp の serverTimestamp) が担う。
+
+将来どうしても `deadline` を optional 化したくなったら、独立した formatVersion 2 の ADR で扱う (現時点は不要)。
+
+## Consequences
+
+### Positive
+- 横断改修ゼロ・既存パッケージ完全互換。`releaseTime` の鍵有効性検証 (defense-in-depth) を維持。
+- スケジュール責務が明確化 (Moodle が正、TypedCode は記録のみ)。
+
+### Negative / Trade-offs
+- `deadline` が advisory な必須フィールドとして残り、「オープン」をセンチネル日付で表す。
+- verifier の time-box 出力に「advisory」である旨が伝わるかは UI 表示次第 (既存の繰り越し課題)。
+
+### Follow-ups / 残課題
+- system-spec §4.7 に releaseTime=issued-at/アンカー・deadline=advisory(Moodle が正) を明記 (本 ADR と同時)。
+- (将来・任意) `deadline` optional 化を formatVersion 2 で検討。
+
+## References
+
+- 関連コード: [packages/shared/src/exam/examPackage.ts](../../packages/shared/src/exam/examPackage.ts)（`checkExamKeyValidityAtRelease` / `verifyExamBinding` の time-box）、[packages/shared/src/types/exam.ts](../../packages/shared/src/types/exam.ts)（`ExamPackageManifest`）
+- 関連 ADR: [ADR-0006](0006-exam-mode-sealed-problem-binding.md)（封印・束縛 — release/deadline を定義）、[ADR-0012](0012-sealed-starter-template-in-exam-payload.md)（N問バンドル）
+- 関連 issue / PR: #80、#92（`/author` スケジュール撤去）

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,6 +43,7 @@
 | [0010](0010-exam-session-model.md) | Accepted (sticky 部分は ADR-0011 で置換) | 試験モードのセッション構造 (1問1タブ・固定・リロード復帰可能) |
 | [0011](0011-course-modes-and-path-routing.md) | Accepted | 授業・課題・試験を1ドメインのパスで分岐し能力プリセットでモデル化する |
 | [0012](0012-sealed-starter-template-in-exam-payload.md) | Proposed | 封印問題の平文を構造化し N問バンドル＋問題ごとのスターターコードを同梱する |
+| [0013](0013-exam-schedule-advisory-keep-manifest-format.md) | Accepted | 試験スケジュールを advisory とし manifest フォーマットは据え置く |
 
 ## 参考
 

--- a/docs/system-spec.md
+++ b/docs/system-spec.md
@@ -292,6 +292,7 @@ interface SignedCheckpointEnvelope {
 ```
 - **署名 / packageHash の対象は同一の canonical core** = manifest から `{signature, publicKeyJwk}` を除いたもの (`deterministicStringify`)。任意同梱の publicKeyJwk・署名値そのものに packageHash が依存しない。
 - KDF は **Argon2id** (純 JS の `@noble/hashes`、メモリハードで GPU 並列耐性)、暗号は **AES-256-GCM**。
+- **`releaseTime` / `deadline` の意味 (ADR-0013)**: `releaseTime` は **パッケージ発行時刻 (issued-at) かつ出題者鍵有効性アンカー** (`checkExamKeyValidityAtRelease` が `releaseTime` 時点の鍵 validFrom/validUntil/revokedAt を判定する)。`deadline` は **advisory な提出窓の上限**で、`verifyExamBinding` の time-box は失格条件にしない。**実際の開始/締切の管理は Moodle が唯一の正**で、TypedCode 側は「いつ解いたか」(イベントのタイムスタンプ・署名 cp の serverTimestamp) を記録するに留まる。`/author` はスケジュールを尋ねず、`releaseTime`=生成時刻・`deadline`=オープン (遠い未来 `2999-12-31`) を入れる。manifest フォーマットは据え置き (ADR-0013)。
 
 **(2) 監督コード (`startToken`)**: **8 文字 Crockford Base32 (`I L O U` 除外, 40 bit)**。CSPRNG 生成、T0 に監督が口頭/板書で解禁。入力は正準化 (大文字化 + 区切り除去) して KDF / root / `proof.exam` の全経路で一致させる。**コードの正しさは AES-GCM 認証タグで判定** (誤コード → 復号失敗)。平文 manifest に token のコミットメント (`H(token)`) は**置かない** (低エントロピーゆえ総当たりで漏れる)。封印は「T0 までの数分だけ確実に持つ消費期限つき」であり永続金庫ではない。
 


### PR DESCRIPTION
## 概要

「`.tcexam` manifest から `releaseTime`/`deadline` を消す（フォーマットを変える）べきか」の検討結果を ADR-0013 として記録（**結論: 変えない**）＋ system-spec に意味づけを明記。

## 検討

両フィールドの用途は非対称:
- **`releaseTime`** = パッケージ発行時刻 (issued-at) **かつ出題者鍵有効性アンカー**（`checkExamKeyValidityAtRelease` が `releaseTime` 時点の鍵 validFrom/validUntil/revokedAt を判定）。スケジュールと独立した正当な意味を持つ。
- **`deadline`** = `verifyExamBinding` の **advisory な time-box のみ**（失格条件にしない）。純粋にスケジュール専用。

## 決定（Option A: 据え置き）

- フォーマットは変更しない。`releaseTime`=issued-at/鍵アンカー・`deadline`=advisory として必須維持。
- 実際の開始/締切は **Moodle が唯一の正**。Moodle 管理時は `deadline` にオープン（遠い未来 `2999-12-31`）を入れる。「いつ解いたか」は proof のタイムスタンプ・署名 cp が担う。
- **却下（Option B: deadline を optional 化）**: formatVersion 2 への bump＋signing core/verifier/後方互換の横断改修となり、advisory な1フィールド除去にリスク/便益が見合わない。`releaseTime` はいずれにせよ必須。

## 変更

- `docs/adr/0013-...md`（Accepted）＋ README 索引
- `docs/system-spec.md` §4.7 に releaseTime/deadline の意味を明記

#92 と独立（docs のみ）。

Refs #80, #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)