### PR TITLE
feat(ui): 機能別アクセントカラーで editor/verify/author をぱっと見で判別

### DIFF
--- a/packages/editor/src/authoring/AuthorPage.ts
+++ b/packages/editor/src/authoring/AuthorPage.ts
@@ -407,6 +407,7 @@ export class AuthorPage {
       <div class="author-app">
         <header class="author-toolbar">
           <div class="author-toolbar-brand"><i class="fas fa-feather-pointed"></i> ${escapeHtml(t('author.title'))}</div>
+          <span class="feature-badge"><i class="fas fa-feather-pointed"></i> ${escapeHtml(t('feature.author'))}</span>
           <input type="text" id="author-exam-id" class="author-input author-toolbar-input" placeholder="${escapeHtml(t('author.problem.examId'))}" autocomplete="off" spellcheck="false">
           <input type="text" id="author-languages" class="author-input author-toolbar-input author-toolbar-narrow" value="c" placeholder="${escapeHtml(t('author.problem.languages'))}" autocomplete="off" spellcheck="false">
           <input type="text" id="author-token" class="author-input author-mono author-toolbar-narrow" autocomplete="off" autocapitalize="characters" spellcheck="false" title="${escapeHtml(t('author.token.label'))}">

--- a/packages/editor/src/authoring/authorMain.ts
+++ b/packages/editor/src/authoring/authorMain.ts
@@ -15,6 +15,8 @@ import { AuthorPage } from './AuthorPage.js';
 // テーマ適用 (編集アプリと同じ localStorage キーを尊重。既定 dark)。
 const theme = localStorage.getItem('typedcode-theme') === 'light' ? 'light' : 'dark';
 document.documentElement.setAttribute('data-theme', theme);
+// 機能別アクセント (要望: ぱっと見で機能を判別)。出題アプリ = 紫。
+document.documentElement.setAttribute('data-feature', 'author');
 
 configureMonacoWorkers();
 initDOMi18n();

--- a/packages/editor/src/i18n/translations/en.ts
+++ b/packages/editor/src/i18n/translations/en.ts
@@ -23,6 +23,14 @@ export const en: TranslationKeys = {
     initializing: 'Initializing...',
   },
 
+  feature: {
+    casual: 'Create',
+    class: 'Class',
+    assignment: 'Assignment',
+    exam: 'Exam',
+    author: 'Author',
+  },
+
   settings: {
     title: 'Settings',
     verifyProof: 'Verify Proof',

--- a/packages/editor/src/i18n/translations/ja.ts
+++ b/packages/editor/src/i18n/translations/ja.ts
@@ -23,6 +23,14 @@ export const ja: TranslationKeys = {
     initializing: '初期化中...',
   },
 
+  feature: {
+    casual: '作成',
+    class: '授業',
+    assignment: '課題',
+    exam: '試験',
+    author: '出題',
+  },
+
   settings: {
     title: '設定',
     verifyProof: 'Verify Proof',

--- a/packages/editor/src/i18n/types.ts
+++ b/packages/editor/src/i18n/types.ts
@@ -34,6 +34,15 @@ export interface TranslationKeys {
     initializing: string;
   };
 
+  // 機能バッジ (ぱっと見で機能/モードを判別)
+  feature: {
+    casual: string;
+    class: string;
+    assignment: string;
+    exam: string;
+    author: string;
+  };
+
   // Settings menu
   settings: {
     title: string;

--- a/packages/editor/src/main.ts
+++ b/packages/editor/src/main.ts
@@ -10,6 +10,10 @@ const mode = resolveModeFromPath(window.location.pathname);
 setStorageNamespace(mode);
 const examMode = mode === 'exam';
 
+// 機能別アクセント (要望): 作成アプリは data-feature=editor、色はモードで切替 (data-mode)。
+document.documentElement.setAttribute('data-feature', 'editor');
+document.documentElement.setAttribute('data-mode', mode);
+
 // 全消去リクエスト (?reset): 全モードのデータを消す手動ユーティリティ (sticky 解除用ではない)。
 if (urlParams.get('reset')) {
   console.log('[TypedCode] Reset parameter detected, clearing all data...');
@@ -144,6 +148,17 @@ import type { WelcomeScreen } from './ui/components/WelcomeScreen.js';
 
 // i18n初期化（DOM翻訳を適用）
 initDOMi18n();
+
+// 機能バッジ (ぱっと見で機能/モードを判別): titlebar にモード名のピルを挿入。
+{
+  const icon: Record<string, string> = {
+    casual: 'fa-pen', class: 'fa-chalkboard-user', assignment: 'fa-house-laptop', exam: 'fa-lock',
+  };
+  const badge = document.createElement('span');
+  badge.className = 'feature-badge';
+  badge.innerHTML = `<i class="fas ${icon[mode] ?? 'fa-pen'}"></i> ${t(`feature.${mode}`)}`;
+  document.querySelector('.titlebar-left')?.appendChild(badge);
+}
 
 // Monaco Editor の Worker 設定
 configureMonacoWorkers();

--- a/packages/editor/src/styles/author.css
+++ b/packages/editor/src/styles/author.css
@@ -5,6 +5,31 @@
 
 * { box-sizing: border-box; }
 
+/* 機能別アクセント (要望: ぱっと見で機能を判別)。出題アプリ = 紫 (--feature-accent)。 */
+body::before {
+  content: '';
+  position: fixed;
+  top: 0; left: 0; right: 0; height: 3px;
+  background: var(--feature-accent);
+  z-index: 10000;
+  pointer-events: none;
+}
+.feature-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 9px;
+  border-radius: 999px;
+  background: var(--feature-accent);
+  color: var(--feature-accent-fg);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  user-select: none;
+}
+.feature-badge i { font-size: 10px; }
+
 body {
   margin: 0;
   background: var(--bg-primary);
@@ -144,7 +169,7 @@ html, body { height: 100%; }
   flex-shrink: 0;
 }
 .author-toolbar-brand { font-weight: 600; white-space: nowrap; margin-right: var(--spacing-sm); }
-.author-toolbar-brand i { color: var(--accent-info); }
+.author-toolbar-brand i { color: var(--feature-accent); }
 .author-toolbar-input { width: 220px; }
 .author-toolbar-narrow { width: 120px; }
 .author-toolbar-spacer { flex: 1; }
@@ -250,11 +275,11 @@ html, body { height: 100%; }
 .author-btn:hover:not(:disabled) { background: var(--bg-hover); }
 .author-btn:disabled { opacity: 0.6; cursor: default; }
 .author-btn-primary {
-  background: var(--accent-primary);
-  border-color: var(--accent-primary);
-  color: #fff;
+  background: var(--feature-accent);
+  border-color: var(--feature-accent);
+  color: var(--feature-accent-fg);
 }
-.author-btn-primary:hover:not(:disabled) { background: var(--accent-secondary); }
+.author-btn-primary:hover:not(:disabled) { filter: brightness(1.12); }
 .author-btn-build { width: 100%; justify-content: center; padding: 12px; font-size: 15px; font-weight: 600; }
 
 .author-btn-row { display: flex; gap: var(--spacing-sm); align-items: center; }

--- a/packages/editor/src/styles/components/_feature-accent.css
+++ b/packages/editor/src/styles/components/_feature-accent.css
@@ -1,0 +1,37 @@
+/* 機能別アクセント — 上端ストリップ + 機能バッジ (要望: ぱっと見で機能を判別)。
+   色は --feature-accent (variables/_colors.css、data-feature/data-mode で切替)。 */
+
+/* 全機能共通: 画面上端の細いアクセントストリップ (レイアウトを崩さない overlay)。 */
+body::before {
+  content: '';
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: var(--feature-accent);
+  z-index: 10000;
+  pointer-events: none;
+}
+
+/* 機能バッジ (機能/モード名のピル)。各アプリのヘッダに JS で挿入する。 */
+.feature-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 9px;
+  border-radius: 999px;
+  background: var(--feature-accent);
+  color: var(--feature-accent-fg);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1.6;
+  white-space: nowrap;
+  user-select: none;
+}
+.feature-badge i { font-size: 10px; }
+
+/* editor: titlebar 下端をアクセントに、statusbar 全体をアクセント色に。 */
+.titlebar { border-bottom: 1px solid var(--feature-accent); }
+.statusbar { background: var(--feature-accent); }

--- a/packages/editor/src/styles/main.css
+++ b/packages/editor/src/styles/main.css
@@ -27,6 +27,7 @@
 @import './components/_modals.css';
 @import './components/_notifications.css';
 @import './components/_welcome.css';
+@import './components/_feature-accent.css';
 
 /* Utilities */
 @import './utilities/_responsive.css';

--- a/packages/editor/src/styles/variables/_colors.css
+++ b/packages/editor/src/styles/variables/_colors.css
@@ -14,7 +14,18 @@
   --radius-md: 6px;
   --radius-lg: 8px;
   --radius-xl: 12px;
+
+  /* 機能別アクセント — ぱっと見で機能/モードを判別する (要望)。
+     既定 = 作成(editor/casual) の青。editor のモードは data-mode が、
+     verify/author は data-feature が <html> 上で上書きする。 */
+  --feature-accent: #0078d4;       /* 作成 (casual) = 青 */
+  --feature-accent-fg: #ffffff;
 }
+:root[data-mode="class"]      { --feature-accent: #1f9d9d; } /* 授業 = ティール */
+:root[data-mode="assignment"] { --feature-accent: #bf8700; } /* 課題 = アンバー */
+:root[data-mode="exam"]       { --feature-accent: #cf222e; } /* 試験 = 赤 */
+:root[data-feature="verify"]  { --feature-accent: #2ea043; } /* 検証 = 緑 */
+:root[data-feature="author"]  { --feature-accent: #8957e5; } /* 出題 = 紫 */
 
 :root[data-theme="dark"] {
   /* Base colors */

--- a/packages/verify/src/i18n/translations/en.ts
+++ b/packages/verify/src/i18n/translations/en.ts
@@ -16,6 +16,10 @@ export const en: VerifyTranslationKeys = {
     subtitle: 'Verify typing proofs',
   },
 
+  feature: {
+    verify: 'Verify',
+  },
+
   settings: {
     language: 'Language',
     about: 'About',

--- a/packages/verify/src/i18n/translations/ja.ts
+++ b/packages/verify/src/i18n/translations/ja.ts
@@ -16,6 +16,10 @@ export const ja: VerifyTranslationKeys = {
     subtitle: 'タイピング証明を検証',
   },
 
+  feature: {
+    verify: '検証',
+  },
+
   settings: {
     language: '言語',
     about: 'バージョン情報',

--- a/packages/verify/src/i18n/types.ts
+++ b/packages/verify/src/i18n/types.ts
@@ -22,6 +22,11 @@ export interface VerifyTranslationKeys {
     subtitle: string;
   };
 
+  // 機能バッジ (ぱっと見で機能を判別)
+  feature: {
+    verify: string;
+  };
+
   // Settings
   settings: {
     language: string;

--- a/packages/verify/src/main.ts
+++ b/packages/verify/src/main.ts
@@ -3,12 +3,21 @@
  */
 
 import { AppController } from './ui/AppController';
-import { initDOMi18n } from './i18n/index';
+import { initDOMi18n, t } from './i18n/index';
+
+// 機能別アクセント (要望: ぱっと見で機能を判別)。検証アプリ = 緑。
+document.documentElement.setAttribute('data-feature', 'verify');
 
 // Initialize the application when DOM is ready
 document.addEventListener('DOMContentLoaded', () => {
   // Initialize i18n first
   initDOMi18n();
+
+  // 機能バッジを sidebar-header に挿入。
+  const badge = document.createElement('span');
+  badge.className = 'feature-badge';
+  badge.innerHTML = `<i class="fas fa-circle-check"></i> ${t('feature.verify')}`;
+  document.querySelector('.sidebar-header')?.prepend(badge);
 
   new AppController();
 });

--- a/packages/verify/src/styles/components/_feature-accent.css
+++ b/packages/verify/src/styles/components/_feature-accent.css
@@ -1,0 +1,34 @@
+/* 機能別アクセント — 上端ストリップ + 機能バッジ (要望: ぱっと見で機能を判別)。
+   検証アプリ = 緑 (--feature-accent, variables/_colors.css)。 */
+
+body::before {
+  content: '';
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: var(--feature-accent);
+  z-index: 10000;
+  pointer-events: none;
+}
+
+.feature-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 9px;
+  border-radius: 999px;
+  background: var(--feature-accent);
+  color: var(--feature-accent-fg);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1.6;
+  white-space: nowrap;
+  user-select: none;
+}
+.feature-badge i { font-size: 10px; }
+
+/* verify: statusbar を機能色 (緑) に揃える (editor の statusbar=機能色パターンと一致)。 */
+.statusbar { background: var(--feature-accent); }

--- a/packages/verify/src/styles/main.css
+++ b/packages/verify/src/styles/main.css
@@ -18,6 +18,7 @@
 /* Components */
 @import './components/_tabs.css';
 @import './components/_statusbar.css';
+@import './components/_feature-accent.css';
 @import './components/_welcome.css';
 @import './components/_result-panel.css';
 @import './components/_charts.css';

--- a/packages/verify/src/styles/variables/_colors.css
+++ b/packages/verify/src/styles/variables/_colors.css
@@ -14,6 +14,10 @@
   --radius-md: 6px;
   --radius-lg: 8px;
   --radius-xl: 12px;
+
+  /* 機能別アクセント (要望: ぱっと見で機能を判別)。検証アプリ = 緑。 */
+  --feature-accent: #2ea043;
+  --feature-accent-fg: #ffffff;
 }
 
 :root[data-theme="dark"] {


### PR DESCRIPTION
## 概要

要望「各機能ごとに色を分けて、ぱっと見でわかるように」「UI テイストを揃える」に対応。`--feature-accent` 変数を `<html>` の `data-feature` / `data-mode` で切替え、**全アプリ共通の「上端アクセントストリップ＋機能バッジ」**＋主要クロムに適用する。

## 配色

| 機能 | 色 | バッジ |
|---|---|---|
| 作成 (editor / casual) | 青 `#0078d4` | 作成 |
| 授業 (class) | ティール `#1f9d9d` | 授業 |
| 課題 (assignment) | アンバー `#bf8700` | 課題 |
| 試験 (exam) | 赤 `#cf222e` | 試験 |
| 検証 (verify) | 緑 `#2ea043` | 検証 |
| 出題 (author) | 紫 `#8957e5` | 出題 |

editor はモード（`data-mode`）で色が変わり、verify/author は `data-feature` 固定。

## 仕組み

- **共通**: `body::before` の 3px アクセントストリップ（レイアウト非破壊の overlay）＋ `.feature-badge`（機能/モード名のピル）をヘッダに挿入。
- **editor**: `variables/_colors.css` に `--feature-accent` + `data-mode`/`data-feature` マップ。`main.ts` が属性設定＋titlebar にバッジ。statusbar 全体＋titlebar 下端を機能色に。
- **verify**: `--feature-accent`=緑。`main.ts` が `data-feature=verify`＋sidebar-header にバッジ。statusbar を緑に。
- **author**: editor の色トークンを共有、`data-feature=author` で紫。toolbar にバッジ、主要ボタン/ブランドを機能色に。
- i18n に `feature.*` キーを追加（editor/verify）。

## 検証

- editor/verify `tsc --noEmit`・build green、editor authoring **38 tests** pass
- **ブラウザ実機（Playwright）**: `/` 青「作成」/ `/exam` 赤「試験」/ `/author` 紫「出題」/ verify 緑「検証」を確認（ストリップ・バッジ・statusbar が機能色）

## 補足（follow-up 候補）

- 3アプリのクロム構造は異なる（editor=titlebar+statusbar / verify=sidebar / author=toolbar）。本 PR は**色アイデンティティの統一**が主眼で、レイアウト構造の完全統一（メニュー/フッターの構造的な一致）はより大きな別 PR 向け。

🤖 Generated with [Claude Code](https://claude.com/claude-code)