### PR TITLE
Phase 8 W4-A: 提出前セルフレビューと振り返りノート reflectionNote (ADR-0022)

### DIFF
--- a/docs/adr/0022-pre-export-self-review.md
+++ b/docs/adr/0022-pre-export-self-review.md
@@ -1,0 +1,77 @@
+# ADR-0022: 提出前セルフレビューと振り返りノート (reflectionNote)
+
+- **Status**: Accepted
+- **Date**: 2026-06-12
+- **Deciders**: (PR 上の合意者 / レビュアー)
+- **PR / Commit**: (本 ADR と同一 PR)
+
+## Context
+
+プロセス記録は現状、採点者だけが見る「監視の産物」になっている。process-first 路線
+(Phase 8) の核心は**過程そのものを第一級の提出物にする**ことであり、そのためには:
+
+1. **学生が自分の過程を先に見る** — ツールの性格を監視から「鏡」(自己省察の道具) へ変え、
+   導入の心理的障壁を下げる。提出物に何が含まれるかを本人が提出前に把握する (透明性)。
+2. **本人の声を過程に残す** — 工夫・詰まった点・参照したものの自己申告は採点・指導の
+   一次資料になり、口頭試問の接続点にもなる (述べたことを後から説明できるか)。
+
+## Considered Options
+
+### Option A: ノートを ZIP 内の別ファイル (proof 外) に置く
+- Cons: チェーン外なので後から差し替え可能。「提出時に本人がそう述べた」ことを
+  採点者が信頼できない。→ 却下
+
+### Option B: reflectionNote イベントとしてチェーンに記録する ★採用
+- 新イベント型 `reflectionNote` (data: `{ text }`) を export 直前に記録。
+  チェーンに焼かれるため改ざん検出つきで、最終 checkpoint / 署名 cp にも覆われる。
+- Pros: 「本人が提出時に何を述べたか」が暗号的に固定される。
+- Cons: 新イベント型の追加 (下記の互換性検討)。
+
+## Decision
+
+Option B を採用。
+
+1. **新イベント型 `reflectionNote`** (`ReflectionNoteData { text: string }`)。空文字は
+   記録しない (イベント自体を作らない)。
+2. **互換性**: 検証経路は未知イベント型を拒否しない (確認済み: チェーンハッシュは型非依存・
+   `verifyProofMetadata` の再カウントは inputType 基準・content replay は対象 3 型のみ・
+   `validateEventType` は検証経路で未使用・バージョン上限チェックなし)。よって
+   **`PROOF_FORMAT_VERSION` は 1.2.0 据え置き** (加算的)。
+3. **UI**: export 開始時 (チェーン完了待ちより前) に `SelfReviewDialog` を表示。
+   `ProcessSummary` (W3 と同一の抽出器 = 採点者が見るものと同じ要約) + 任意の
+   ノート欄。**スキップ可・キャンセルで export 中止可**。一括 export では 1 回だけ
+   表示し、ノートはアクティブタブのチェーンへ記録する (タブ毎 N 回は摩擦過多)。
+4. **能力トグル `selfReview`** (ADR-0011 のプリセット): casual/class/assignment = on、
+   **exam = off** (試験の時間圧迫を避ける。フォーマットは共通なので将来出題者判断で
+   有効化可能)。
+5. **表示**: `summarizeProcess` が `reflectionNotes` として抽出し、verify の
+   プロセス要約カードに「本人の振り返り (提出時に記録)」、CLI に `Reflection:` 行。
+   中立表示 (内容の真偽は採点者・口頭試問が判断する自己申告)。
+
+## Consequences
+
+### Positive
+
+- 学生が提出前に「採点者が見るものと同じ要約」を見る — 透明性と自己省察 (メタ認知) の装置。
+- 振り返りが改ざん検出つきの一次資料になり、採点・指導・口頭試問の材料になる。
+- proof フォーマット非破壊・旧 verifier 互換 (検証済み)。
+
+### Negative / Trade-offs
+
+- export に 1 ステップ追加 (スキップ可・exam では出さないことで緩和)。
+- ノートは自己申告であり真正性の保証はない (「提出時にそう述べた」ことだけが保証される)。
+- 旧 verify ビルドはノートを専用表示しない (イベントログには出る。検証は壊れない)。
+
+### Follow-ups / 残課題
+
+- エディタ内ミニ再生 (W4-B): セルフビューに自分のリプレイを足す — 価値検証後。
+- LogViewer の reflectionNote 表示 (表示のみ)。
+- 振り返りプロンプトの教育設計 (何を問うと省察が深まるか) — 運用知見待ち。
+
+## References
+
+- [ADR-0011](0011-course-modes-and-path-routing.md) — 能力プリセット (selfReview トグルの置き場)
+- [ADR-0009](0009-pluggable-analysis-layer.md) / [ADR-0020](0020-three-layer-assurance-vocabulary.md) — 自己申告を判定に使わない既存原則
+- `packages/editor/src/ui/components/SelfReviewDialog.ts` — UI
+- `packages/editor/src/export/ProofExporter.ts` — フック (`performSelfReview`)
+- `packages/shared/src/processSummary.ts` — `reflectionNotes` 抽出

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -52,6 +52,7 @@
 | [0019](0019-editor-assist-declaration.md) | Accepted | エディタ支援機能 (補完等) の実効状態を `environmentProbe` に宣言として焼く (記録のみ・ポリシーは別 ADR) |
 | [0020](0020-three-layer-assurance-vocabulary.md) | Accepted | 保証を三層語彙 (整合性 × 時刻アンカー × 著述性[advisory]) で実証拠から機械導出し表示する |
 | [0021](0021-code-execution-result-capture.md) | Accepted | コード実行の結果 (成功/失敗/exit code) を start/result の 2 イベントで加算的に捕捉する |
