### PR TITLE
Phase 8 W2: 三層保証語彙を実証拠から機械導出し UI/CLI に表示 (ADR-0020)

### DIFF
--- a/docs/adr/0020-three-layer-assurance-vocabulary.md
+++ b/docs/adr/0020-three-layer-assurance-vocabulary.md
@@ -1,0 +1,99 @@
+# ADR-0020: 保証を三層語彙 (整合性 × 時刻アンカー × 著述性) で機械導出し表示する
+
+- **Status**: Accepted
+- **Date**: 2026-06-12
+- **Deciders**: (PR 上の合意者 / レビュアー)
+- **PR / Commit**: (本 ADR と同一 PR)
+
+## Context
+
+TypedCode の proof は強度の異なる複数の保証を束ねているが、検証 UI / CLI はそれを単一の
+PASS/FAIL (+ 信頼バッジ verified/partial/failed) に圧縮して見せている。これは 2 つの誤読を生む:
+
+1. **過剰主張 (overclaim)**: 「検証 PASSED」を見た教員が「AI 不使用のお墨付き」と読む。実際に
+   暗号が保証するのは「記録の完全性と時刻」であって「著述の人間性」ではない (後者は原理的に
+   advisory、ADR-0009)。誤読のまま運用されると、誤検知が学生への冤罪に、検知漏れが制度への
+   過信になる。
+2. **過小主張**: 警告 1 件で `partial` に落ちる現行バッジは、「チェーンは数学的に無傷」という
+   強い事実を弱い表示に巻き込む。
+
+また ADR-0011 §6 は「保証ラベルは自己申告 `mode` でなく**実証拠から機械判定**できるようにする」
+を宿題として残しており、これが未実装だった。
+
+## Considered Options
+
+### Option A: 現行の単一バッジを維持し、説明文で補う
+- Pros: 実装ゼロ。
+- Cons: 圧縮こそが誤読の原因。説明文は読まれない。→ 却下
+
+### Option B: 保証を独立した三層の語彙として導出・表示する ★採用
+- **整合性 (integrity)**: 記録は事後改変されていないか。暗号検証、決定的、二値 (proven/failed)。
+- **時刻アンカー (temporal)**: 記録はいつ存在したか。サーバ署名 (root アンカー ADR-0017 +
+  署名 cp ADR-0002/0016) による決定的判定。anchored / partial / unanchored。試験 proof は
+  T0 束縛 (封印 + 監督コード = proctor) が時刻 regime を担うため独立値 `exam-t0`。
+- **著述性 (provenance)**: 打鍵が転写でなく著述に見えるか。**常に advisory** でレベルを持たない
+  (pureTyping + 分析シグナル数 + 要確認度の事実併記のみ)。ADR-0009 の直交性を表示語彙にまで
+  延長する。
+- Pros: 各層の強度差が一目で伝わる。advisory が verdict に化ける余地を構造的に塞ぐ。
+- Cons: UI が 1 バッジ → 3 バッジに増える。
+
+### Option C: スコアリング (重み付き合成点)
+- Cons: 合成した瞬間に「advisory が判定に混入する」。重みの根拠も示せない。→ 却下
+
+## Decision
+
+Option B を採用。
+
+1. **導出は shared の純関数** `deriveAssurance(AssuranceInput): AssuranceResult`
+   (`packages/shared/src/assurance.ts`)。verify (web) と verify-cli が同一実装を使い、
+   「Web と CLI で保証表示が食い違う」事故を構造的に防ぐ。テストは shared に置く。
+2. **入力は実証拠のみ**: metadataValid / chainValid / スクショ改竄数 / exam 束縛 /
+   rootAnchored / 署名 cp (valid・sparse・postHoc) / isPureTyping / 分析サマリ。
+   **自己申告 `proof.mode` は入力に使わない** (ADR-0011 §6)。mode は「自己申告」と明記の上で
+   参考表示のみ。
+3. **温度差の規律**:
+   - integrity と temporal は決定的入力のみから導出する。
+   - provenance はどんな値でも integrity / temporal に影響しない (テストで固定)。
+   - 本導出は `verifyProofFile` の valid を**置き換えない** (表示語彙であって判定ではない)。
+4. **temporal の導出規則**:
+   - exam present → `exam-t0` (署名 cp は best-effort の補強で regime を変えない)
+   - rootAnchored ∧ 署名 cp が valid・密・post-hoc 疑いなし → `anchored`
+   - rootAnchored ∨ 有効な署名 cp (ただし疎 / post-hoc / 片方のみ) → `partial`
+   - どちらも無し (invalid な cp 連鎖は時刻証拠に数えない) → `unanchored`
+5. **表示**: verify (web) は結果画面最上部に三層バッジ (+ mode の参考表示)、verify-cli は
+   ヘッダ直下に `--- Assurance ---` 1 行サマリ。既存の TrustCalculator (issue リスト) と
+   タブ status は詳細パネルとして併存する (issue の母集団は変えない)。
+6. **文言の是正**: README / system-spec の「人間がキー打鍵で順番に入力した」级の表現を、
+   本語彙に整合する精密な主張 (「このエディタ内で・この時間窓に・この編集列で構築され、
+   事後改変されていない」+ 著述性は参考情報) に改める。
+
+## Consequences
+
+### Positive
+
+- 採点者が「何がどの強さで保証されているか」を 1 画面で誤読なく読める。overclaim の構造的抑止。
+- ADR-0011 §6 (実証拠からの保証導出) を消化。低保証 proof が表示上「上に化ける」余地がない。
+- Web / CLI の保証表示が単一実装に揃う。
+- ADR-0009 の「advisory を判定にしない」が表示レイヤまで貫通する。
+
+### Negative / Trade-offs
+
+- バッジが増え UI が賑やかになる (3 つに限定し、詳細は既存 issue パネルへ委譲して緩和)。
+- temporal の `partial` は複数要因 (疎 / post-hoc / 片側のみ) を 1 語に畳む。詳細は
+  既存の Anchoring カードが補う。
+- 既存の TrustCalculator と二重構造になる (役割分担: 三層 = 最上部の語彙、TrustCalculator =
+  個別 issue の列挙。将来 TrustCalculator の level を三層から導出する統合は別途検討)。
+
+### Follow-ups / 残課題
+
+- ProcessSummary (Phase 8 W3) と並ぶ「最上部 1 画面」の情報設計の調整。
+- TrustCalculator level と三層語彙の統合 (重複の解消) — 実運用の様子を見て。
+- エクスポート README (提出 ZIP 同梱) にも三層の説明を載せるか — 別途。
+
+## References
+
+- [ADR-0009](0009-pluggable-analysis-layer.md) — 分析は advisory・判定しない (本 ADR はその表示への延長)
+- [ADR-0011](0011-course-modes-and-path-routing.md) — §6 保証ラベルの機械判定 (本 ADR が消化)
+- [ADR-0016](0016-anchoring-density-signal.md) / [ADR-0017](0017-server-anchored-chain-root.md) — temporal 層の入力
+- [ADR-0006](0006-exam-mode-sealed-problem-binding.md) — exam の T0 regime
+- `packages/shared/src/assurance.ts` — 導出の実装 (単一ソース)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -50,6 +50,7 @@
 | [0017](0017-server-anchored-chain-root.md) | Accepted | セッション開始 ECDSA トークンで casual/class の root をサーバアンカーする (format 1.2.0) |
 | [0018](0018-istrusted-capture.md) | Accepted | 合成打鍵を `isTrusted` で捕捉し advisory シグナル化する (keystroke data に hashed・加算的) |
 | [0019](0019-editor-assist-declaration.md) | Accepted | エディタ支援機能 (補完等) の実効状態を `environmentProbe` に宣言として焼く (記録のみ・ポリシーは別 ADR) |
