### PR TITLE
docs(adr-0012): Accepted 化 (実装完了)

### DIFF
--- a/docs/adr/0012-sealed-starter-template-in-exam-payload.md
+++ b/docs/adr/0012-sealed-starter-template-in-exam-payload.md
@@ -1,9 +1,9 @@
 # ADR-0012: 封印問題の平文を構造化し、N問バンドル＋問題ごとのスターターコードを同梱する
 
-- **Status**: Proposed
-- **Date**: 2026-06-08
+- **Status**: Accepted (実装済み・develop マージ済み)
+- **Date**: 2026-06-08 (Accepted: 2026-06-09)
 - **Deciders**: (PR 上の合意者 / レビュアー)
-- **PR / Commit**: #89 (ADR) / 後続実装 PR
+- **PR / Commit**: #89 (ADR) / #90 (Phase1+2a: shared codec + grader v2) / #91 (Phase2b: editor N タブ解錠) / #92 (Phase3: /author N問オーサリング)。追加で #95 にて editor クロム統一・Markdown プレビュー(受験表示と統一)・スターターコードの C 実行。すべて develop マージ済み。
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,7 +42,7 @@
 | [0009](0009-pluggable-analysis-layer.md) | Accepted | 改ざん検証と直交する pluggable な分析層フレームワークを定義する |
 | [0010](0010-exam-session-model.md) | Accepted (sticky 部分は ADR-0011 で置換) | 試験モードのセッション構造 (1問1タブ・固定・リロード復帰可能) |
 | [0011](0011-course-modes-and-path-routing.md) | Accepted | 授業・課題・試験を1ドメインのパスで分岐し能力プリセットでモデル化する |
-| [0012](0012-sealed-starter-template-in-exam-payload.md) | Proposed | 封印問題の平文を構造化し N問バンドル＋問題ごとのスターターコードを同梱する |
+| [0012](0012-sealed-starter-template-in-exam-payload.md) | Accepted | 封印問題の平文を構造化し N問バンドル＋問題ごとのスターターコードを同梱する |
 | [0013](0013-exam-schedule-advisory-keep-manifest-format.md) | Accepted | 試験スケジュールを advisory とし manifest フォーマットは据え置く |
 
 ## 参考


### PR DESCRIPTION
ADR-0012（N問バンドル＋問題ごとスターターコード）を **Proposed → Accepted** に更新。

理由: Phase 1–3（#90/#91/#92）に加え #95 で editor クロム統一・Markdown プレビュー（受験表示と統一）・スターターコードの C 実行を実装し、**すべて develop マージ済み**。README 索引も連動。

ドキュメントのみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)