+| [0022](0022-pre-export-self-review.md) | Accepted | 提出前セルフレビュー: 自分の過程要約を確認し任意の振り返り `reflectionNote` をチェーンへ記録する (exam は off) |
 
 ## 参考
 

--- a/docs/system-spec.md
+++ b/docs/system-spec.md
@@ -103,7 +103,7 @@ TypedCode は、ブラウザ上のコードエディタにおける編集操作 
 
 ### 4.1. イベント (Event) の収集
 
-エディタ上の操作はすべて「イベント」として記録される。28 種類のイベントタイプがある:
+エディタ上の操作はすべて「イベント」として記録される。29 種類のイベントタイプがある:
 
 **カテゴリ別**:
 - **コンテンツ変更**: `contentChange`, `contentSnapshot`, `externalInput`, `templateInjection`
@@ -114,6 +114,7 @@ TypedCode は、ブラウザ上のコードエディタにおける編集操作 
 - **試験**: `examOpened` (試験モードで封印問題を開封した瞬間 = T0 を記録。`#1` として記録される可読な監査印。権威ある束縛は root + `proof.exam`。ADR-0006)
 - **環境/自動化**: `environmentProbe` (起動時ワンショット。`navigator.webdriver` と自動化グローバル痕跡。ADR-0007 / ADR-0009 の automation 分析器が消費。加えて **editor-assist 宣言** `editorAssist` = Monaco 支援機能 (補完/スニペット/括弧自動閉じ/inlineSuggest 等) の解決済み実効状態を `editor-assist/1` スキーマで宣言する。取得不可は null。ADR-0019)
 - **認証**: `humanAttestation`, `preExportAttestation`, `termsAccepted`
+- **振り返り**: `reflectionNote` (提出前セルフレビューで学生が任意に書く振り返り。チェーンに焼かれ改ざん検出つき。空文字は記録しない。ADR-0022)
 - **実行**: `codeExecution` (ADR-0021: `phase:'start'` と `phase:'result'` の 2 イベント。result は outcome (success/failure/error/aborted)・exitCode・elapsedMs を持ち「失敗→修正→成功」のデバッグサイクルを導出可能にする。旧 proof の data 無しは start 相当), `terminalInput`
 - **キャプチャ**: `screenshotCapture`, `screenShareStart`, `screenShareStop`, `screenShareOptOut`
 - **セッション**: `sessionResumed`, `copyOperation`