+| [0020](0020-three-layer-assurance-vocabulary.md) | Accepted | 保証を三層語彙 (整合性 × 時刻アンカー × 著述性[advisory]) で実証拠から機械導出し表示する |
 
 ## 参考
 

--- a/docs/system-spec.md
+++ b/docs/system-spec.md
@@ -8,7 +8,13 @@
 
 ## 1. システム目的
 
-TypedCode は、ブラウザ上のコードエディタにおける編集操作 (キーストローク、貼り付け、選択、削除など) を **逐次** ハッシュチェーンに記録し、その記録を後から **暗号学的に検証可能** にすることを目的とする。最終的に「このソースコードは copy/paste ではなく、人間がキー打鍵で順番に入力した」という主張を、外部の検証者が再現可能な手順で確認できる。
+TypedCode は、ブラウザ上のコードエディタにおける編集操作 (キーストローク、貼り付け、選択、削除など) を **逐次** ハッシュチェーンに記録し、その記録を後から **暗号学的に検証可能** にすることを目的とする。外部の検証者が再現可能な手順で確認できる主張は、強度の異なる**三層** (ADR-0020) に分かれる:
+
+- **整合性 (決定的)**: この編集列はこのエディタ内でこの順序で記録され、エクスポート後 1 bit も改変されていない
+- **時刻アンカー (決定的)**: 記録はサーバ署名された時間窓の中に存在した (試験は T0 束縛が regime を担う)
+- **著述性 (advisory)**: 打鍵列が転写でなく著述に見えるか — **確率的な参考情報であり「人間が書いた」ことの証明ではない** (分析層 = ADR-0009 と読み手の判断に委ねる)
+
+「人間がキー打鍵で順番に入力した」という素朴な一文は上記三層の合成であり、検証 UI / CLI はこれを 1 つの PASS/FAIL に圧縮せず三層で併記する (overclaim の構造的抑止)。
 
 ### 想定ユースケース
 - 学習目的: タイピング演習・コーディング試験
@@ -733,3 +739,5 @@ typedcode-verify my-code.zip --mode audit    # 将来用 (現状 full と同等)
 | 2026-06-12 | root サーバアンカー (ADR-0017, Phase 7-A) | **`PROOF_FORMAT_VERSION` 1.1.0→1.2.0** (MIN_SUPPORTED 1.0.0 据置・後方互換)。session/start (Turnstile→ECDSA トークン) で casual/class の root を `SHA256(fp ‖ localNonce ‖ serverNonce)` にサーバアンカーし、完全オフライン捏造を封じる。proof に `sessionStartToken` + `rootAnchored` を加算。検証器は registry-only でトークン検証→serverNonce 込み root 再計算→token↔cp sessionId 突合。フォールバック (b): 不達なら `rootAnchored:false` で継続 (warning)。`requireRootAnchor` で strict-fail (exam 除外)。HMAC attestation の作成経路を session/start に統合。§4/§6.2/§6.3/§10 を反映 |
 | 2026-06-12 | isTrusted 捕捉 (ADR-0018, Phase 7-C) | keyDown/keyUp の `KeystrokeDynamicsData.isTrusted` に**合成打鍵 (`!e.isTrusted`) のときだけ** `false` を載せる (keystroke data 経由で hash 済・**加算的**・honest 打鍵はバイト一致で hash 不変)。`automationAnalyzer` が untrusted 打鍵数を数えて advisory signal。**限界**: CDP/ハード注入は isTrusted=true で捕捉不可 (部分的)。§10 を反映 |
 | 2026-06-12 | editor-assist 宣言 (ADR-0019, Phase 8-W0) | `environmentProbe` に **`editorAssist` 宣言** (`editor-assist/1`) を加算的に追加。Monaco の**解決済み**支援オプション (quickSuggestions / inlineSuggest / snippet / 括弧自動閉じ 等 13 項目) を起動時に正規化して焼き、「どの支援が有効な環境での記録か」をセッション間で比較可能にする。記録のみでポリシー判断はしない (別 ADR)。取得不可は null (graceful absence)。proof フォーマット非破壊・新イベント型なし。§4.1 を反映 |
+| 2026-06-12 | 分析層の配線 (ADR-0009, Phase 8-W1) | shared の分析フレームワーク (`runAnalysis`) を **verify(web) と verify-cli の両方に配線**。verify は verificationWorker が検証後に実行し `AnalysisReportCard` で表示、**evidence (event index) クリックでシークバーの当該イベントへジャンプ**。CLI は evidence 表示 + `--analysis-json` (評価ハーネスの機械可読入口) を追加。すべて advisory で valid / exit code には不反映 (直交性維持)。proof フォーマット不変 |
+| 2026-06-12 | 三層保証語彙 (ADR-0020, Phase 8-W2) | 保証を **整合性 (proven/failed) × 時刻アンカー (anchored/partial/unanchored/exam-t0) × 著述性 (常に advisory)** の三層として shared `deriveAssurance` で**実証拠のみから機械導出** (自己申告 `mode` 不使用 = ADR-0011 §6 消化)。verify は結果最上部にバッジ列 (+ mode 参考表示)、CLI は `--- Assurance ---` を出力。§1 の主張文言を三層に精密化 (overclaim 是正)。判定 (`verifyProofFile` の valid) は不変・proof フォーマット不変 |

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -38,6 +38,7 @@
 | `attestation.ts` | 人間認証クライアント |
 | `fileProcessing/` | ZIP / JSON 解析 |
 | `types.ts` (実体は `types/`) | 全公開型 |
