### PR TITLE
Phase 8 W1: 分析層 (ADR-0009) を verify Web/CLI に配線し evidence をシークバーへ接続

### DIFF
--- a/packages/verify-cli/CLAUDE.md
+++ b/packages/verify-cli/CLAUDE.md
@@ -53,3 +53,10 @@ src/
 
 - `--require-root-anchor` (任意・boolean): root がサーバアンカーされていない (`sessionStartToken` 無し = オフライン劣化 / 旧 proof) proof を **exit 1** にする (採点向け opt-in)。既定は warning のみで `Root anchor: unanchored` を出す。**exam proof は対象外** (独自の T0 束縛を持つ)
 - 判定は shared の `verifyProofFile` (`requireRootAnchor`) に委譲。CLI はフラグを通すだけ。proof は `PROOF_FORMAT_VERSION` 1.2.0 (`MIN_SUPPORTED` 1.0.0 据置) なので **旧 proof もそのまま検証**でき、`rootAnchored:false` で受理 (後方互換)
+
+## 分析層の出力 (ADR-0009)
+
+- 検証 (`--- Checks ---`) と**直交する advisory** を `--- Analysis (advisory) ---` セクションに出す。判定ではない (**exit code には一切影響させない** — ここを破ると ADR-0009 の直交性が壊れる)
+- 各 signal は severity (`INFO`/`NOTICE`/`REVIEW`) + summary + **evidence (event index)** を出す。evidence は人間が当該イベントを検分するためのリンクで ADR-0009 上必須
+- `--analysis-json <out.json>` (任意): 全 proof 分の `{filename, valid, analysis}` を JSON でファイル出力する。分析器の評価ハーネス / コホート集計の機械可読な入口 (Phase 8 W5)。advisory のみで exit code 非干渉
+- 分析ロジックは shared の `runAnalysis` に委譲。CLI 側に分析器を書かない

--- a/packages/verify-cli/src/cli.ts
+++ b/packages/verify-cli/src/cli.ts
@@ -5,7 +5,7 @@
  * Usage: typedcode-verify <file.json|file.zip> [--mode <m>] [--exam-package <f>] [--submitted-at <ISO>]
  */
 