@@ -123,7 +124,7 @@ TypedCode は、ブラウザ上のコードエディタにおける編集操作 
 interface EventHashData {
   sequence: number;        // 連続インデックス (0, 1, 2, ...)
   timestamp: number;       // performance.now() ベースの相対 ms
-  type: EventType;         // 上記 28 種類
+  type: EventType;         // 上記 29 種類
   inputType: InputType | null;  // contentChange 系の詳細 (insertText, deleteContentBackward など 26 種)
   data: string | object | null; // type 別の本体
   rangeOffset: number | null;
@@ -656,7 +657,7 @@ typedcode-verify my-code.zip --mode audit    # 将来用 (現状 full と同等)
 | 用語 | 意味 |
 |------|------|
 | **proof** | ExportedProof または MultiFileExportedProof。エクスポートされた検証可能な記録 |
-| **event** | エディタ操作 1 つを表す最小単位。28 種類 |
+| **event** | エディタ操作 1 つを表す最小単位。29 種類 |
 | **chain hash** | event.hash。previousHash + eventData の SHA-256 |
 | **PoSW** | Proof of Sequential Work。10000 回 SHA-256 反復 |
 | **checkpoint** | 直前 cp から 100 event か 10 秒のいずれかが先に到達した時点で作られる「中間スナップショット」 |
@@ -741,5 +742,6 @@ typedcode-verify my-code.zip --mode audit    # 将来用 (現状 full と同等)
 | 2026-06-12 | editor-assist 宣言 (ADR-0019, Phase 8-W0) | `environmentProbe` に **`editorAssist` 宣言** (`editor-assist/1`) を加算的に追加。Monaco の**解決済み**支援オプション (quickSuggestions / inlineSuggest / snippet / 括弧自動閉じ 等 13 項目) を起動時に正規化して焼き、「どの支援が有効な環境での記録か」をセッション間で比較可能にする。記録のみでポリシー判断はしない (別 ADR)。取得不可は null (graceful absence)。proof フォーマット非破壊・新イベント型なし。§4.1 を反映 |
 | 2026-06-12 | 分析層の配線 (ADR-0009, Phase 8-W1) | shared の分析フレームワーク (`runAnalysis`) を **verify(web) と verify-cli の両方に配線**。verify は verificationWorker が検証後に実行し `AnalysisReportCard` で表示、**evidence (event index) クリックでシークバーの当該イベントへジャンプ**。CLI は evidence 表示 + `--analysis-json` (評価ハーネスの機械可読入口) を追加。すべて advisory で valid / exit code には不反映 (直交性維持)。proof フォーマット不変 |
 | 2026-06-12 | 三層保証語彙 (ADR-0020, Phase 8-W2) | 保証を **整合性 (proven/failed) × 時刻アンカー (anchored/partial/unanchored/exam-t0) × 著述性 (常に advisory)** の三層として shared `deriveAssurance` で**実証拠のみから機械導出** (自己申告 `mode` 不使用 = ADR-0011 §6 消化)。verify は結果最上部にバッジ列 (+ mode 参考表示)、CLI は `--- Assurance ---` を出力。§1 の主張文言を三層に精密化 (overclaim 是正)。判定 (`verifyProofFile` の valid) は不変・proof フォーマット不変 |
-| 2026-06-12 | プロセス要約 (Phase 8-W3 A/B) | shared `summarizeProcess` がイベント列から制作過程の**中立な要約** (挿入/削除・実行・編集停止・focus 喪失・外部入力 + 見どころの event index) を決定的に抽出。verify は `ProcessSummaryCard` (見どころ→シークバージャンプ)、CLI は `--- Process summary ---`。**再生強化 (W3-C)**: シークバーに再生モード (= 等間隔 / ×1 ×10 ×60 実時間比例) と**見どころマーカー** (moments をトラック上に色分け表示・クリックでシーク) を追加。 |
-| 2026-06-12 | 実行結果の捕捉 (ADR-0021) | `codeExecution` を **start / result の 2 イベント**に拡張 (新イベント型なし・加算的・旧 proof 互換)。result の outcome/exitCode/elapsedMs から `summarizeProcess` が **初の失敗実行 / 失敗からの初成功** (デバッグサイクル) を見どころ抽出。出力テキストは記録しない。§4.1 を反映疑い指標ではない (疑いは ADR-0009 分析層)。proof 非焼込・フォーマット不変。既知の捕捉ギャップ: `codeExecution` は実行結果 (成功/失敗) を持たない (加算的捕捉の拡張は別 ADR 候補) |
+| 2026-06-12 | プロセス要約 (Phase 8-W3 A/B) | shared `summarizeProcess` がイベント列から制作過程の**中立な要約** (挿入/削除・実行・編集停止・focus 喪失・外部入力 + 見どころの event index) を決定的に抽出。verify は `ProcessSummaryCard` (見どころ→シークバージャンプ)、CLI は `--- Process summary ---`。**再生強化 (W3-C)**: シークバーに再生モード (= 等間隔 / ×1 ×10 ×60 実時間比例) と**見どころマーカー** (moments をトラック上に色分け表示・クリックでシーク) を追加。中立な記述であって疑い指標ではない (疑いは ADR-0009 分析層)。proof 非焼込・フォーマット不変 |
+| 2026-06-12 | 実行結果の捕捉 (ADR-0021) | `codeExecution` を **start / result の 2 イベント**に拡張 (新イベント型なし・加算的・旧 proof 互換)。result の outcome/exitCode/elapsedMs から `summarizeProcess` が **初の失敗実行 / 失敗からの初成功** (デバッグサイクル) を見どころ抽出。出力テキストは記録しない。§4.1 を反映 |
+| 2026-06-12 | セルフレビュー (ADR-0022, Phase 8-W4A) | export 直前に**提出前セルフレビュー** (自分の ProcessSummary = 採点者と同じ要約 + 任意の振り返り)。ノートは新イベント型 **`reflectionNote`** としてチェーンに焼かれ改ざん検出つき。能力 `selfReview` (casual/class/assignment=on, **exam=off**)。検証経路は未知イベント型を拒否しないことを確認済みで `PROOF_FORMAT_VERSION` 1.2.0 据え置き。verify 要約カード/CLI に「本人の振り返り」を表示。§4.1 を反映 |

--- a/packages/editor/CLAUDE.md
+++ b/packages/editor/CLAUDE.md
@@ -49,6 +49,7 @@ User Action
 
 ```
 ProofExporter.export()
+  → performSelfReview() (ADR-0022。capabilities.selfReview、exam は off。任意の reflectionNote をチェーンへ)
   → performPreExportVerification() (Turnstile。exam/class/assignment は best-effort)
   → getProofData() → ScreenshotTracker.getAllScreenshots()
   → JSZip → ダウンロード

--- a/packages/editor/src/core/mode.ts
+++ b/packages/editor/src/core/mode.ts
@@ -45,6 +45,12 @@ export interface ModeCapabilities {
   problemPanel: boolean;
   /** export 前 Turnstile を best-effort 化 (サーバを critical path に置かない)。 */
   preExportBestEffort: boolean;
+  /**
+   * 提出前セルフレビュー (ADR-0022): export 時に自分のプロセス要約を確認し、
+   * 任意の振り返りノートをチェーンへ記録するステップを出すか。
+   * exam は時間圧迫を避けて off (記録自体は他モードと同一フォーマット)。
+   */
+  selfReview: boolean;
 }
 
 /**
@@ -62,6 +68,7 @@ const CASUAL: ModeCapabilities = {
   unifyDownloadToProblemPanel: false,
   problemPanel: false,
   preExportBestEffort: false,
+  selfReview: true,
 };
 
 const EXAM: ModeCapabilities = {
@@ -74,6 +81,7 @@ const EXAM: ModeCapabilities = {
   unifyDownloadToProblemPanel: true,
   problemPanel: true,
   preExportBestEffort: true,
+  selfReview: false,
 };
 
 /**
@@ -93,6 +101,7 @@ const CLASS: ModeCapabilities = {
   unifyDownloadToProblemPanel: false,
   problemPanel: true,
   preExportBestEffort: true,
+  selfReview: true,
 };
 
 /**

--- a/packages/editor/src/export/ProofExporter.ts
+++ b/packages/editor/src/export/ProofExporter.ts
@@ -18,6 +18,8 @@ import { getLanguageDefinition } from '../config/SupportedLanguages.js';
 import { t } from '../i18n/index.js';
 import { generateReadmeEn } from './readme-template-en.js';
 import { generateReadmeJa } from './readme-template-ja.js';
+import { summarizeProcess } from '@typedcode/shared';
+import { SelfReviewDialog } from '../ui/components/SelfReviewDialog.js';
 
 export interface ExportCallbacks {
   onNotification?: (message: string) => void;
@@ -37,6 +39,9 @@ export class ProofExporter {
   /** 多重 export ガード。ダウンロードボタン連打での二重 export (attestation 二重記録 /
    *  Turnstile 二重描画 / 二重ダウンロード) を防ぐ。 */
   private isExporting = false;
+  /** 提出前セルフレビュー (ADR-0022, `capabilities.selfReview` で駆動)。 */
+  private selfReviewEnabled = false;
+  private selfReviewDialog = new SelfReviewDialog();
 
   constructor() {
     this.exportProgressDialog = new ExportProgressDialog();
@@ -55,6 +60,35 @@ export class ProofExporter {
    */
   setPreExportBestEffort(bestEffort: boolean): void {
     this.preExportBestEffort = bestEffort;
+  }
+
+  /** 提出前セルフレビュー (ADR-0022) の有効化 (`capabilities.selfReview` で駆動)。 */
+  setSelfReviewEnabled(enabled: boolean): void {
+    this.selfReviewEnabled = enabled;
+  }
+
+  /**
+   * 提出前セルフレビュー (ADR-0022): アクティブタブのプロセス要約を見せ、任意の
+   * 振り返りノートを reflectionNote イベントとしてチェーンへ記録する。
+   * @returns export を続行するか (false = ユーザがキャンセル)
+   */
+  private async performSelfReview(activeTab: TabState): Promise<boolean> {
+    if (!this.selfReviewEnabled) return true;
+
+    const summary = summarizeProcess(activeTab.typingProof.events);
+    const result = await this.selfReviewDialog.show(summary);
+    if (!result.proceed) return false;
+
+    if (result.note.length > 0) {
+      // ノートはチェーンに焼かれる (改ざん耐性)。exportProof が後段でチェーン完了を
+      // 待つため、ここは fire-and-forget でよい (preExportAttestation と同じ経路特性)。
+      await activeTab.typingProof.recordEvent({
+        type: 'reflectionNote',
+        data: { text: result.note },
+        description: t('selfReview.recorded'),
+      });
+    }
+    return true;
   }
 
   /**
@@ -279,6 +313,14 @@ export class ProofExporter {
         return;
       }
 
+      // 提出前セルフレビュー (ADR-0022): チェーン完了待ちより前に行い、
+      // 記録した reflectionNote も後段の待機/最終 checkpoint に含める。
+      const reviewOk = await this.performSelfReview(activeTab);
+      if (!reviewOk) {
+        this.callbacks.onNotification?.(t('export.cancelled'));
+        return;
+      }
+
       // ハッシュチェーン生成完了を待機
       const completed = await this.waitForProcessingComplete();
       if (!completed) {
@@ -413,6 +455,17 @@ export class ProofExporter {
       if (this.tabManager.getAllTabs().length === 0) {
         console.log('[Export] No tabs to export');
         return;
+      }
+
+      // 提出前セルフレビュー (ADR-0022): 一括 export では 1 回だけ表示し、
+      // ノートはアクティブタブのチェーンへ記録する (タブ毎 N 回は摩擦過多)。
+      const activeTabForReview = this.tabManager.getActiveTab();
+      if (activeTabForReview) {
+        const reviewOk = await this.performSelfReview(activeTabForReview);
+        if (!reviewOk) {
+          this.callbacks.onNotification?.(t('export.cancelled'));
+          return;
+        }
       }
 
       // ハッシュチェーン生成完了を待機

--- a/packages/editor/src/i18n/translations/en.ts
+++ b/packages/editor/src/i18n/translations/en.ts
@@ -348,6 +348,21 @@ export const en: TranslationKeys = {
     clearLogConfirm: 'Clear logs? (Proof data will be preserved)',
   },
 
+  selfReview: {
+    title: 'Pre-submission review',
+    lead: 'A summary of your working process. The export contains your full edit history, and graders see this same summary.',
+    duration: 'Duration',
+    edits: 'Edits (+/-)',
+    runs: 'Runs',
+    pauses: 'Long pauses',
+    noteLabel: 'Reflection note (optional)',
+    notePlaceholder: 'What you tried, where you got stuck, what you referenced…',
+    noteHint: 'The note is recorded tamper-evidently like your edit history and shown to graders. You can submit without one.',
+    cancel: 'Cancel',
+    proceed: 'Continue to export',
+    recorded: 'Reflection note recorded',
+  },
+
   export: {
     preAuthRunning: 'Running pre-export verification...',
     preAuthFailed: 'Pre-export verification failed',

--- a/packages/editor/src/i18n/translations/ja.ts
+++ b/packages/editor/src/i18n/translations/ja.ts
@@ -348,6 +348,21 @@ export const ja: TranslationKeys = {
     clearLogConfirm: 'ログをクリアしますか？（証明データは保持されます）',
   },
 
+  selfReview: {
+    title: '提出前の振り返り',
+    lead: 'あなたの制作過程の要約です。提出物には全編集履歴が含まれ、採点者も同じ要約を見ます。',
+    duration: '作業時間',
+    edits: '編集 (挿入/削除)',
+    runs: '実行',
+    pauses: '長い停止',
+    noteLabel: '振り返りノート (任意)',
+    notePlaceholder: '工夫した点・詰まった所・参考にしたもの など',
+    noteHint: 'ノートは編集履歴と同じく改ざん検出つきで記録され、採点者に表示されます。空欄のままでも提出できます。',
+    cancel: 'キャンセル',
+    proceed: '書き出しへ進む',
+    recorded: '振り返りノートを記録しました',
+  },
+
   export: {
     preAuthRunning: 'エクスポート前の認証を実行中...',
     preAuthFailed: 'エクスポート前の認証に失敗しました',

--- a/packages/editor/src/i18n/types.ts
+++ b/packages/editor/src/i18n/types.ts
@@ -375,6 +375,22 @@ export interface TranslationKeys {
   };
 
   // Export
+  // 提出前セルフレビュー (ADR-0022)
+  selfReview: {
+    title: string;
+    lead: string;
+    duration: string;
+    edits: string;
+    runs: string;
+    pauses: string;
+    noteLabel: string;
+    notePlaceholder: string;
+    noteHint: string;
+    cancel: string;
+    proceed: string;
+    recorded: string;
+  };
+
   export: {
     preAuthRunning: string;
     preAuthFailed: string;

--- a/packages/editor/src/main.ts
+++ b/packages/editor/src/main.ts
@@ -320,6 +320,8 @@ ctx.trackers.environment.setAssistDeclarationProvider(() => {
 ctx.proofExporter.setMode(ctx.mode);
 // export 前認証の best-effort 化はモード能力で決まる (ADR-0006: exam のみ。サーバを critical path に置かない)。
 ctx.proofExporter.setPreExportBestEffort(ctx.capabilities.preExportBestEffort);
+// 提出前セルフレビュー (ADR-0022): 自分の過程を確認し任意の振り返りを残す (exam は off)。
+ctx.proofExporter.setSelfReviewEnabled(ctx.capabilities.selfReview);
 
 // exam 固有のクロム (タブ追加/削除・汎用DLメニューの非表示、unify) は body.exam-mode が駆動する。
 if (ctx.examMode) {

--- a/packages/editor/src/styles/components/_self-review.css
+++ b/packages/editor/src/styles/components/_self-review.css
@@ -1,0 +1,118 @@
+/* SelfReviewDialog (ADR-0022) — 提出前セルフレビュー */
+
+.self-review-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+}
+
+.self-review-dialog {
+  width: min(560px, calc(100vw - 32px));
+  background: var(--bg-secondary, #252526);
+  border: 1px solid var(--border-color, #3c3c3c);
+  border-radius: 8px;
+  padding: 20px;
+  color: var(--text-primary, #d4d4d4);
+}
+
+.self-review-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.self-review-header h2 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.self-review-close {
+  background: none;
+  border: none;
+  color: var(--text-secondary, #9da5b4);
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.self-review-lead {
+  font-size: 12px;
+  color: var(--text-secondary, #9da5b4);
+  margin: 8px 0 12px;
+}
+
+.self-review-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  gap: 8px;
+  margin-bottom: 14px;
+}
+
+.self-review-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.self-review-stat-label {
+  font-size: 10px;
+  color: var(--text-secondary, #9da5b4);
+}
+
+.self-review-stat-value {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.self-review-note-label {
+  display: block;
+  font-size: 12px;
+  margin-bottom: 4px;
+}
+
+.self-review-note {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--bg-primary, #1e1e1e);
+  color: var(--text-primary, #d4d4d4);
+  border: 1px solid var(--border-color, #3c3c3c);
+  border-radius: 6px;
+  padding: 8px;
+  font-size: 13px;
+  resize: vertical;
+}
+
+.self-review-note-hint {
+  font-size: 11px;
+  color: var(--text-secondary, #9da5b4);
+  margin: 6px 0 14px;
+}
+
+.self-review-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.self-review-btn-cancel,
+.self-review-btn-proceed {
+  padding: 6px 16px;
+  border-radius: 6px;
+  font-size: 13px;
+  cursor: pointer;
+  border: 1px solid var(--border-color, #3c3c3c);
+  background: transparent;
+  color: var(--text-primary, #d4d4d4);
+}
+
+.self-review-btn-proceed {
+  background: var(--accent-color, #0e639c);
+  border-color: transparent;
+  color: #fff;
+}

--- a/packages/editor/src/styles/main.css
+++ b/packages/editor/src/styles/main.css
@@ -25,6 +25,7 @@
 @import './components/_browser-preview.css';
 @import './components/_problem-panel.css';
 @import './components/_modals.css';
+@import './components/_self-review.css';
 @import './components/_notifications.css';
 @import './components/_welcome.css';
 @import './components/_landing.css';

--- a/packages/editor/src/ui/components/SelfReviewDialog.ts
+++ b/packages/editor/src/ui/components/SelfReviewDialog.ts
@@ -1,0 +1,109 @@
+/**
+ * SelfReviewDialog - 提出前セルフレビュー (ADR-0022)
+ *
+ * export 直前に自分の制作過程 (ProcessSummary) を確認し、任意の振り返りノートを
+ * 書けるモーダル。位置づけは「監視ではなく鏡」— 学生が自分の過程を先に見る。
+ *
+ * - ノートは任意。空のまま進めば reflectionNote イベントは記録されない
+ * - キャンセルで export 自体を中止できる
+ * - 表示は中立 (疑い・判定の意味づけをしない)
+ */
+
+import type { ProcessSummary } from '@typedcode/shared';
+import { t } from '../../i18n/index.js';
+
+export interface SelfReviewResult {
+  /** export を続行するか (false = キャンセル)。 */
+  proceed: boolean;
+  /** 振り返りノート。空文字なら記録しない。 */
+  note: string;
+}
+
+export class SelfReviewDialog {
+  private overlay: HTMLElement | null = null;
+
+  /**
+   * ダイアログを表示し、ユーザの選択を返す。
+   */
+  show(summary: ProcessSummary): Promise<SelfReviewResult> {
+    return new Promise((resolve) => {
+      this.close();
+
+      const overlay = document.createElement('div');
+      overlay.className = 'self-review-overlay';
+      overlay.innerHTML = `
+        <div class="self-review-dialog" role="dialog" aria-modal="true">
+          <div class="self-review-header">
+            <h2>${t('selfReview.title')}</h2>
+            <button type="button" class="self-review-close" aria-label="${t('selfReview.cancel')}">×</button>
+          </div>
+          <p class="self-review-lead">${t('selfReview.lead')}</p>
+          <div class="self-review-stats">
+            ${this.stat(t('selfReview.duration'), formatDuration(summary.durationMs))}
+            ${this.stat(t('selfReview.edits'), `+${summary.insertedChars.toLocaleString()} / -${summary.deletedChars.toLocaleString()}`)}
+            ${this.stat(t('selfReview.runs'), this.runsLabel(summary))}
+            ${this.stat(t('selfReview.pauses'), String(summary.pauseCount))}
+          </div>
+          <label class="self-review-note-label" for="self-review-note">${t('selfReview.noteLabel')}</label>
+          <textarea id="self-review-note" class="self-review-note" rows="4"
+            placeholder="${t('selfReview.notePlaceholder')}"></textarea>
+          <p class="self-review-note-hint">${t('selfReview.noteHint')}</p>
+          <div class="self-review-actions">
+            <button type="button" class="self-review-btn-cancel">${t('selfReview.cancel')}</button>
+            <button type="button" class="self-review-btn-proceed">${t('selfReview.proceed')}</button>
+          </div>
+        </div>
+      `;
+
+      const finish = (result: SelfReviewResult): void => {
+        this.close();
+        resolve(result);
+      };
+
+      const textarea = overlay.querySelector<HTMLTextAreaElement>('#self-review-note')!;
+      overlay
+        .querySelector('.self-review-btn-proceed')!
+        .addEventListener('click', () => finish({ proceed: true, note: textarea.value.trim() }));
+      overlay
+        .querySelector('.self-review-btn-cancel')!
+        .addEventListener('click', () => finish({ proceed: false, note: '' }));
+      overlay
+        .querySelector('.self-review-close')!
+        .addEventListener('click', () => finish({ proceed: false, note: '' }));
+
+      this.overlay = overlay;
+      document.body.appendChild(overlay);
+      textarea.focus();
+    });
+  }
+
+  private runsLabel(summary: ProcessSummary): string {
+    if (!summary.hasRunResults) return String(summary.executionCount);
+    return `${summary.executionCount} (✓${summary.runSuccessCount} ✗${summary.runFailureCount})`;
+  }
+
+  private stat(label: string, value: string): string {
+    return `
+      <div class="self-review-stat">
+        <span class="self-review-stat-label">${label}</span>
+        <span class="self-review-stat-value">${value}</span>
+      </div>
+    `;
+  }
+
+  private close(): void {
+    this.overlay?.remove();
+    this.overlay = null;
+  }
+}
+
+/** ms を「1h 23m」「4m 05s」「12s」形式へ。 */
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000);
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${String(s).padStart(2, '0')}s`;
+  return `${s}s`;
+}