+| `assurance.ts` | 三層保証語彙 (ADR-0020)。`deriveAssurance` が実証拠のみから整合性/時刻アンカー/著述性(advisory) を導出。verify(web)/verify-cli が同一実装を使う (表示の食い違い防止)。**自己申告 `proof.mode` を入力に使わない・provenance を判定に昇格させない** |
 | `analysis/` | 分析層フレームワーク (ADR-0009)。`runAnalysis` + 差し替え可能な `Analyzer` 群 (automation / transcription-topology / focus-burst の第一次ヒューリスティック + pureTyping)。検証と**直交**する advisory のみ・判定しない。`automationAnalyzer` は webdriver/headless GPU に加え **合成打鍵 (`KeystrokeDynamicsData.isTrusted===false`, ADR-0018)** も数える |
 | `exam/` | 試験モードの暗号コア (ADR-0006)。封印 `.tcexam` の build/verify(署名)/decrypt(Argon2id+AES-256-GCM)、`computeExamChainRoot`、`parseExamPackageManifest`、grader 用 `verifyExamBinding`。root 式は `proof.exam` 有無で分岐。N問バンドル codec は `examBundle.ts` (`tcexam-exam/1`)。**授業モードの平文配布 `classPackage.ts` (ADR-0014, `tcclass/1`) も同居** — 暗号を持たず `parseExamBundle` を平文で再利用する `parseClassPackage`/`encodeClassPackage` |
 | `examAuthorityKeys/` | 出題者 (問題署名) 公開鍵レジストリ (ADR-0006)。`checkpointKeys/` と**別系統・同型** (append-only、`registry.ts` 本番 + skip-worktree な `localKeys.ts`) |

--- a/packages/shared/src/__tests__/assurance.test.ts
+++ b/packages/shared/src/__tests__/assurance.test.ts
@@ -1,0 +1,146 @@
+/**
+ * 三層保証語彙 (ADR-0020) の導出テスト。
+ * deriveAssurance は純関数なので実体を直接使う。
+ */
+
+import { describe, expect, it } from 'vitest';
+import { deriveAssurance, summarizeAnalysisForAssurance, type AssuranceInput } from '../assurance.js';
+
+/** 健全な anchored casual proof の入力 (テストごとに上書きして崩す)。 */
+function healthyInput(): AssuranceInput {
+  return {
+    metadataValid: true,
+    chainValid: true,
+    screenshotsTampered: 0,
+    rootAnchored: true,
+    signedCheckpoints: { anchored: true, valid: true, sparse: false, postHocSuspected: false },
+    isPureTyping: true,
+    analysis: { reviewPriority: 0, notableSignals: 0 },
+  };
+}
+
+describe('deriveAssurance — integrity', () => {
+  it('marks integrity proven when all cryptographic checks pass', () => {
+    expect(deriveAssurance(healthyInput()).integrity).toBe('proven');
+  });
+
+  it('fails integrity when the hash chain is broken', () => {
+    expect(deriveAssurance({ ...healthyInput(), chainValid: false }).integrity).toBe('failed');
+  });
+
+  it('fails integrity when metadata verification fails', () => {
+    expect(deriveAssurance({ ...healthyInput(), metadataValid: false }).integrity).toBe('failed');
+  });
+
+  it('fails integrity when any screenshot is tampered', () => {
+    expect(deriveAssurance({ ...healthyInput(), screenshotsTampered: 1 }).integrity).toBe('failed');
+  });
+
+  it('fails integrity when a provided exam package fails binding verification', () => {
+    const input: AssuranceInput = {
+      ...healthyInput(),
+      exam: { present: true, packageProvided: true, bindingValid: false },
+    };
+    expect(deriveAssurance(input).integrity).toBe('failed');
+  });
+
+  it('keeps integrity proven for an exam proof when no package was provided', () => {
+    const input: AssuranceInput = {
+      ...healthyInput(),
+      exam: { present: true, packageProvided: false },
+    };
+    expect(deriveAssurance(input).integrity).toBe('proven');
+  });
+});
+
+describe('deriveAssurance — temporal', () => {
+  it('reports anchored when root is server-anchored and checkpoints are dense and clean', () => {
+    expect(deriveAssurance(healthyInput()).temporal).toBe('anchored');
+  });
+
+  it('downgrades to partial when anchoring density is sparse', () => {
+    const input = healthyInput();
+    input.signedCheckpoints!.sparse = true;
+    expect(deriveAssurance(input).temporal).toBe('partial');
+  });
+
+  it('downgrades to partial when post-hoc batch signing is suspected', () => {
+    const input = healthyInput();
+    input.signedCheckpoints!.postHocSuspected = true;
+    expect(deriveAssurance(input).temporal).toBe('partial');
+  });
+
+  it('downgrades to partial when the root is anchored but no signed checkpoints exist', () => {
+    const input: AssuranceInput = { ...healthyInput(), signedCheckpoints: undefined };
+    expect(deriveAssurance(input).temporal).toBe('partial');
+  });
+
+  it('downgrades to partial when checkpoints exist but the root is not anchored', () => {
+    expect(deriveAssurance({ ...healthyInput(), rootAnchored: false }).temporal).toBe('partial');
+  });
+
+  it('reports unanchored when no server time evidence exists at all', () => {
+    const input: AssuranceInput = {
+      ...healthyInput(),
+      rootAnchored: false,
+      signedCheckpoints: undefined,
+    };
+    expect(deriveAssurance(input).temporal).toBe('unanchored');
+  });
+
+  it('does not count an invalid checkpoint chain as time evidence', () => {
+    const input: AssuranceInput = {
+      ...healthyInput(),
+      rootAnchored: false,
+      signedCheckpoints: { anchored: true, valid: false },
+    };
+    expect(deriveAssurance(input).temporal).toBe('unanchored');
+  });
+
+  it('uses the exam-t0 regime for exam proofs regardless of checkpoints', () => {
+    const input: AssuranceInput = {
+      ...healthyInput(),
+      rootAnchored: false,
+      signedCheckpoints: undefined,
+      exam: { present: true, packageProvided: true, bindingValid: true },
+    };
+    expect(deriveAssurance(input).temporal).toBe('exam-t0');
+  });
+});
+
+describe('deriveAssurance — provenance (advisory)', () => {
+  it('never elevates provenance into integrity or temporal', () => {
+    const input = healthyInput();
+    input.isPureTyping = false;
+    input.analysis = { reviewPriority: 1, notableSignals: 5 };
+    const result = deriveAssurance(input);
+    expect(result.integrity).toBe('proven');
+    expect(result.temporal).toBe('anchored');
+  });
+
+  it('reports null analysis fields when no analysis was run', () => {
+    const input: AssuranceInput = { ...healthyInput(), analysis: undefined };
+    const result = deriveAssurance(input);
+    expect(result.provenance.notableSignals).toBeNull();
+    expect(result.provenance.reviewPriority).toBeNull();
+  });
+
+  it('carries pureTyping through verbatim', () => {
+    expect(deriveAssurance({ ...healthyInput(), isPureTyping: false }).provenance.pureTyping).toBe(false);
+  });
+});
+
+describe('summarizeAnalysisForAssurance', () => {
+  it('counts only signals above info severity as notable', () => {
+    const summary = summarizeAnalysisForAssurance({
+      reviewPriority: 0.4,
+      signals: [
+        { severity: 'info' },
+        { severity: 'notice' },
+        { severity: 'review' },
+      ],
+    });
+    expect(summary.notableSignals).toBe(2);
+    expect(summary.reviewPriority).toBe(0.4);
+  });
+});