-import { readFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 import { resolve, extname } from 'node:path';
 import { verifyProof, type ProofFile } from './verify.js';
 import { extractAllProofs } from './zip.js';
@@ -18,7 +18,7 @@ import {
 } from '@typedcode/shared';
 
 /** value を取る flag。`--name value` と `--name=value` の両方を許す。 */
-const VALUE_FLAGS = new Set(['--mode', '--exam-package', '--submitted-at']);
+const VALUE_FLAGS = new Set(['--mode', '--exam-package', '--submitted-at', '--analysis-json']);
 
 function flagValue(args: string[], name: string): string | undefined {
   const i = args.findIndex((a) => a === name || a.startsWith(`${name}=`));
@@ -71,6 +71,10 @@ async function main(): Promise<void> {
 
   // root アンカー gate (ADR-0017): boolean フラグ。指定すると root 未アンカー proof を fail させる。
   const requireRootAnchor = args.includes('--require-root-anchor');
+
+  // 分析レポートの JSON 出力 (ADR-0009): 評価ハーネス/集計スクリプトの機械可読な入口。
+  // advisory であって判定ではない — exit code には一切影響しない。
+  const analysisJsonPath = flagValue(args, '--analysis-json');
 
   // 試験モード (ADR-0006): 任意の問題パッケージ + 提出時刻
   const examPackagePath = flagValue(args, '--exam-package');
@@ -127,11 +131,19 @@ async function main(): Promise<void> {
     // 全 proof を検証。1 件でも fail なら exit 1 (CI が部分合格を成功と誤読しないように)。
     const multi = proofs.length > 1;
     const summary: Array<{ filename: string; valid: boolean }> = [];
+    const analysisDump: Array<{ filename: string; valid: boolean; analysis: unknown }> = [];
     for (const { filename, proof } of proofs) {
       if (multi) console.log(`\n=== ${filename} ===`);
       const result = await verifyProof(proof, { mode, examPackageManifest, submittedAtMs, requireAnchorDensity, requireRootAnchor });
       console.log(formatResult(result));
       summary.push({ filename, valid: result.valid });
+      analysisDump.push({ filename, valid: result.valid, analysis: result.analysis });
+    }
+
+    // --analysis-json: AnalysisReport を機械可読でファイルへ (advisory、exit code 非干渉)。
+    if (analysisJsonPath !== undefined) {
+      await writeFile(resolve(analysisJsonPath), JSON.stringify(analysisDump, null, 2), 'utf-8');
+      console.log(`\nAnalysis report written to ${analysisJsonPath}`);
     }
 
     if (multi) {

--- a/packages/verify-cli/src/output.ts
+++ b/packages/verify-cli/src/output.ts
@@ -216,6 +216,14 @@ export function formatResult(result: VerificationOutput): string {
               ? c('yellow', 'NOTICE')
               : c('dim', 'INFO');
         lines.push(`  [${tag}] ${s.dimension}: ${s.summary}`);
+        // 証拠リンク (ADR-0009 で必須): 人間が当該イベントを検分できるよう event index を出す。
+        for (const ev of s.evidence) {
+          const range =
+            ev.toEventIndex !== undefined && ev.toEventIndex !== ev.fromEventIndex
+              ? `events ${ev.fromEventIndex}–${ev.toEventIndex}`
+              : `event ${ev.fromEventIndex}`;
+          lines.push(c('dim', `      evidence: ${range}${ev.note ? ` (${ev.note})` : ''}`));
+        }
       }
     }
   }
@@ -237,6 +245,7 @@ ${c('cyan', 'Usage:')}
   typedcode-verify <file.json|file.zip> [--mode <fast|audit|full>]
                    [--exam-package <file.tcexam>] [--submitted-at <ISO>]
                    [--require-anchor-density] [--require-root-anchor]
+                   [--analysis-json <out.json>]
 
 ${c('cyan', 'Arguments:')}
   file    Path to proof file (.json) or exported archive (.zip)
@@ -259,6 +268,9 @@ ${c('cyan', 'Options:')}
                    Fail (exit 1) when the chain root is not server-anchored (ADR-0017) —
                    i.e. no session start token (offline/degraded or old proof). Off by
                    default (unanchored root is only a warning). exam proofs are exempt.
+  --analysis-json  Write the advisory analysis report (ADR-0009) for every verified
+                   proof to the given file as JSON, for aggregation / evaluation
+                   tooling. Advisory only — never affects the exit code.
 
 ${c('cyan', 'Examples:')}
   typedcode-verify proof.json

--- a/packages/verify/CLAUDE.md
+++ b/packages/verify/CLAUDE.md
@@ -19,7 +19,7 @@
 
 | ディレクトリ | 役割 |
 |---|---|
-| `ui/` | `AppController`, `TabBar`, `ActivityBar`, `StatusBarUI`, `ResultPanel`, `Sidebar`, `TypingPatternCard`, `ChartEventSelector` |
+| `ui/` | `AppController`, `TabBar`, `ActivityBar`, `StatusBarUI`, `ResultPanel`, `Sidebar`, `TypingPatternCard`, `AnalysisReportCard` (ADR-0009 の advisory 表示), `ChartEventSelector` |
 | `ui/controllers/` | `VerificationController`, `TabController`, `FileController`, `FolderController`, `ChartController` |
 | `state/` | `VerificationQueue`, `UIStateManager`, `VerifyTabManager`, `ChartState` |
 | `charts/` | `TimelineChart`, `MouseChart`, `IntegratedChart`, `SeekbarController` (Chart.js) |
@@ -39,7 +39,8 @@ File Selection (drag&drop / FSA API)
      ├─ previousHash 検証
      ├─ ハッシュ再計算
      ├─ PoSW (POSW_ITERATIONS 反復)
-     └─ 署名済み cp の連結検証 (任意)
+     ├─ 署名済み cp の連結検証 (任意)
+     └─ runAnalysis (ADR-0009。advisory のみ・valid に不反映・失敗しても検証結果を落とさない)
   → AttestationService.verify() (Workers API)
   → ResultPanel + charts
 ```
@@ -60,3 +61,10 @@ File Selection (drag&drop / FSA API)
 - **チャートのズーム / パン状態は `ChartPreferencesService` で永続化**: 検証結果のリセット時にクリアするか、ユーザー設定として残すかの線引きに注意
 - **マルチファイル proof の `tabSwitches`**: タブごとの最終ハッシュとつながっている。タブの順序を変えるとチェーンが切れる
 - **試験束縛カード (ADR-0006)**: `proof.exam` がある proof は root 束縛を worker が runtime で検証済み (`verifyInitialHashRoot` の exam 分岐。worker は proofData 全体を受け取る)。完全束縛 (署名/復号/内容) は **`.tcexam` を「問題パッケージを読み込む」で取り込んだとき** `verifyExamBinding` で検証 → `VerificationQueue.reverifyWithManifest` で当該タブのみ再検証。result-card は**折りたたみ式** (`.result-card-content` は既定 `display:none`、ヘッダクリックで展開) なので、ボタンは展開後に現れる
+
+## 分析カード (ADR-0009)
+
+- worker が検証後に shared の `runAnalysis` を実行し `VerificationResultData.analysis` で返す。**advisory であって判定ではない** — `valid` / TrustCalculator / タブ status には一切反映しない (ここを破ると ADR-0009 の直交性が壊れる)
+- 表示は `AnalysisReportCard` (`#card-analysis`)。severity (`info`/`notice`/`review`)・score/confidence・summary に加え **evidence (event index) をボタンで出す**
+- evidence クリックは `document` に `verify:seek-to-event` CustomEvent を dispatch し、`ChartController` が `SeekbarController.seekTo(eventIndex + 1)` で当該イベント適用後の状態へジャンプする (「シグナルを見る → 現場を検分」の 1 クリック化)
+- 分析ロジックは shared に置く。verify 側に分析器を書かない (verify はテスト未整備のため)

--- a/packages/verify/index.html
+++ b/packages/verify/index.html
@@ -590,6 +590,22 @@
                       <!-- Rendered by TypingPatternCard.ts -->
                     </div>
                   </div>
+
+                  <!-- Analysis Layer Card (ADR-0009, advisory) -->
+                  <div class="result-card" id="card-analysis" style="display: none;">
+                    <div class="result-card-header">
+                      <div class="result-card-header-left">
+                        <div class="result-card-icon pending" id="analysis-icon">
+                          <i class="fas fa-magnifying-glass-chart"></i>
+                        </div>
+                        <span class="result-card-title" data-i18n="result.analysis">プロセス分析</span>
+                      </div>
+                      <span class="result-card-badge pending" id="analysis-badge">-</span>
+                    </div>
+                    <div class="result-card-content" id="analysis-content">
+                      <!-- Rendered by AnalysisReportCard.ts -->
+                    </div>
+                  </div>
                 </div>
 
                 <!-- Stats -->

--- a/packages/verify/src/i18n/translations/en.ts
+++ b/packages/verify/src/i18n/translations/en.ts
@@ -89,6 +89,7 @@ export const en: VerifyTranslationKeys = {
     createTime: 'Created',
     exportTime: 'Exported',
     typingPattern: 'Typing Pattern',
+    analysis: 'Process Analysis',
     anchoring: 'Temporal Anchoring',
     anchoringStatus: 'Status',
     anchoringCoverage: 'Coverage',
@@ -271,6 +272,23 @@ export const en: VerifyTranslationKeys = {
 
   trust: {
     screenShareOptOut: 'Recorded without screen sharing',
+  },
+
+  analysis: {
+    advisory: 'Heuristic, advisory information — clues for human review, not a verdict (independent of verification).',
+    noSignals: 'No analysis signals',
+    reviewPriority: 'Review priority',
+    evidence: 'Evidence',
+    score: 'Anomaly',
+    confidence: 'Confidence',
+    analyzers: 'Analyzers',
+    severityInfo: 'INFO',
+    severityNotice: 'NOTICE',
+    severityReview: 'REVIEW',
+    dimensionAutomation: 'Automation detection',
+    dimensionKeystrokeContent: 'Keystroke–content consistency',
+    dimensionTranscriptionTopology: 'Construction shape (transcription/authoring)',
+    dimensionFocusBurst: 'Focus-loss / burst correlation',
   },
 
   pattern: {

--- a/packages/verify/src/i18n/translations/ja.ts
+++ b/packages/verify/src/i18n/translations/ja.ts
@@ -89,6 +89,7 @@ export const ja: VerifyTranslationKeys = {
     createTime: '作成時',
     exportTime: 'エクスポート時',
     typingPattern: 'タイピングパターン',
+    analysis: 'プロセス分析',
     anchoring: '時刻アンカー',
     anchoringStatus: '状態',
     anchoringCoverage: 'カバレッジ',
@@ -271,6 +272,23 @@ export const ja: VerifyTranslationKeys = {
 
   trust: {
     screenShareOptOut: '画面共有なしモードで記録されました',
+  },
+
+  analysis: {
+    advisory: 'ヒューリスティックな参考情報です。判定ではなく、人間によるレビューの手掛かりです (検証結果とは独立)。',
+    noSignals: '分析シグナルなし',
+    reviewPriority: '要確認度',
+    evidence: '証拠',
+    score: '異常度',
+    confidence: '確信度',
+    analyzers: '分析器',
+    severityInfo: '情報',
+    severityNotice: '注意',
+    severityReview: '要確認',
+    dimensionAutomation: '自動化検出',
+    dimensionKeystrokeContent: '打鍵と内容の整合',
+    dimensionTranscriptionTopology: '構築の形 (転写/著述)',
+    dimensionFocusBurst: '離脱とバーストの相関',
   },
 
   pattern: {

--- a/packages/verify/src/i18n/types.ts
+++ b/packages/verify/src/i18n/types.ts
@@ -102,6 +102,7 @@ export interface VerifyTranslationKeys {
     createTime: string;
     exportTime: string;
     typingPattern: string;
+    analysis: string;
     anchoring: string;
     anchoringStatus: string;
     anchoringCoverage: string;
@@ -294,6 +295,24 @@ export interface VerifyTranslationKeys {
   };
 
   // Typing pattern analysis
+  // 分析層 (ADR-0009) — advisory レポートカード
+  analysis: {
+    advisory: string;
+    noSignals: string;
+    reviewPriority: string;
+    evidence: string;
+    score: string;
+    confidence: string;
+    analyzers: string;
+    severityInfo: string;
+    severityNotice: string;
+    severityReview: string;
+    dimensionAutomation: string;
+    dimensionKeystrokeContent: string;
+    dimensionTranscriptionTopology: string;
+    dimensionFocusBurst: string;
+  };
+
   pattern: {
     title: string;
     score: string;

--- a/packages/verify/src/services/ResultDataService.ts
+++ b/packages/verify/src/services/ResultDataService.ts
@@ -151,6 +151,8 @@ export function buildResultData(tabState: VerifyTabState): ResultData | null {
     typingTime,
     typingSpeed,
     typingPatternAnalysis,
+    // 分析層 (ADR-0009): worker が runAnalysis で生成した advisory レポート (判定ではない)。
+    analysis: verificationResult.analysis,
     verificationMode: verificationResult.verificationMode,
     poswMode: verificationResult.poswMode,
     signedCheckpoint:

--- a/packages/verify/src/styles/components/_analysis-card.css
+++ b/packages/verify/src/styles/components/_analysis-card.css
@@ -1,0 +1,118 @@
+/* AnalysisReportCard (ADR-0009) — 分析層の advisory レポート表示 */
+
+.analysis-advisory-note {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 10px;
+  margin-bottom: 10px;
+  border-radius: 6px;
+  background: var(--bg-tertiary, rgba(255, 255, 255, 0.04));
+  color: var(--text-secondary, #9da5b4);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.analysis-advisory-note i {
+  margin-top: 2px;
+}
+
+.analysis-no-signals {
+  color: var(--text-secondary, #9da5b4);
+  font-size: 13px;
+  padding: 4px 2px;
+}
+
+.analysis-signal-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.analysis-signal {
+  padding: 8px 10px;
+  border-radius: 6px;
+  border-left: 3px solid var(--text-secondary, #9da5b4);
+  background: var(--bg-tertiary, rgba(255, 255, 255, 0.03));
+}
+
+.analysis-signal.warning {
+  border-left-color: #fbbf24;
+}
+
+.analysis-signal-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 4px;
+}
+
+.analysis-severity {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: rgba(157, 165, 180, 0.2);
+  color: var(--text-secondary, #9da5b4);
+}
+
+.analysis-severity.warning {
+  background: rgba(251, 191, 36, 0.15);
+  color: #fbbf24;
+}
+
+.analysis-dimension {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.analysis-scores {
+  font-size: 11px;
+  color: var(--text-secondary, #9da5b4);
+  margin-left: auto;
+}
+
+.analysis-summary {
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.analysis-evidence-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+}
+
+.analysis-evidence-label {
+  font-size: 11px;
+  color: var(--text-secondary, #9da5b4);
+}
+
+.analysis-evidence-link {
+  font-size: 11px;
+  font-family: var(--font-mono, monospace);
+  padding: 1px 8px;
+  border-radius: 10px;
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.15));
+  background: transparent;
+  color: var(--accent-color, #4fc1ff);
+  cursor: pointer;
+}
+
+.analysis-evidence-link:hover {
+  background: rgba(79, 193, 255, 0.12);
+}
+
+.analysis-versions {
+  margin-top: 10px;
+  font-size: 10px;
+  color: var(--text-secondary, #9da5b4);
+  opacity: 0.7;
+}

--- a/packages/verify/src/styles/main.css
+++ b/packages/verify/src/styles/main.css
@@ -29,6 +29,7 @@
 @import './components/_verification-progress.css';
 @import './components/_lightbox.css';
 @import './components/_typing-pattern.css';
+@import './components/_analysis-card.css';
 
 /* Utilities */
 @import './utilities/_misc.css';

--- a/packages/verify/src/types.ts
+++ b/packages/verify/src/types.ts
@@ -1,4 +1,4 @@
-import type { ExportedProof, StoredEvent, InputType, DisplayInfo, ScreenshotCaptureType, HumanAttestation, SignedCheckpointsVerificationResult, ExamPackageManifest, ExamBindingVerificationResult } from '@typedcode/shared';
+import type { ExportedProof, StoredEvent, InputType, DisplayInfo, ScreenshotCaptureType, HumanAttestation, SignedCheckpointsVerificationResult, ExamPackageManifest, ExamBindingVerificationResult, AnalysisReport } from '@typedcode/shared';
 
 // Re-export HumanAttestation from shared for backward compatibility
 export type { HumanAttestation } from '@typedcode/shared';
@@ -106,6 +106,8 @@ export interface VerificationResultData {
   signedCheckpointDensity?: SignedCheckpointsVerificationResult['density'];
   signedCheckpointReason?: string;
   signedCheckpointAnchored?: boolean;
+  /** 分析層 (ADR-0009) の advisory レポート。判定ではない (valid とは独立軸)。 */
+  analysis?: AnalysisReport;
   /**
    * 「時刻アンカー」カードの展開ビュー用の追加情報。
    * - 検証に用いた公開鍵の registry エントリ

--- a/packages/verify/src/ui/AnalysisReportCard.ts
+++ b/packages/verify/src/ui/AnalysisReportCard.ts
@@ -1,0 +1,142 @@
+/**
+ * AnalysisReportCard - 分析層 (ADR-0009) の advisory レポートを表示するカード
+ *
+ * 重要: ここに出すのは「判定」ではなく「人間レビューの手掛かり」。
+ * - 暗号検証 (valid/invalid) とは独立軸 — このカードの内容は検証結果に影響しない
+ * - 各 signal の evidence (event index) はクリックでシークバーの当該位置へジャンプし、
+ *   採点者が現場を検分できるようにする (ADR-0009 の証拠リンク必須要件)
+ */
+
+import { escapeHtml, type AnalysisReport, type AnalysisSignal, type AnalysisDimension, type AnalysisSeverity, type EvidenceRef } from '@typedcode/shared';
+import { t } from '../i18n/index.js';
+
+export class AnalysisReportCard {
+  private cardElement: HTMLElement | null = null;
+
+  show(): void {
+    this.cardElement = document.getElementById('card-analysis');
+    if (this.cardElement) {
+      this.cardElement.style.display = '';
+    }
+  }
+
+  hide(): void {
+    this.cardElement = document.getElementById('card-analysis');
+    if (this.cardElement) {
+      this.cardElement.style.display = 'none';
+    }
+  }
+
+  render(report: AnalysisReport): void {
+    this.show();
+    this.cardElement = document.getElementById('card-analysis');
+    if (!this.cardElement) return;
+
+    const icon = this.cardElement.querySelector('#analysis-icon');
+    const badge = this.cardElement.querySelector('#analysis-badge');
+    const content = this.cardElement.querySelector('#analysis-content');
+
+    // advisory なので error クラスは使わない: review/notice あり → warning、無し → success。
+    const notable = report.signals.filter((s) => s.severity !== 'info');
+    const stateClass = notable.length > 0 ? 'warning' : 'success';
+
+    if (icon) {
+      icon.className = `result-card-icon ${stateClass}`;
+    }
+    if (badge) {
+      badge.className = `result-card-badge ${stateClass}`;
+      badge.textContent =
+        notable.length > 0
+          ? `${t('analysis.reviewPriority')} ${(report.reviewPriority * 100).toFixed(0)}%`
+          : t('analysis.noSignals');
+    }
+    if (content) {
+      content.innerHTML = this.renderContent(report);
+      this.setupEventListeners(content);
+    }
+  }
+
+  private renderContent(report: AnalysisReport): string {
+    const signals = report.signals.length
+      ? `<ul class="analysis-signal-list">${report.signals.map((s) => this.renderSignal(s)).join('')}</ul>`
+      : `<div class="analysis-no-signals">${t('analysis.noSignals')}</div>`;
+
+    const versions = Object.entries(report.analyzerVersions)
+      .map(([id, v]) => `${escapeHtml(id)}@${escapeHtml(v)}`)
+      .join(', ');
+
+    return `
+      <div class="analysis-advisory-note">
+        <i class="fas fa-info-circle"></i>
+        <span>${t('analysis.advisory')}</span>
+      </div>
+      ${signals}
+      <div class="analysis-versions">${t('analysis.analyzers')}: ${versions}</div>
+    `;
+  }
+
+  private renderSignal(signal: AnalysisSignal): string {
+    const sevClass = signal.severity === 'info' ? 'info' : 'warning';
+    const evidence = signal.evidence.map((ev) => this.renderEvidence(ev)).join('');
+    return `
+      <li class="analysis-signal ${sevClass}">
+        <div class="analysis-signal-header">
+          <span class="analysis-severity ${sevClass}">${this.severityLabel(signal.severity)}</span>
+          <span class="analysis-dimension">${this.dimensionLabel(signal.dimension)}</span>
+          <span class="analysis-scores">
+            ${t('analysis.score')} ${(signal.score * 100).toFixed(0)} ·
+            ${t('analysis.confidence')} ${(signal.confidence * 100).toFixed(0)}%
+          </span>
+        </div>
+        <div class="analysis-summary">${escapeHtml(signal.summary)}</div>
+        ${evidence ? `<div class="analysis-evidence-row"><span class="analysis-evidence-label">${t('analysis.evidence')}:</span>${evidence}</div>` : ''}
+      </li>
+    `;
+  }
+
+  private renderEvidence(ev: EvidenceRef): string {
+    const label =
+      ev.toEventIndex !== undefined && ev.toEventIndex !== ev.fromEventIndex
+        ? `#${ev.fromEventIndex}–${ev.toEventIndex}`
+        : `#${ev.fromEventIndex}`;
+    const note = ev.note ? ` title="${escapeHtml(ev.note)}"` : '';
+    return `<button type="button" class="analysis-evidence-link" data-event-index="${ev.fromEventIndex}"${note}>${label}</button>`;
+  }
+
+  private setupEventListeners(container: Element): void {
+    for (const button of container.querySelectorAll<HTMLButtonElement>('.analysis-evidence-link')) {
+      button.addEventListener('click', () => {
+        const eventIndex = Number(button.dataset['eventIndex']);
+        if (!Number.isFinite(eventIndex)) return;
+        // ChartController が listen し、シークバーを当該イベントへ移動する。
+        document.dispatchEvent(
+          new CustomEvent('verify:seek-to-event', { detail: { eventIndex } })
+        );
+      });
+    }
+  }
+
+  private severityLabel(severity: AnalysisSeverity): string {
+    switch (severity) {
+      case 'review':
+        return t('analysis.severityReview');
+      case 'notice':
+        return t('analysis.severityNotice');
+      default:
+        return t('analysis.severityInfo');
+    }
+  }
+
+  private dimensionLabel(dimension: AnalysisDimension): string {
+    switch (dimension) {
+      case 'automation':
+        return t('analysis.dimensionAutomation');
+      case 'keystroke-content-consistency':
+        return t('analysis.dimensionKeystrokeContent');
+      case 'transcription-topology':
+        return t('analysis.dimensionTranscriptionTopology');
+      case 'focus-burst-correlation':
+        return t('analysis.dimensionFocusBurst');
+    }
+  }
+}

--- a/packages/verify/src/ui/ResultPanel.ts
+++ b/packages/verify/src/ui/ResultPanel.ts
@@ -18,9 +18,10 @@ import type {
 } from '../types';
 import type { SignedCheckpointsVerificationResult, ExamBindingVerificationResult } from '@typedcode/shared';
 import type { SignedCheckpointReport } from '../types';
-import { escapeHtml, type TypingPatternAnalysis } from '@typedcode/shared';
+import { escapeHtml, type TypingPatternAnalysis, type AnalysisReport } from '@typedcode/shared';
 import { SyntaxHighlighter } from '../services/SyntaxHighlighter.js';
 import { TypingPatternCard } from './TypingPatternCard.js';
+import { AnalysisReportCard } from './AnalysisReportCard.js';
 import { t } from '../i18n/index.js';
 
 export interface ResultData {
@@ -35,6 +36,8 @@ export interface ResultData {
   typingSpeed: string;
   trustResult?: TrustResult;
   typingPatternAnalysis?: TypingPatternAnalysis;
+  /** 分析層 (ADR-0009) の advisory レポート。判定ではない (検証結果とは独立軸)。 */
+  analysis?: AnalysisReport;
   /** 検証モード (Phase 5) */
   verificationMode?: VerificationMode;
   /** PoSW の実行モード (skipped / sampled / full) */
@@ -186,6 +189,7 @@ export class ResultPanel {
 
   // Typing pattern card
   private typingPatternCard: TypingPatternCard;
+  private analysisReportCard: AnalysisReportCard;
 
   // Chart tabs
   private tabIntegrated: HTMLElement;
@@ -322,6 +326,9 @@ export class ResultPanel {
 
     // Typing pattern card
     this.typingPatternCard = new TypingPatternCard();
+
+    // Analysis layer card (ADR-0009)
+    this.analysisReportCard = new AnalysisReportCard();
 
     // Chart tabs
     this.tabIntegrated = document.getElementById('tab-integrated')!;
@@ -648,6 +655,13 @@ export class ResultPanel {
     } else {
       this.statusPattern.style.display = 'none';
       this.typingPatternCard.hide();
+    }
+
+    // Analysis layer (ADR-0009) - advisory のみ。検証の valid とは独立軸。
+    if (data.analysis) {
+      this.analysisReportCard.render(data.analysis);
+    } else {
+      this.analysisReportCard.hide();
     }
 
     // Stats

--- a/packages/verify/src/ui/controllers/ChartController.ts
+++ b/packages/verify/src/ui/controllers/ChartController.ts
@@ -122,6 +122,17 @@ export class ChartController {
       this.seekbarController.setIntegratedChart(this.integratedChart);
     }
 
+    // 分析カード (ADR-0009) の evidence リンクからのジャンプを受ける。
+    // 分析 signal は event index を指す — クリックで当該イベント適用後の状態へシークし、
+    // 採点者が「シグナルを見る → 現場を検分する」を 1 クリックにする。
+    document.addEventListener('verify:seek-to-event', (e) => {
+      const detail = (e as CustomEvent<{ eventIndex: number }>).detail;
+      if (detail && typeof detail.eventIndex === 'number' && this.seekbarController) {
+        // seekTo の index は「適用済みイベント数」(0..N)。event i の結果を見るには i+1。
+        this.seekbarController.seekTo(detail.eventIndex + 1);
+      }
+    });
+
     // ChartEventSelector を初期化
     const selectorButton = document.getElementById('chart-event-selector-btn');
     const selectorDropdown = document.getElementById('chart-event-selector-dropdown');

--- a/packages/verify/src/workers/verificationWorker.ts
+++ b/packages/verify/src/workers/verificationWorker.ts
@@ -7,6 +7,7 @@ import {
   CHECKPOINT_PUBLIC_KEYS,
   TypingProof,
   findCheckpointPublicKey,
+  runAnalysis,
   verifyCheckpoints,
   verifyContentReplay,
   verifyFinalChainHash,
@@ -16,6 +17,7 @@ import {
   verifyExamBinding,
 } from '@typedcode/shared';
 import type {
+  AnalysisReport,
   CheckpointData,
   ExportedProof,
   ExamPackageManifest,
@@ -346,6 +348,30 @@ async function verify(request: VerifyRequest): Promise<void> {
       };
     }
 
+    // 5.7 分析層 (ADR-0009): 検証と直交する post-hoc 分析。advisory であって判定ではない
+    // (valid には一切反映しない)。分析の失敗は検証結果を落とさない。
+    let analysis: AnalysisReport | undefined;
+    try {
+      analysis = await runAnalysis({
+        proof: proofData as unknown as ExportedProof,
+        verification: {
+          valid: metadataValid && chainValid,
+          metadataValid,
+          rootValid,
+          rootAnchored,
+          chainValid,
+          finalHashValid: finalHashVerification.valid,
+          contentValid: contentVerification.valid,
+          checkpointValid: checkpointVerification.valid,
+          isPureTyping,
+          poswSkipped: skipPosw,
+          signedCheckpoints: signedCheckpointResult,
+        },
+      });
+    } catch {
+      analysis = undefined;
+    }
+
     // 6. 結果を送信
     sendResult(id, {
       metadataValid,
@@ -369,6 +395,7 @@ async function verify(request: VerifyRequest): Promise<void> {
       signedCheckpointDensity: signedCheckpointResult.density,
       signedCheckpointReason: signedCheckpointResult.reason,
       signedCheckpointReport,
+      analysis,
       exam: examResult,
     });
   } catch (error) {


### PR DESCRIPTION
## 概要 (stacked)

shared に実装済み・テスト済みだった分析フレームワーク (ADR-0009) が verify Web では未配線 (orchestrator が一度も呼ばれていない) だったのを覚醒させます。

### W1-A: verify-cli の補完
- 各 signal の **evidence (event index)** 表示 (ADR-0009 で必須の証拠リンク)
- `--analysis-json <out.json>`: 全 proof 分の `{filename, valid, analysis}` を機械可読出力。**W5 (分析器の実証) の評価ハーネスの入口**
- ※ CLI の runAnalysis 呼び出し + Analysis セクション自体は Phase 7 で配線済みでした

### W1-B: verify Web
- verificationWorker が検証後に `runAnalysis` 実行 (**advisory のみ・valid 不反映・分析失敗で検証を落とさない**)
- `AnalysisReportCard` 新設: severity / 異常度 / 確信度 / summary / analyzer バージョン
- **evidence クリック → `verify:seek-to-event` CustomEvent → シークバーが当該イベントへジャンプ** (「シグナルを見る→現場を検分」の 1 クリック化)
- i18n ja/en + 専用 CSS

検証の VALID/INVALID と分析の要確認度は独立軸として併記されます (混ぜない = ADR-0009 の直交性)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)