--- a/packages/shared/src/__tests__/processSummary.test.ts
+++ b/packages/shared/src/__tests__/processSummary.test.ts
@@ -179,6 +179,21 @@ describe('summarizeProcess — moments', () => {
     expect(s.runFailureCount).toBe(0);
   });
 
+  it('collects reflection notes from reflectionNote events (ADR-0022)', () => {
+    const s = summarizeProcess([
+      insert(0, 'a'),
+      makeEvent({ type: 'reflectionNote', timestamp: 100, data: { text: '再帰で詰まったので紙に書いた' } }),
+    ]);
+    expect(s.reflectionNotes).toEqual(['再帰で詰まったので紙に書いた']);
+  });
+
+  it('ignores empty reflection notes', () => {
+    const s = summarizeProcess([
+      makeEvent({ type: 'reflectionNote', timestamp: 0, data: { text: '' } }),
+    ]);
+    expect(s.reflectionNotes).toEqual([]);
+  });
+
   it('does not count internal paste (allowed input) as external input', () => {
     const s = summarizeProcess([
       makeEvent({ type: 'contentChange', timestamp: 0, inputType: 'insertFromInternalPaste', data: 'own code', rangeLength: 0 }),

--- a/packages/shared/src/processSummary.ts
+++ b/packages/shared/src/processSummary.ts
@@ -8,12 +8,12 @@
  * - **中立な記述**であって疑いの指標ではない (疑いは分析層 = AnalysisSignal の責務)。
  *   pause や書き直しは著述の自然な痕跡として「教育的に見るべき場所」を指す。
  * - 純関数・決定的 (同じイベント列 → 同じ要約)。proof には焼かない (後付け再計算可能)。
- * - 既知の捕捉ギャップ: `codeExecution` は実行開始のみ記録され**結果 (成功/失敗) を持たない**
- *   ため、「失敗 → 成功」遷移は抽出できない (捕捉の加算的拡張は別 ADR 候補)。
+ * - 実行結果 (成功/失敗) は ADR-0021 の result イベントから導出する。それ以前の proof は
+ *   `hasRunResults=false` (結果不明であって 0 回ではない)。
  */
 
 import type { StoredEvent } from './types/proof.js';
-import type { CodeExecutionEventData, FocusChangeData } from './types/events.js';
+import type { CodeExecutionEventData, FocusChangeData, ReflectionNoteData } from './types/events.js';
 import { isProhibitedInputType } from './typingProof/InputTypeValidator.js';
 
 /** 編集の停止 (考え中) とみなす contentChange 間ギャップの下限。 */
@@ -69,6 +69,8 @@ export interface ProcessSummary {
   longestPauseMs: number | null;
   focusLossCount: number;
   externalInputCount: number;
+  /** 提出前セルフレビューの振り返りノート (ADR-0022)。チェーン由来で改ざん耐性あり。 */
+  reflectionNotes: string[];
   moments: ProcessKeyMoment[];
 }
 
@@ -88,6 +90,7 @@ export function summarizeProcess(events: readonly StoredEvent[]): ProcessSummary
   let pauseCount = 0;
   let focusLossCount = 0;
   let externalInputCount = 0;
+  const reflectionNotes: string[] = [];
 
   let firstRun: ProcessKeyMoment | null = null;
   let firstFailedRun: ProcessKeyMoment | null = null;
@@ -214,6 +217,13 @@ export function summarizeProcess(events: readonly StoredEvent[]): ProcessSummary
         }
         break;
       }
+      case 'reflectionNote': {
+        const data = event.data as ReflectionNoteData | null;
+        if (data && typeof data === 'object' && typeof data.text === 'string' && data.text.length > 0) {
+          reflectionNotes.push(data.text);
+        }
+        break;
+      }
       case 'focusChange': {
         const data = event.data as FocusChangeData | null;
         if (data && typeof data === 'object' && 'focused' in data) {
@@ -284,6 +294,7 @@ export function summarizeProcess(events: readonly StoredEvent[]): ProcessSummary
     longestPauseMs: longestPause?.value ?? null,
     focusLossCount,
     externalInputCount,
+    reflectionNotes,
     moments,
   };
 }

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -33,6 +33,7 @@ export type EventType =
   | 'sessionResumed' // セッション再開（リロードまたはIndexedDBからの復旧）
   | 'copyOperation' // コピー操作（監査用）
   | 'screenShareOptOut' // 画面共有オプトアウト
+  | 'reflectionNote' // 提出前セルフレビューの振り返りノート（ADR-0022）
   | 'environmentProbe' // 環境/自動化プローブ（起動時ワンショット, ADR-0007）
   | 'fullscreenChange' // フルスクリーン状態変化（試験モード, ADR-0008）
   | 'examOpened'; // 封印問題パッケージの開封（試験モード, ADR-0006。#1 として記録）
@@ -170,6 +171,17 @@ export interface EditorAssistDeclaration {
   formatOnType: boolean | null;
   /** ペースト時の自動フォーマット。 */
   formatOnPaste: boolean | null;
+}
+
+/**
+ * 振り返りノート（ADR-0022）。
+ *
+ * 提出前セルフレビューで学生が任意に書く振り返り。チェーンに焼かれるため
+ * 改ざん耐性があり、採点者は「本人が提出時に何を述べたか」を信頼できる。
+ * 空文字は記録しない（イベント自体を作らない）。
+ */
+export interface ReflectionNoteData {
+  text: string;
 }
 
 /**

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -21,6 +21,7 @@ export type {
   NetworkStatusData,
   SessionResumedData,
   CodeExecutionEventData,
+  ReflectionNoteData,
   EditorAssistDeclaration,
   EnvironmentProbeData,
   FullscreenChangeData,

--- a/packages/shared/src/types/proof.ts
+++ b/packages/shared/src/types/proof.ts
@@ -20,6 +20,7 @@ import type {
   FullscreenChangeData,
   ExamOpenedEventData,
   CodeExecutionEventData,
+  ReflectionNoteData,
 } from './events.js';
 import type { ExamProofBlock } from './exam.js';
 import type { SessionStartToken } from './sessionStartToken.js';
@@ -53,7 +54,7 @@ export interface PoSWData {
 export interface RecordEventInput {
   type: EventType;
   inputType?: InputType | null;
-  data?: string | CursorPositionData | SelectionData | MousePositionData | VisibilityChangeData | FocusChangeData | KeystrokeDynamicsData | WindowSizeData | NetworkStatusData | SessionResumedData | HumanAttestationEventData | TermsAcceptedData | ScreenshotCaptureData | ScreenShareStartData | ScreenShareStopData | ScreenShareOptOutData | TemplateInjectionEventData | EnvironmentProbeData | FullscreenChangeData | ExamOpenedEventData | CodeExecutionEventData | null;
+  data?: string | CursorPositionData | SelectionData | MousePositionData | VisibilityChangeData | FocusChangeData | KeystrokeDynamicsData | WindowSizeData | NetworkStatusData | SessionResumedData | HumanAttestationEventData | TermsAcceptedData | ScreenshotCaptureData | ScreenShareStartData | ScreenShareStopData | ScreenShareOptOutData | TemplateInjectionEventData | EnvironmentProbeData | FullscreenChangeData | ExamOpenedEventData | CodeExecutionEventData | ReflectionNoteData | null;
   rangeOffset?: number | null;
   rangeLength?: number | null;
   range?: TextRange | null;
@@ -73,7 +74,7 @@ export interface EventHashData {
   timestamp: number;
   type: EventType;
   inputType: InputType | null;
-  data: string | CursorPositionData | SelectionData | MousePositionData | VisibilityChangeData | FocusChangeData | KeystrokeDynamicsData | WindowSizeData | NetworkStatusData | SessionResumedData | HumanAttestationEventData | TermsAcceptedData | ScreenshotCaptureData | ScreenShareStartData | ScreenShareStopData | ScreenShareOptOutData | TemplateInjectionEventData | EnvironmentProbeData | FullscreenChangeData | ExamOpenedEventData | CodeExecutionEventData | null;
+  data: string | CursorPositionData | SelectionData | MousePositionData | VisibilityChangeData | FocusChangeData | KeystrokeDynamicsData | WindowSizeData | NetworkStatusData | SessionResumedData | HumanAttestationEventData | TermsAcceptedData | ScreenshotCaptureData | ScreenShareStartData | ScreenShareStopData | ScreenShareOptOutData | TemplateInjectionEventData | EnvironmentProbeData | FullscreenChangeData | ExamOpenedEventData | CodeExecutionEventData | ReflectionNoteData | null;
   rangeOffset: number | null;
   rangeLength: number | null;
   range: TextRange | null;

--- a/packages/shared/src/types/storage.ts
+++ b/packages/shared/src/types/storage.ts
@@ -19,6 +19,7 @@ import type {
   FullscreenChangeData,
   ExamOpenedEventData,
   CodeExecutionEventData,
+  ReflectionNoteData,
 } from './events.js';
 import type {
   ScreenshotCaptureData,
@@ -61,6 +62,7 @@ export type PendingEventDataType =
   | FullscreenChangeData
   | ExamOpenedEventData
   | CodeExecutionEventData
+  | ReflectionNoteData
   | null;
 
 // ============================================================================

--- a/packages/shared/src/typingProof/InputTypeValidator.ts
+++ b/packages/shared/src/typingProof/InputTypeValidator.ts
@@ -16,6 +16,7 @@ const VALID_EVENT_TYPES: ReadonlySet<string> = new Set([
   'selectionChange',
   'externalInput',
   'editorInitialized',
+  'reflectionNote',
   'mousePositionChange',
   'visibilityChange',
   'focusChange',

--- a/packages/verify-cli/src/output.ts
+++ b/packages/verify-cli/src/output.ts
@@ -171,6 +171,9 @@ function formatProcessSummary(p: ProcessSummary): string[] {
   lines.push(
     `Activity:    ${runs}, ${p.pauseCount} long pause(s), ${p.focusLossCount} focus loss(es), ${p.externalInputCount} external input(s)`
   );
+  for (const note of p.reflectionNotes) {
+    lines.push(`Reflection:  ${note.replace(/\n/g, ' / ')}`);
+  }
   for (const m of p.moments) {
     const range =
       m.toEventIndex !== undefined && m.toEventIndex !== m.fromEventIndex

--- a/packages/verify/src/i18n/translations/en.ts
+++ b/packages/verify/src/i18n/translations/en.ts
@@ -285,6 +285,7 @@ export const en: VerifyTranslationKeys = {
     focusLosses: 'Focus losses',
     externalInputs: 'External input',
     moments: 'Key moments',
+    reflectionNotes: "Author's reflection (recorded at submission)",
     chars: 'chars',
     kindFirstRun: 'First run',
     kindFirstFailedRun: 'First failed run',

--- a/packages/verify/src/i18n/translations/ja.ts
+++ b/packages/verify/src/i18n/translations/ja.ts
@@ -285,6 +285,7 @@ export const ja: VerifyTranslationKeys = {
     focusLosses: '離脱',
     externalInputs: '外部入力',
     moments: '見どころ',
+    reflectionNotes: '本人の振り返り (提出時に記録)',
     chars: '文字',
     kindFirstRun: '初回実行',
     kindFirstFailedRun: '初の失敗した実行',

--- a/packages/verify/src/i18n/types.ts
+++ b/packages/verify/src/i18n/types.ts
@@ -307,6 +307,7 @@ export interface VerifyTranslationKeys {
     focusLosses: string;
     externalInputs: string;
     moments: string;
+    reflectionNotes: string;
     chars: string;
     kindFirstRun: string;
     kindFirstFailedRun: string;

--- a/packages/verify/src/styles/components/_process-summary.css
+++ b/packages/verify/src/styles/components/_process-summary.css
@@ -71,3 +71,19 @@
 .process-moment-jump:hover {
   background: rgba(79, 193, 255, 0.12);
 }
+
+.process-reflection-list {
+  list-style: none;
+  margin: 0 0 10px;
+  padding: 0;
+}
+
+.process-reflection-note {
+  font-size: 12px;
+  line-height: 1.6;
+  padding: 8px 10px;
+  border-left: 3px solid #4fc1ff;
+  border-radius: 4px;
+  background: var(--bg-tertiary, rgba(255, 255, 255, 0.03));
+  white-space: pre-wrap;
+}

--- a/packages/verify/src/types/chartVisibility.ts
+++ b/packages/verify/src/types/chartVisibility.ts
@@ -52,6 +52,7 @@ export const EVENT_CATEGORY_MAP: Record<EventType, EventCategory> = {
   environmentProbe: 'system',
   examOpened: 'system',
   // Auth
+  reflectionNote: 'auth',
   humanAttestation: 'auth',
   preExportAttestation: 'auth',
   termsAccepted: 'auth',

--- a/packages/verify/src/ui/ProcessSummaryCard.ts
+++ b/packages/verify/src/ui/ProcessSummaryCard.ts
@@ -62,6 +62,13 @@ export class ProcessSummaryCard {
       </div>
     `;
 
+    const notes = summary.reflectionNotes.length
+      ? `<div class="process-moments-title">${t('process.reflectionNotes')}</div>
+         <ul class="process-reflection-list">
+           ${summary.reflectionNotes.map((n) => `<li class="process-reflection-note">${escapeHtml(n)}</li>`).join('')}
+         </ul>`
+      : '';
+
     const moments = summary.moments.length
       ? `<div class="process-moments-title">${t('process.moments')}</div>
          <ul class="process-moment-list">
@@ -69,7 +76,7 @@ export class ProcessSummaryCard {
          </ul>`
       : '';
 
-    return stats + moments;
+    return stats + notes + moments;
   }
 
   private stat(label: string, value: string): string {


### PR DESCRIPTION
## 概要 (stacked)

プロセス記録を「監視の産物」から「鏡 (自己省察の道具)」へ。export 直前に学生が自分の ProcessSummary (**採点者が見るものと同一の要約**) を確認し、任意の振り返りノートを残せます。

- **新イベント型 `reflectionNote`** (`{text}`、空は記録しない)。チェーンに焼かれ改ざん検出つき = 「本人が提出時にそう述べた」ことが暗号的に固定される
- **互換性は実地検証してから導入**: 検証経路は未知イベント型を拒否しない (チェーンハッシュは型非依存・metadata 再カウントは inputType 基準・content replay は対象 3 型のみ・`validateEventType` は検証経路未使用・バージョン上限チェック無し) → `PROOF_FORMAT_VERSION` 1.2.0 据え置き
- `SelfReviewDialog`: 統計 4 種 + ノート欄。**スキップ可・キャンセルで export 中止可**。一括 export は 1 回表示でアクティブタブへ記録
- 能力トグル `selfReview`: casual/class/assignment = on / **exam = off** (時間圧迫回避)
- 採点者側: verify 要約カードに「本人の振り返り (提出時に記録)」、CLI に `Reflection:` 行 (中立表示 — 内容の真偽は採点者・口頭試問が判断する自己申告)

## テスト

- shared に reflectionNotes 抽出テスト 2 件追加 (337 passing)、editor 95 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)