--- a/packages/shared/src/assurance.ts
+++ b/packages/shared/src/assurance.ts
@@ -1,0 +1,144 @@
+/**
+ * 三層保証語彙 (ADR-0020)
+ *
+ * proof が読み手 (採点者・検証者) に与える保証を、強度の異なる 3 つの独立した層として
+ * 機械導出する。**自己申告ラベル (proof.mode) は入力に使わず、実証拠のみから導く**
+ * (ADR-0011 §6 の宿題)。
+ *
+ * - 整合性 (integrity):   記録は事後改変されていないか — 暗号検証、決定的
+ * - 時刻アンカー (temporal): 記録はいつ存在したか — サーバ署名 / T0 束縛、決定的
+ * - 著述性 (provenance):  打鍵が転写でなく著述に見えるか — **常に advisory**。
+ *                          レベルを持たず、判定に昇格させてはならない (ADR-0009)
+ *
+ * 重要な不変条件:
+ * - provenance は何があっても integrity / temporal に影響しない (直交)
+ * - 本導出は verifyProofFile の valid を置き換えない (表示語彙の導出であって判定ではない)
+ */
+
+/** 整合性: 暗号検証の結果。二値 (決定的)。 */
+export type IntegrityLevel = 'proven' | 'failed';
+
+/**
+ * 時刻アンカー: 記録の存在時刻がどの程度固定されているか。
+ * - anchored:   root サーバアンカー + 署名 cp が密 (申告セッション全体が時刻固定)
+ * - partial:    何らかのサーバアンカーはあるが弱い (疎 / post-hoc 疑い / root か cp の片方のみ)
+ * - unanchored: サーバ由来の時刻証拠なし (完全オフライン捏造の余地)
+ * - exam-t0:    試験 proof。T0 束縛 (封印 + 監督コード) が時刻の regime を担う (ADR-0006)
+ */
+export type TemporalLevel = 'anchored' | 'partial' | 'unanchored' | 'exam-t0';
+
+/** 著述性: レベルを持たない advisory サマリ。判定に使ってはならない。 */
+export interface ProvenanceAdvisory {
+  /** ペースト/ドロップ等の外部入力が無いか (入力出自、ADR-0005)。 */
+  pureTyping: boolean;
+  /** severity が info を超える分析シグナル数 (ADR-0009)。分析未実行は null。 */
+  notableSignals: number | null;
+  /** 分析の要確認度 0..1 (ADR-0009)。分析未実行は null。 */
+  reviewPriority: number | null;
+}
+
+export interface AssuranceResult {
+  integrity: IntegrityLevel;
+  temporal: TemporalLevel;
+  provenance: ProvenanceAdvisory;
+}
+
+/** 導出に必要な最小の実証拠。UI 固有型に依存しない (verify / verify-cli 両方から使う)。 */
+export interface AssuranceInput {
+  /** メタデータ整合 (typingProofHash / root / metadata 再カウント)。 */
+  metadataValid: boolean;
+  /** ハッシュチェーン整合 (finalHash / content replay / checkpoint 含む複合)。 */
+  chainValid: boolean;
+  /** 改竄が検出されたスクリーンショット数 (検証していない場合は省略)。 */
+  screenshotsTampered?: number;
+  /** 試験 proof の束縛 (ADR-0006)。 */
+  exam?: {
+    present: boolean;
+    packageProvided: boolean;
+    /** package 提供時のみ意味を持つ。 */
+    bindingValid?: boolean;
+  };
+  /** root がサーバアンカーされているか (ADR-0017)。 */
+  rootAnchored: boolean;
+  /** 署名チェックポイント (ADR-0002/0016)。無ければ省略。 */
+  signedCheckpoints?: {
+    anchored: boolean;
+    valid?: boolean;
+    sparse?: boolean;
+    postHocSuspected?: boolean;
+  };
+  /** ピュアタイピング (外部入力なし)。 */
+  isPureTyping: boolean;
+  /** 分析レポートのサマリ (ADR-0009)。分析未実行は省略。 */
+  analysis?: {
+    reviewPriority: number;
+    notableSignals: number;
+  };
+}
+
+/**
+ * 実証拠から三層保証を導出する。
+ */
+export function deriveAssurance(input: AssuranceInput): AssuranceResult {
+  // --- 整合性: 暗号検証はどれか 1 つでも破れたら failed (二値・決定的)。
+  const examBindingFailed =
+    input.exam?.present === true &&
+    input.exam.packageProvided &&
+    input.exam.bindingValid === false;
+  const integrity: IntegrityLevel =
+    input.metadataValid &&
+    input.chainValid &&
+    (input.screenshotsTampered ?? 0) === 0 &&
+    !examBindingFailed
+      ? 'proven'
+      : 'failed';
+
+  // --- 時刻アンカー
+  const temporal = deriveTemporal(input);
+
+  // --- 著述性: 常に advisory。レベル化しない。
+  const provenance: ProvenanceAdvisory = {
+    pureTyping: input.isPureTyping,
+    notableSignals: input.analysis ? input.analysis.notableSignals : null,
+    reviewPriority: input.analysis ? input.analysis.reviewPriority : null,
+  };
+
+  return { integrity, temporal, provenance };
+}
+
+function deriveTemporal(input: AssuranceInput): TemporalLevel {
+  // 試験 proof は T0 束縛 (封印 + 監督コード = proctor) が時刻 regime を担う (ADR-0006)。
+  // 署名 cp は best-effort の補強であり、有無で regime は変わらない。
+  if (input.exam?.present) {
+    return 'exam-t0';
+  }
+
+  const sc = input.signedCheckpoints;
+  // 有効な署名 cp 連鎖があるか (anchored だが invalid は時刻証拠として数えない)
+  const hasValidCheckpoints = sc?.anchored === true && sc.valid !== false;
+  const checkpointsClean =
+    hasValidCheckpoints && sc?.sparse !== true && sc?.postHocSuspected !== true;
+
+  if (input.rootAnchored && checkpointsClean) {
+    return 'anchored';
+  }
+  if (input.rootAnchored || hasValidCheckpoints) {
+    // 片方のみ / 疎 / post-hoc 疑い — 何らかのサーバ時刻証拠はある
+    return 'partial';
+  }
+  return 'unanchored';
+}
+
+/**
+ * AnalysisReport から AssuranceInput.analysis を作るヘルパ。
+ * notableSignals = severity が 'info' を超える signal 数。
+ */
+export function summarizeAnalysisForAssurance(report: {
+  reviewPriority: number;
+  signals: ReadonlyArray<{ severity: 'info' | 'notice' | 'review' }>;
+}): NonNullable<AssuranceInput['analysis']> {
+  return {
+    reviewPriority: report.reviewPriority,
+    notableSignals: report.signals.filter((s) => s.severity !== 'info').length,
+  };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -14,6 +14,16 @@ export { Fingerprint } from './fingerprint.js';
 // デバッグログ制御 (デフォルト off。ホスト側が dev で有効化する)
 export { setSharedDebug, isSharedDebugEnabled } from './utils/debug.js';
 
+// 三層保証語彙 (ADR-0020) — 実証拠から integrity / temporal / provenance を機械導出
+export { deriveAssurance, summarizeAnalysisForAssurance } from './assurance.js';
+export type {
+  AssuranceInput,
+  AssuranceResult,
+  IntegrityLevel,
+  TemporalLevel,
+  ProvenanceAdvisory,
+} from './assurance.js';
+
 // 検証ユーティリティ
 export {
   deterministicStringify,

--- a/packages/verify-cli/CLAUDE.md
+++ b/packages/verify-cli/CLAUDE.md
@@ -60,3 +60,8 @@ src/
 - 各 signal は severity (`INFO`/`NOTICE`/`REVIEW`) + summary + **evidence (event index)** を出す。evidence は人間が当該イベントを検分するためのリンクで ADR-0009 上必須
 - `--analysis-json <out.json>` (任意): 全 proof 分の `{filename, valid, analysis}` を JSON でファイル出力する。分析器の評価ハーネス / コホート集計の機械可読な入口 (Phase 8 W5)。advisory のみで exit code 非干渉
 - 分析ロジックは shared の `runAnalysis` に委譲。CLI 側に分析器を書かない
+
+## 三層保証サマリ (ADR-0020)
+
+- ヘッダ直下に `--- Assurance ---` (Integrity / Timeline / Authorship) を出す。導出は shared の `deriveAssurance` に委譲 (CLI 側で再実装しない)
+- Authorship は常に `ADVISORY` 表記 — 判定に見せない (ADR-0009/0020)。exit code にも不干渉

--- a/packages/verify-cli/src/output.ts
+++ b/packages/verify-cli/src/output.ts
@@ -22,6 +22,7 @@ import type {
   VerificationMode,
   SignedCheckpointsVerificationResult,
   AnalysisReport,
+  AssuranceResult,
 } from '@typedcode/shared';
 import type { CLIExamResult } from './verify.js';
 
@@ -45,12 +46,53 @@ export interface VerificationOutput {
   rootAnchored?: boolean;
   /** 分析層 (ADR-0009) の advisory レポート。判定ではない。 */
   analysis?: AnalysisReport;
+  /** 三層保証語彙 (ADR-0020)。 */
+  assurance?: AssuranceResult;
   /** 試験モードの束縛検証 (ADR-0006)。exam proof でないときは undefined。 */
   exam?: CLIExamResult;
 }
 
 function passFail(ok: boolean): string {
   return ok ? c('green', 'PASS') : c('red', 'FAIL');
+}
+
+/**
+ * 三層保証語彙 (ADR-0020) の 1 行サマリ。
+ * 整合性 / 時刻アンカーは決定的、著述性は常に advisory (判定ではない) として併記する。
+ */
+function formatAssurance(a: AssuranceResult): string[] {
+  const integrity =
+    a.integrity === 'proven' ? c('green', 'PROVEN') : c('red', 'FAILED');
+
+  let temporal: string;
+  switch (a.temporal) {
+    case 'anchored':
+      temporal = c('green', 'ANCHORED');
+      break;
+    case 'partial':
+      temporal = c('yellow', 'PARTIAL');
+      break;
+    case 'exam-t0':
+      temporal = c('green', 'EXAM-T0');
+      break;
+    default:
+      temporal = c('yellow', 'UNANCHORED');
+  }
+
+  const parts: string[] = [a.provenance.pureTyping ? 'pure typing' : 'external input present'];
+  if (a.provenance.notableSignals !== null) {
+    parts.push(`${a.provenance.notableSignals} signal(s)`);
+  }
+  if (a.provenance.reviewPriority !== null) {
+    parts.push(`review ${(a.provenance.reviewPriority * 100).toFixed(0)}%`);
+  }
+
+  return [
+    c('cyan', '--- Assurance (ADR-0020) ---'),
+    `Integrity:  ${integrity}  ${c('dim', '(tamper evidence — cryptographic, deterministic)')}`,
+    `Timeline:   ${temporal}  ${c('dim', '(when it existed — server-signed / exam T0)')}`,
+    `Authorship: ${c('yellow', 'ADVISORY')}  ${c('dim', `(${parts.join(', ')} — human judgment required)`)}`,
+  ];
 }
 
 /** 試験モード (ADR-0006) の束縛検証セクションを描画する。 */
@@ -120,6 +162,12 @@ export function formatResult(result: VerificationOutput): string {
     }
   }
   lines.push('');
+
+  // 三層保証語彙 (ADR-0020): PASS/FAIL の直下で「何がどの強さで保証されているか」を先に示す。
+  if (result.assurance) {
+    lines.push(...formatAssurance(result.assurance));
+    lines.push('');
+  }
 
   lines.push(c('cyan', '--- Details ---'));
   if (result.language) {

--- a/packages/verify-cli/src/verify.ts
+++ b/packages/verify-cli/src/verify.ts
@@ -7,12 +7,15 @@ import {
   verifyProofFile,
   runAnalysis,
   verifyExamBinding,
+  deriveAssurance,
+  summarizeAnalysisForAssurance,
   EXAM_AUTHORITY_KEYS,
   type ProofFile,
   type VerificationProgressCallback,
   type VerificationMode,
   type FullVerificationResult,
   type AnalysisReport,
+  type AssuranceResult,
   type ExamPackageManifest,
   type ExamBindingVerificationResult,
 } from '@typedcode/shared';
@@ -56,6 +59,8 @@ export interface CLIVerificationResult {
   rootAnchored: boolean;
   /** 分析層 (ADR-0009) の advisory レポート。判定ではない。 */
   analysis: AnalysisReport;
+  /** 三層保証語彙 (ADR-0020)。実証拠から機械導出した表示用語彙 (valid の置換ではない)。 */
+  assurance: AssuranceResult;
   /** 試験モードの束縛検証 (ADR-0006)。exam proof でないときは undefined。 */
   exam?: CLIExamResult;
 }
@@ -136,6 +141,30 @@ export async function verifyProof(
   // package が渡されたとき、束縛失敗は全体を fail にする (proof 自己整合とは別軸の真正性)。
   const examValid = exam?.binding ? exam.binding.valid : true;
 
+  // 三層保証語彙 (ADR-0020): 実証拠のみから導出 (自己申告 mode は使わない)。
+  const assurance = deriveAssurance({
+    metadataValid: result.metadataValid,
+    chainValid: result.chainValid,
+    exam: exam
+      ? {
+          present: true,
+          packageProvided: exam.packageProvided,
+          bindingValid: exam.binding?.valid,
+        }
+      : undefined,
+    rootAnchored: result.rootAnchored ?? false,
+    signedCheckpoints: result.signedCheckpoints
+      ? {
+          anchored: result.signedCheckpoints.anchored,
+          valid: result.signedCheckpoints.valid,
+          sparse: result.signedCheckpoints.density?.sparse,
+          postHocSuspected: result.signedCheckpoints.temporal?.postHocSuspected,
+        }
+      : undefined,
+    isPureTyping: result.isPureTyping,
+    analysis: summarizeAnalysisForAssurance(analysis),
+  });
+
   return {
     valid: result.valid && examValid,
     metadataValid: result.metadataValid,
@@ -154,6 +183,7 @@ export async function verifyProof(
     signedCheckpoints: result.signedCheckpoints,
     rootAnchored: result.rootAnchored ?? false,
     analysis,
+    assurance,
     exam,
   };
 }

--- a/packages/verify/CLAUDE.md
+++ b/packages/verify/CLAUDE.md
@@ -68,3 +68,10 @@ File Selection (drag&drop / FSA API)
 - 表示は `AnalysisReportCard` (`#card-analysis`)。severity (`info`/`notice`/`review`)・score/confidence・summary に加え **evidence (event index) をボタンで出す**
 - evidence クリックは `document` に `verify:seek-to-event` CustomEvent を dispatch し、`ChartController` が `SeekbarController.seekTo(eventIndex + 1)` で当該イベント適用後の状態へジャンプする (「シグナルを見る → 現場を検分」の 1 クリック化)
 - 分析ロジックは shared に置く。verify 側に分析器を書かない (verify はテスト未整備のため)
+
+## 三層保証バッジ (ADR-0020)
+
+- 結果画面最上部の `#assurance-strip` に **整合性 / 時刻アンカー / 著述性** の 3 チップ (+ 自己申告 mode の参考チップ) を出す。導出は shared の `deriveAssurance` (**verify 側で再実装しない** — CLI と食い違うため)
+- 導出は `TabController.renderResult` で行う (スクショ改竄数を持つのがこの層だけのため)。入力は実証拠のみで **自己申告 `proof.mode` は使わない**
+- **著述性チップは常に advisory**: 判定色 (緑/赤) を使わず破線・中立色。pureTyping + シグナル数の事実併記のみ。ここを判定に見せる変更は ADR-0009/0020 違反
+- 既存の TrustCalculator (issue リスト) とタブ status は詳細表示として併存。三層バッジは語彙、issue は根拠の列挙という役割分担

--- a/packages/verify/index.html
+++ b/packages/verify/index.html
@@ -306,6 +306,10 @@
                       <div class="result-status-filename" id="result-status-filename"></div>
                     </div>
                   </div>
+                  <!-- 三層保証語彙 (ADR-0020): 整合性 × 時刻アンカー × 著述性(advisory) -->
+                  <div class="assurance-strip" id="assurance-strip" style="display: none;">
+                    <!-- Rendered by ResultPanel.renderAssurance -->
+                  </div>
                   <div class="result-status-pattern" id="result-status-pattern" style="display: none;">
                     <div class="pattern-mini-gauge" id="pattern-mini-gauge"></div>
                     <div class="pattern-mini-info">

--- a/packages/verify/src/i18n/translations/en.ts
+++ b/packages/verify/src/i18n/translations/en.ts
@@ -274,6 +274,32 @@ export const en: VerifyTranslationKeys = {
     screenShareOptOut: 'Recorded without screen sharing',
   },
 
+  assurance: {
+    integrity: 'Integrity',
+    temporal: 'Time anchor',
+    provenance: 'Authorship',
+    integrityProven: 'Proven',
+    integrityFailed: 'Failed',
+    temporalAnchored: 'Anchored',
+    temporalPartial: 'Partial',
+    temporalUnanchored: 'Unanchored',
+    temporalExamT0: 'T0-bound (exam)',
+    pureTypingYes: 'Pure typing',
+    pureTypingNo: 'External input present',
+    signals: 'signals',
+    modeLabel: 'Mode',
+    modeSelfAsserted: 'Self-asserted label — never used for assurance derivation',
+    integrityHint: 'Has the record been tampered with — cryptographic verification (deterministic)',
+    temporalHint: 'When did the record exist — server signatures / exam T0 binding (deterministic)',
+    provenanceHint: 'Does the typing look authored — advisory only, not a verdict. Final judgment is human',
+    mode: {
+      casual: 'Practice',
+      class: 'Class',
+      assignment: 'Assignment',
+      exam: 'Exam',
+    },
+  },
+
   analysis: {
     advisory: 'Heuristic, advisory information — clues for human review, not a verdict (independent of verification).',
     noSignals: 'No analysis signals',

--- a/packages/verify/src/i18n/translations/ja.ts
+++ b/packages/verify/src/i18n/translations/ja.ts
@@ -274,6 +274,32 @@ export const ja: VerifyTranslationKeys = {
     screenShareOptOut: '画面共有なしモードで記録されました',
   },
 
+  assurance: {
+    integrity: '整合性',
+    temporal: '時刻アンカー',
+    provenance: '著述性',
+    integrityProven: '証明済み',
+    integrityFailed: '失敗',
+    temporalAnchored: 'アンカー済み',
+    temporalPartial: '部分的',
+    temporalUnanchored: '未アンカー',
+    temporalExamT0: 'T0 束縛 (試験)',
+    pureTypingYes: 'ピュアタイピング',
+    pureTypingNo: '外部入力あり',
+    signals: 'シグナル',
+    modeLabel: 'モード',
+    modeSelfAsserted: '自己申告ラベルです。保証の判定には使われません',
+    integrityHint: '記録が事後改変されていないか — 暗号検証 (決定的)',
+    temporalHint: '記録がいつ存在したか — サーバ署名 / 試験 T0 束縛 (決定的)',
+    provenanceHint: '打鍵が著述に見えるか — 参考情報であり判定ではありません。最終判断は人間が行います',
+    mode: {
+      casual: '練習',
+      class: '授業',
+      assignment: '課題',
+      exam: '試験',
+    },
+  },
+
   analysis: {
     advisory: 'ヒューリスティックな参考情報です。判定ではなく、人間によるレビューの手掛かりです (検証結果とは独立)。',
     noSignals: '分析シグナルなし',

--- a/packages/verify/src/i18n/types.ts
+++ b/packages/verify/src/i18n/types.ts
@@ -295,6 +295,33 @@ export interface VerifyTranslationKeys {
   };
 
   // Typing pattern analysis
+  // 三層保証語彙 (ADR-0020)
+  assurance: {
+    integrity: string;
+    temporal: string;
+    provenance: string;
+    integrityProven: string;
+    integrityFailed: string;
+    temporalAnchored: string;
+    temporalPartial: string;
+    temporalUnanchored: string;
+    temporalExamT0: string;
+    pureTypingYes: string;
+    pureTypingNo: string;
+    signals: string;
+    modeLabel: string;
+    modeSelfAsserted: string;
+    integrityHint: string;
+    temporalHint: string;
+    provenanceHint: string;
+    mode: {
+      casual: string;
+      class: string;
+      assignment: string;
+      exam: string;
+    };
+  };
+
   // 分析層 (ADR-0009) — advisory レポートカード
   analysis: {
     advisory: string;

--- a/packages/verify/src/services/ResultDataService.ts
+++ b/packages/verify/src/services/ResultDataService.ts
@@ -144,6 +144,8 @@ export function buildResultData(tabState: VerifyTabState): ResultData | null {
     filename: tabState.filename,
     content: proofData.content || '',
     language: tabState.language,
+    // 自己申告モードラベル (ADR-0011)。参考表示のみ — 保証導出には使わない (ADR-0020)。
+    mode: proofData.mode,
     result,
     poswStats,
     attestations: attestations.length > 0 ? attestations : undefined,

--- a/packages/verify/src/styles/components/_assurance.css
+++ b/packages/verify/src/styles/components/_assurance.css
@@ -1,0 +1,67 @@
+/* 三層保証語彙 (ADR-0020) — 整合性 × 時刻アンカー × 著述性 (advisory) のバッジ列 */
+
+.assurance-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 8px 12px 10px;
+}
+
+.assurance-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  border-radius: 12px;
+  font-size: 11px;
+  line-height: 1.6;
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.15));
+  cursor: help;
+}
+
+.assurance-chip-label {
+  color: var(--text-secondary, #9da5b4);
+}
+
+.assurance-chip-value {
+  font-weight: 700;
+}
+
+.assurance-chip.success {
+  border-color: rgba(34, 197, 94, 0.5);
+}
+
+.assurance-chip.success .assurance-chip-value {
+  color: #22c55e;
+}
+
+.assurance-chip.warning {
+  border-color: rgba(251, 191, 36, 0.5);
+}
+
+.assurance-chip.warning .assurance-chip-value {
+  color: #fbbf24;
+}
+
+.assurance-chip.error {
+  border-color: rgba(239, 68, 68, 0.5);
+}
+
+.assurance-chip.error .assurance-chip-value {
+  color: #ef4444;
+}
+
+/* 著述性は advisory — 判定色 (緑/赤) を使わず中立に保つ (ADR-0020) */
+.assurance-chip.advisory {
+  border-style: dashed;
+}
+
+.assurance-chip.advisory .assurance-chip-value {
+  color: var(--text-primary, #d4d4d4);
+  font-weight: 500;
+}
+
+.assurance-chip.neutral .assurance-chip-value {
+  color: var(--text-primary, #d4d4d4);
+  font-weight: 500;
+}

--- a/packages/verify/src/styles/main.css
+++ b/packages/verify/src/styles/main.css
@@ -30,6 +30,7 @@
 @import './components/_lightbox.css';
 @import './components/_typing-pattern.css';
 @import './components/_analysis-card.css';
+@import './components/_assurance.css';
 
 /* Utilities */
 @import './utilities/_misc.css';

--- a/packages/verify/src/ui/ResultPanel.ts
+++ b/packages/verify/src/ui/ResultPanel.ts
@@ -18,7 +18,7 @@ import type {
 } from '../types';
 import type { SignedCheckpointsVerificationResult, ExamBindingVerificationResult } from '@typedcode/shared';
 import type { SignedCheckpointReport } from '../types';
-import { escapeHtml, type TypingPatternAnalysis, type AnalysisReport } from '@typedcode/shared';
+import { escapeHtml, type TypingPatternAnalysis, type AnalysisReport, type AssuranceResult } from '@typedcode/shared';
 import { SyntaxHighlighter } from '../services/SyntaxHighlighter.js';
 import { TypingPatternCard } from './TypingPatternCard.js';
 import { AnalysisReportCard } from './AnalysisReportCard.js';
@@ -38,6 +38,10 @@ export interface ResultData {
   typingPatternAnalysis?: TypingPatternAnalysis;
   /** 分析層 (ADR-0009) の advisory レポート。判定ではない (検証結果とは独立軸)。 */
   analysis?: AnalysisReport;
+  /** 三層保証語彙 (ADR-0020)。実証拠から機械導出 (自己申告 mode は不使用)。 */
+  assurance?: AssuranceResult;
+  /** proof の自己申告モード (ADR-0011)。参考表示のみで保証導出には使わない。 */
+  mode?: 'casual' | 'class' | 'assignment' | 'exam';
   /** 検証モード (Phase 5) */
   verificationMode?: VerificationMode;
   /** PoSW の実行モード (skipped / sampled / full) */
@@ -97,6 +101,7 @@ export class ResultPanel {
   private statusTitle: HTMLElement;
   private statusFilename: HTMLElement;
   private statusPattern: HTMLElement;
+  private assuranceStrip: HTMLElement;
   private patternMiniGauge: HTMLElement;
   private patternMiniJudgment: HTMLElement;
 
@@ -231,6 +236,7 @@ export class ResultPanel {
     this.statusTitle = document.getElementById('result-status-title')!;
     this.statusFilename = document.getElementById('result-status-filename')!;
     this.statusPattern = document.getElementById('result-status-pattern')!;
+    this.assuranceStrip = document.getElementById('assurance-strip')!;
     this.patternMiniGauge = document.getElementById('pattern-mini-gauge')!;
     this.patternMiniJudgment = document.getElementById('pattern-mini-judgment')!;
 
@@ -664,6 +670,9 @@ export class ResultPanel {
       this.analysisReportCard.hide();
     }
 
+    // 三層保証語彙 (ADR-0020) - 結果画面最上部に整合性/時刻アンカー/著述性を併記。
+    this.renderAssurance(data.assurance, data.mode);
+
     // Stats
     this.statEvents.textContent = eventCount.toLocaleString();
     this.statTime.textContent = typingTime;
@@ -679,6 +688,75 @@ export class ResultPanel {
     }
 
     this.showContent();
+  }
+
+  /**
+   * 三層保証語彙 (ADR-0020) のバッジ列を描画する。
+   * - 整合性 / 時刻アンカー = 決定的 (実証拠から導出)
+   * - 著述性 = 常に advisory (判定に見えない中立色で出す)
+   * - mode は自己申告ラベルなので「(自己申告)」を明記して参考表示のみ
+   */
+  private renderAssurance(assurance: AssuranceResult | undefined, mode?: ResultData['mode']): void {
+    if (!assurance) {
+      this.assuranceStrip.style.display = 'none';
+      return;
+    }
+    this.assuranceStrip.style.display = '';
+
+    const integrityClass = assurance.integrity === 'proven' ? 'success' : 'error';
+    const integrityValue =
+      assurance.integrity === 'proven' ? t('assurance.integrityProven') : t('assurance.integrityFailed');
+
+    let temporalClass: string;
+    let temporalValue: string;
+    switch (assurance.temporal) {
+      case 'anchored':
+        temporalClass = 'success';
+        temporalValue = t('assurance.temporalAnchored');
+        break;
+      case 'exam-t0':
+        temporalClass = 'success';
+        temporalValue = t('assurance.temporalExamT0');
+        break;
+      case 'partial':
+        temporalClass = 'warning';
+        temporalValue = t('assurance.temporalPartial');
+        break;
+      default:
+        temporalClass = 'warning';
+        temporalValue = t('assurance.temporalUnanchored');
+    }
+
+    const p = assurance.provenance;
+    const provenanceParts: string[] = [
+      p.pureTyping ? t('assurance.pureTypingYes') : t('assurance.pureTypingNo'),
+    ];
+    if (p.notableSignals !== null) {
+      provenanceParts.push(`${t('assurance.signals')} ${p.notableSignals}`);
+    }
+
+    const modeChip = mode
+      ? `<span class="assurance-chip neutral" title="${escapeHtml(t('assurance.modeSelfAsserted'))}">
+           <span class="assurance-chip-label">${t('assurance.modeLabel')}</span>
+           <span class="assurance-chip-value">${t(`assurance.mode.${mode}`)}</span>
+         </span>`
+      : '';
+
+    this.assuranceStrip.innerHTML = `
+      <span class="assurance-chip ${integrityClass}" title="${escapeHtml(t('assurance.integrityHint'))}">
+        <span class="assurance-chip-label">${t('assurance.integrity')}</span>
+        <span class="assurance-chip-value">${integrityValue}</span>
+      </span>
+      <span class="assurance-chip ${temporalClass}" title="${escapeHtml(t('assurance.temporalHint'))}">
+        <span class="assurance-chip-label">${t('assurance.temporal')}</span>
+        <span class="assurance-chip-value">${temporalValue}</span>
+      </span>
+      <span class="assurance-chip advisory" title="${escapeHtml(t('assurance.provenanceHint'))}">
+        <span class="assurance-chip-label">${t('assurance.provenance')}</span>
+        <span class="assurance-chip-value">${provenanceParts.map((x) => escapeHtml(x)).join(' · ')}</span>
+      </span>
+      ${modeChip}
+    `;
   }
 
   private renderCard(

--- a/packages/verify/src/ui/controllers/TabController.ts
+++ b/packages/verify/src/ui/controllers/TabController.ts
@@ -16,6 +16,7 @@ import type { SeekbarController } from '../../charts/SeekbarController';
 import type { VerifyTabState, ProgressDetails, VerifyScreenshot, ScreenshotVerificationSummary, VerificationStepType } from '../../types';
 import { buildResultData, calculateChartStats } from '../../services/ResultDataService';
 import { TrustCalculator } from '../../services/TrustCalculator';
+import { deriveAssurance, summarizeAnalysisForAssurance, type AssuranceResult } from '@typedcode/shared';
 
 export interface TabControllerDependencies {
   tabManager: VerifyTabManager;
@@ -277,8 +278,38 @@ export class TabController {
     const resultData = buildResultData(tabState);
     if (!resultData) return;
 
+    // 三層保証語彙 (ADR-0020): 実証拠のみから導出 (自己申告 mode は使わない)。
+    // スクショ改竄数を持つのはここだけなので導出はこの層で行う。
+    const vr = tabState.verificationResult;
+    const assurance: AssuranceResult | undefined = vr
+      ? deriveAssurance({
+          metadataValid: vr.metadataValid,
+          chainValid: vr.chainValid,
+          screenshotsTampered: screenshotSummary.tampered,
+          exam: vr.exam
+            ? {
+                present: true,
+                packageProvided: vr.exam.packageProvided,
+                bindingValid: vr.exam.binding?.valid,
+              }
+            : undefined,
+          rootAnchored: vr.rootAnchored ?? false,
+          signedCheckpoints:
+            vr.signedCheckpointAnchored !== undefined
+              ? {
+                  anchored: vr.signedCheckpointAnchored,
+                  valid: vr.signedCheckpointValid,
+                  sparse: vr.signedCheckpointDensity?.sparse,
+                  postHocSuspected: vr.signedCheckpointTemporal?.postHocSuspected,
+                }
+              : undefined,
+          isPureTyping: vr.isPureTyping,
+          analysis: vr.analysis ? summarizeAnalysisForAssurance(vr.analysis) : undefined,
+        })
+      : undefined;
+
     // trustResult を追加してレンダリング
-    this.deps.resultPanel.render({ ...resultData, trustResult });
+    this.deps.resultPanel.render({ ...resultData, trustResult, assurance });
 
     // スクリーンショット検証結果を表示
     if (tabState.screenshots && tabState.screenshots.length > 0) {


### PR DESCRIPTION
## 概要 (stacked)

単一の PASS/FAIL + 信頼バッジは「検証 PASSED = AI 不使用のお墨付き」という overclaim 誤読を生みます。保証を強度の異なる独立した三層で併記します:

| 層 | 値 | 性質 |
|---|---|---|
| 整合性 | proven / failed | 暗号検証・決定的 |
| 時刻アンカー | anchored / partial / unanchored / exam-t0 | サーバ署名・決定的 |
| 著述性 | レベルなし (pureTyping + シグナル数の事実のみ) | **常に advisory** |

- 導出は shared の純関数 `deriveAssurance` (テスト 18 件)。Web と CLI が同一実装 = 表示の食い違いが構造的に起きない
- **入力は実証拠のみで自己申告 `proof.mode` は不使用** — ADR-0011 §6 の宿題 (保証ラベルの機械判定) を消化
- verify: 結果最上部に三層チップ + mode 参考チップ (「自己申告」明記・mode 表示はこれが初)。著述性チップは破線・中立色で判定色を使わない
- verify-cli: `--- Assurance ---` (Integrity / Timeline / Authorship=ADVISORY)
- system-spec §1 の「人間がキー打鍵で順番に入力した」を三層に分解して精密化
- 既存 TrustCalculator は併存 (三層=語彙 / issue リスト=根拠列挙。統合は follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)