### PR TITLE
fix(verify): UI レビュー指摘の修正 + 合成 proof フィクスチャ生成器

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ docs/plans/
 
 # Playwright MCP output (screenshots, snapshots, e2e fixtures)
 .playwright-mcp/
+fix-*.png

--- a/packages/shared/src/__tests__/analysisOrchestrator.test.ts
+++ b/packages/shared/src/__tests__/analysisOrchestrator.test.ts
@@ -11,11 +11,15 @@ import type {
 function makeInput(opts: {
   isPureTyping?: boolean;
   timestamps?: number[];
+  /** paste/drop など禁止 InputType のイベントを混ぜる (pureTypingAnalyzer の証拠源)。 */
+  prohibitedInputs?: import('../types/events.js').InputType[];
 }): AnalysisInput {
-  const events = (opts.timestamps ?? []).map((t, i) => ({
-    sequence: i,
-    timestamp: t,
-  }));
+  const events: Array<{ sequence: number; timestamp: number; inputType?: string }> = (
+    opts.timestamps ?? []
+  ).map((t, i) => ({ sequence: i, timestamp: t }));
+  (opts.prohibitedInputs ?? []).forEach((inputType, k) => {
+    events.push({ sequence: events.length, timestamp: 1000 + k, inputType });
+  });
   return {
     proof: { proof: { events } } as unknown as AnalysisInput['proof'],
     verification: {
@@ -95,9 +99,14 @@ describe('runAnalysis orchestrator', () => {
 });
 
 describe('pureTypingAnalyzer (placeholder)', () => {
-  it('emits a notice when verification reports non-pure typing', async () => {
-    const report = await runAnalysis(makeInput({ isPureTyping: false }), [pureTypingAnalyzer]);
+  it('emits a notice with evidence when non-pure typing has prohibited inputs', async () => {
+    const report = await runAnalysis(
+      makeInput({ isPureTyping: false, prohibitedInputs: ['insertFromPaste', 'insertFromDrop'] }),
+      [pureTypingAnalyzer]
+    );
     expect(report.signals).toHaveLength(1);
+    expect(report.signals[0]!.evidence.length).toBe(2); // paste + drop の event index
+    expect(report.signals[0]!.summaryParams).toMatchObject({ paste: 1, drop: 1 });
     expect(report.signals[0]?.severity).toBe('notice');
     expect(report.signals[0]?.dimension).toBe('transcription-topology');
   });

--- a/packages/shared/src/__tests__/genFixtureProof.test.ts
+++ b/packages/shared/src/__tests__/genFixtureProof.test.ts
@@ -1,0 +1,158 @@
+/**
+ * 合成 proof フィクスチャ生成器 (GEN_FIXTURES=1 のときだけ動く。通常の test:run では skip)。
+ *
+ * 実際の TypingProof で「現実的なセッション」を脚本どおりに演じ、検証可能な proof JSON を
+ * 吐く。performance.now をモンキーパッチして停止・バースト・デバッグサイクル等のタイムラインを
+ * 数百 ms で再現する。**手打ち不要で動作検証/UI レビューを自動化する土台**:
+ *   GEN_FIXTURES=1 npx vitest run genFixtureProof -w @typedcode/shared
+ *   → /tmp/typedcode-fixtures/messy_session_proof.json
+ * これを verify-cli の golden テストや verify(web) の Playwright スモークに食わせる。
+ *
+ * 注意: PoSW はテスト環境のモック値なので **fast モード検証専用**。full モードは PoSW
+ * 再計算で落ちる (実 PoSW を焼くには本物の poswWorker 経路が要る)。
+ */
+
+import { describe, expect, it } from 'vitest';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { TypingProof, computeHash, verifyProofFile } from '../index.js';
+import type { FingerprintComponents } from '../types.js';
+
+const components: FingerprintComponents = {
+  userAgent: 'Mozilla/5.0 (Fixture Session)',
+  language: 'ja',
+  languages: ['ja', 'en'],
+  platform: 'FixtureOS',
+  hardwareConcurrency: 8,
+  deviceMemory: 16,
+  screen: {
+    width: 1920,
+    height: 1080,
+    availWidth: 1920,
+    availHeight: 1040,
+    colorDepth: 24,
+    pixelDepth: 24,
+    devicePixelRatio: 1,
+  },
+  timezone: 'Asia/Tokyo',
+  timezoneOffset: -540,
+  canvas: 'fixture-canvas',
+  webgl: { vendor: 'Fixture Vendor', renderer: 'Fixture Renderer' },
+  fonts: ['Arial'],
+  cookieEnabled: true,
+  doNotTrack: 'unspecified',
+  maxTouchPoints: 0,
+};
+
+describe.runIf(process.env['GEN_FIXTURES'] === '1')('generate fixture proofs', () => {
+  it('generates a realistic messy session proof', async () => {
+    // 仮想時計
+    let now = 0;
+    const realNow = performance.now.bind(performance);
+    // eslint-disable-next-line no-global-assign
+    performance.now = () => now;
+
+    try {
+      const fingerprintHash = await computeHash(JSON.stringify(components, null, 0));
+      const proof = new TypingProof();
+      await proof.initialize(fingerprintHash, components);
+
+      let content = '';
+      const type = async (text: string, msPerChar = 120): Promise<void> => {
+        for (const ch of text) {
+          now += msPerChar + (ch.charCodeAt(0) % 70); // 決定的なゆらぎ
+          await proof.recordEvent({
+            type: 'contentChange',
+            inputType: 'insertText',
+            data: ch,
+            rangeOffset: content.length,
+            rangeLength: 0,
+          });
+          content += ch;
+        }
+      };
+      const deleteChars = async (n: number): Promise<void> => {
+        for (let i = 0; i < n; i++) {
+          now += 90;
+          await proof.recordEvent({
+            type: 'contentChange',
+            inputType: 'deleteContentBackward',
+            data: '',
+            rangeOffset: content.length - 1,
+            rangeLength: 1,
+          });
+          content = content.slice(0, -1);
+        }
+      };
+      const run = async (outcome: 'success' | 'failure', exitCode: number): Promise<void> => {
+        now += 800;
+        await proof.recordEvent({
+          type: 'codeExecution',
+          data: { phase: 'start', filename: 'main.c', language: 'c' },
+          description: 'main.c を実行',
+        });
+        now += 1500;
+        await proof.recordEvent({
+          type: 'codeExecution',
+          data: { phase: 'result', filename: 'main.c', language: 'c', outcome, exitCode, elapsedMs: 1500 },
+          description: `main.c: ${outcome} (exit ${exitCode})`,
+        });
+      };
+
+      // --- セッションの脚本 ---
+      await type('#include <stdio.h>\n\nint main(void) {\n');
+      now += 18_000; // 考え中 (長い停止)
+      await type('  printf("hello world")\n  return 0;\n}\n');
+      await run('failure', 1); // セミコロン忘れで失敗
+      now += 4_000;
+      await deleteChars(20);
+      await type('");\n  return 0;\n}\n'); // 修正
+      await run('success', 0); // 失敗からの初成功
+
+      // 離脱 → 復帰 → バースト
+      now += 1_000;
+      await proof.recordEvent({ type: 'focusChange', data: { focused: false } });
+      now += 45_000;
+      await proof.recordEvent({ type: 'focusChange', data: { focused: true } });
+      await type('// add a comment that is long enough to look like a paste burst after refocus!!\n', 25);
+
+      // 外部ペースト (禁止 InputType)
+      now += 2_000;
+      const pasted = '/* pasted from somewhere */\n';
+      await proof.recordEvent({
+        type: 'contentChange',
+        inputType: 'insertFromPaste',
+        data: pasted,
+        rangeOffset: content.length,
+        rangeLength: 0,
+      });
+      content += pasted;
+
+      // 振り返りノート (ADR-0022)
+      now += 5_000;
+      await proof.recordEvent({
+        type: 'reflectionNote',
+        data: { text: 'セミコロン忘れでコンパイルエラー。エラーメッセージの行番号の読み方を覚えた。' },
+      });
+
+      const exported = await proof.exportProof(content);
+
+      // 自己検証 (fast: PoSW 再計算スキップ)
+      const result = await verifyProofFile(
+        { ...exported, content, language: 'c' } as never,
+        undefined,
+        { mode: 'fast' }
+      );
+      expect(result.chainValid).toBe(true);
+      expect(result.metadataValid).toBe(true);
+
+      mkdirSync('/tmp/typedcode-fixtures', { recursive: true });
+      writeFileSync(
+        '/tmp/typedcode-fixtures/messy_session_proof.json',
+        JSON.stringify({ ...exported, content, language: 'c' }, null, 2)
+      );
+      console.log('events:', exported.proof.totalEvents, '→ /tmp/typedcode-fixtures/messy_session_proof.json');
+    } finally {
+      performance.now = realNow;
+    }
+  }, 120_000);
+});

--- a/packages/shared/src/__tests__/processSummary.test.ts
+++ b/packages/shared/src/__tests__/processSummary.test.ts
@@ -106,11 +106,33 @@ describe('summarizeProcess — moments', () => {
     expect(s.pauseCount).toBe(1);
   });
 
-  it('records the largest deletion as a rewrite moment', () => {
-    const s = summarizeProcess([insert(0, 'abcdef'), del(100, 3), del(200, 5)]);
+  it('aggregates consecutive deletions into one rewrite run (not a single char)', () => {
+    // Backspace 連打 = 1 文字ずつの削除イベント。これを 1 つの書き直しとして束ねる。
+    const s = summarizeProcess([
+      insert(0, 'abcdefghij'),
+      del(100, 1),
+      del(200, 1),
+      del(300, 1),
+      del(400, 1),
+      insert(500, 'X'), // 純挿入で削除ランが締まる
+    ]);
     const m = s.moments.find((x) => x.kind === 'largest-deletion');
-    expect(m?.fromEventIndex).toBe(2);
-    expect(m?.value).toBe(5);
+    expect(m?.fromEventIndex).toBe(1);
+    expect(m?.toEventIndex).toBe(4);
+    expect(m?.value).toBe(4); // 1+1+1+1 = 4 文字を 1 ランとして集計
+  });
+
+  it('keeps separate deletion runs apart when broken by an insert', () => {
+    const s = summarizeProcess([
+      insert(0, 'abcdef'),
+      del(100, 2),
+      insert(200, 'x'),
+      del(300, 5), // 別ラン (こちらが最大)
+      del(400, 1),
+    ]);
+    const m = s.moments.find((x) => x.kind === 'largest-deletion');
+    expect(m?.fromEventIndex).toBe(3);
+    expect(m?.value).toBe(6); // 5+1
   });
 
   it('records a focus-return burst when enough characters follow a refocus', () => {

--- a/packages/shared/src/analysis/analyzers/pureTypingAnalyzer.ts
+++ b/packages/shared/src/analysis/analyzers/pureTypingAnalyzer.ts
@@ -1,31 +1,52 @@
 /**
- * [プレースホルダ分析器] 既存の advisory `isPureTyping` を分析 signal に "折り込む" デモ。
+ * 既存の advisory `isPureTyping` を分析 signal に "折り込む" 分析器。
  *
  * ADR-0009 の「散在する advisory (`isPureTyping` 等) を framework の signal へ段階移行
- * する」方針の最小例であり、**検証結果 (`FullVerificationResult`) を消費する形**を示す。
- * paste/drop の存在は弱い手掛かりとして `notice` を 1 つ出すだけで、判定はしない。
+ * する」方針の実体であり、**検証結果 (`FullVerificationResult`) と proof の両方を消費する形**
+ * を示す。paste/drop の存在は弱い手掛かりとして `notice` を 1 つ出すだけで、判定はしない。
  *
  * 本物の転写トポロジー分析 (`range`/`rangeOffset` から構築の形を見る) は後続 spec/ADR。
  */
 
-import type { AnalysisInput, AnalysisSignal, Analyzer } from '../types.js';
+import type { AnalysisInput, AnalysisSignal, Analyzer, EvidenceRef } from '../types.js';
+import { isProhibitedInputType } from '../../typingProof/InputTypeValidator.js';
 
 const ID = 'example-pure-typing';
 
 export const pureTypingAnalyzer: Analyzer = {
   id: ID,
-  version: '0.0.0',
+  version: '0.1.0',
   analyze(input: AnalysisInput): AnalysisSignal[] {
     if (input.verification.isPureTyping) return [];
+
+    // 禁止 InputType (paste/drop/yank 等) の event index を証拠として集める。
+    const evidence: EvidenceRef[] = [];
+    let pasteCount = 0;
+    let dropCount = 0;
+    const events = input.proof.proof?.events ?? [];
+    for (let i = 0; i < events.length; i++) {
+      const inputType = events[i]?.inputType;
+      if (inputType && isProhibitedInputType(inputType)) {
+        if (inputType === 'insertFromDrop') dropCount++;
+        else pasteCount++;
+        evidence.push({ fromEventIndex: i, note: inputType });
+      }
+    }
+
+    const total = pasteCount + dropCount;
+    if (total === 0) return []; // isPureTyping=false だが禁止入力が見つからない (保守的に黙る)
+
     return [
       {
         analyzerId: ID,
         dimension: 'transcription-topology',
-        score: 0.3, // プレースホルダ: paste/drop の存在は弱い手掛かり
+        score: 0.3, // paste/drop の存在は弱い手掛かり (判定ではない)
         confidence: 0.5,
         severity: 'notice',
-        evidence: [], // 本実装では paste/drop の event index を載せる
-        summary: 'Non-pure typing: paste/drop present (placeholder)',
+        evidence,
+        summary: `External input present: ${pasteCount} paste, ${dropCount} drop`,
+        summaryKey: 'analysis.summary.externalInput',
+        summaryParams: { paste: pasteCount, drop: dropCount },
       },
     ];
   },

--- a/packages/shared/src/analysis/types.ts
+++ b/packages/shared/src/analysis/types.ts
@@ -43,8 +43,15 @@ export interface AnalysisSignal {
   severity: AnalysisSeverity;
   /** 証拠の event 参照。空配列も可だが付けることを推奨。 */
   evidence: EvidenceRef[];
-  /** 人間向けの一文サマリ。 */
+  /** 人間向けの一文サマリ (フォールバック / 非ローカライズ環境用)。 */
   summary: string;
+  /**
+   * ローカライズ用の翻訳キー (任意)。表示側が summaryKey を解決できれば summary より優先する。
+   * shared は i18n を持たないため、文言の最終形は消費側 (verify/CLI) が決める。
+   */
+  summaryKey?: string;
+  /** summaryKey の補間パラメータ。 */
+  summaryParams?: Record<string, string | number>;
 }
 
 /** Analyzer への入力: 検証済み proof と暗号判定 (直交) の組。 */

--- a/packages/shared/src/processSummary.ts
+++ b/packages/shared/src/processSummary.ts
@@ -102,6 +102,21 @@ export function summarizeProcess(events: readonly StoredEvent[]): ProcessSummary
   const externalMoments: ProcessKeyMoment[] = [];
 
   let lastContentChange: { index: number; timestamp: number } | null = null;
+  // 連続削除ラン (Backspace 連打は 1 文字ずつの contentChange で来るため束ねる)。
+  // 純挿入イベントで締める。最大の書き直しはこのラン合計で測る (単発 1 文字ではなく)。
+  let delRun: { fromIndex: number; lastIndex: number; chars: number; timestamp: number } | null = null;
+  const finalizeDelRun = (): void => {
+    if (delRun && delRun.chars > (largestDeletion?.value ?? 0)) {
+      largestDeletion = {
+        kind: 'largest-deletion',
+        fromEventIndex: delRun.fromIndex,
+        toEventIndex: delRun.lastIndex !== delRun.fromIndex ? delRun.lastIndex : undefined,
+        timestamp: delRun.timestamp,
+        value: delRun.chars,
+      };
+    }
+    delRun = null;
+  };
   /** フォーカス復帰直後のバースト積算 (復帰イベントごとに 1 つ)。 */
   let pendingBurst: {
     refocusIndex: number;
@@ -140,13 +155,16 @@ export function summarizeProcess(events: readonly StoredEvent[]): ProcessSummary
         insertedChars += inserted;
         deletedChars += deleted;
 
-        if (deleted > 0 && deleted > (largestDeletion?.value ?? 0)) {
-          largestDeletion = {
-            kind: 'largest-deletion',
-            fromEventIndex: i,
-            timestamp: event.timestamp,
-            value: deleted,
-          };
+        // 削除ランの蓄積: 削除を含むイベントで伸ばし、純挿入 (削除なし) で締める。
+        if (deleted > 0) {
+          if (delRun) {
+            delRun.chars += deleted;
+            delRun.lastIndex = i;
+          } else {
+            delRun = { fromIndex: i, lastIndex: i, chars: deleted, timestamp: event.timestamp };
+          }
+        } else if (inserted > 0) {
+          finalizeDelRun();
         }
         if (inserted > 1 && inserted > (largestInsertion?.value ?? 0)) {
           largestInsertion = {
@@ -261,8 +279,9 @@ export function summarizeProcess(events: readonly StoredEvent[]): ProcessSummary
     }
   }
 
-  // 末尾までバースト窓が開いていた場合の昇格判定
+  // 末尾までバースト窓 / 削除ランが開いていた場合の確定
   largestFocusBurst = promoteBurst(pendingBurst, largestFocusBurst);
+  finalizeDelRun();
 
   if (firstRun) moments.push(firstRun);
   if (firstFailedRun) moments.push(firstFailedRun);

--- a/packages/shared/src/typingPattern/TypingPatternAnalyzer.ts
+++ b/packages/shared/src/typingPattern/TypingPatternAnalyzer.ts
@@ -606,6 +606,9 @@ export class TypingPatternAnalyzer {
     const issues: TypingPatternIssue[] = [];
 
     for (const [key, metric] of Object.entries(metrics)) {
+      // データ不足は「計算できなかった」事実であって所見ではない。issue にすると
+      // 「データ不足」警告が羅列してノイズになる (UI レビュー指摘)。除外する。
+      if (metric.reasonKey === 'pattern.insufficient') continue;
       if (metric.judgment === 'suspicious') {
         issues.push({
           severity: 'critical',

--- a/packages/verify/CLAUDE.md
+++ b/packages/verify/CLAUDE.md
@@ -82,3 +82,12 @@ File Selection (drag&drop / FSA API)
 - 見どころ (初回実行 / 最長停止 / 最大書き直し / 復帰直後バースト / 外部入力) は `verify:seek-to-event` で当該イベントへジャンプ (分析カードと同じ経路)
 - 抽出ロジックは shared に置く (テストは shared 側)。閾値も shared の `PROCESS_*` 定数が単一ソース
 - **再生 (W3-C)**: `SeekbarController` は再生モード `steps` (50ms/イベント・従来) と `x1/x10/x60` (イベント timestamp に比例 — 停止やバーストの緩急が見える) を持つ。`#seekbar-speed` で巡回。**見どころマーカー** は `setKeyMoments(moments)` で `#seekbar-markers` に描画 (kind 別の色・クリックでシーク)。moments は TabController が `summarizeProcess(events)` から渡す
+
+## UI レイアウトの不変条件 (UI レビュー 2026-06-12)
+
+- **チャート/シークバーはステータスカード直後 (result-cards の前)** に置く。採点の主要ツールなので 9 枚のカードの下に埋めない (index.html の `#chart-section` 位置)。戻さないこと
+- **シークバー初期化は content をガードにしない**: `TabController.renderCharts` は `proofData.content` の有無に関わらず `seekbarController.initialize` を呼ぶ。proof.json 単体 (ソースファイルなし) では content が無く、`SeekbarController` が events から最終状態を再構成する。content ガードを戻すと JSON 単体で再生/マーカーが死ぬ
+- **読込直後の自動オープン**: `VerificationController.handleComplete` が「アクティブタブが null なら最初に完了した proof を `openTabForFile`」する。ウェルカム画面のまま放置しない
+- **ステータスカードは縦 2 段**: 上段 `.result-status-row` (アイコン+タイトル+ミニゲージ)、下段 `#assurance-strip` (三層バッジ全幅)。横 1 列に詰めると三層チップとタイトルが重なって縦書き崩れする
+- **分析シグナルの文言は `summaryKey` 優先**: `AnalysisSignal.summaryKey` があれば verify 側で `t()` ローカライズ (shared は i18n を持たないため)。`summary` は英語フォールバック。analyzer に生英語を直書きしない
+- **TypingPatternCard は advisory 表示**: 冒頭に `analysis.advisory` 注記。issue 見出しは断定 (「重大な問題」) を避け「特に確認したい点 / 気になる点」。ADR-0020 の「advisory を判定に見せない」を旧カードにも適用 (ADR-0009 への完全統合は follow-up)

--- a/packages/verify/index.html
+++ b/packages/verify/index.html
@@ -297,24 +297,103 @@
               <div class="result-left-panel" id="result-left-panel">
                 <!-- Status Card -->
                 <div class="result-status-card" id="result-status-card">
-                  <div class="result-status-main">
-                    <div class="result-status-icon" id="result-status-icon">
-                      <i class="fas fa-spinner fa-spin"></i>
+                  <div class="result-status-row">
+                    <div class="result-status-main">
+                      <div class="result-status-icon" id="result-status-icon">
+                        <i class="fas fa-spinner fa-spin"></i>
+                      </div>
+                      <div class="result-status-info">
+                        <div class="result-status-title" id="result-status-title" data-i18n="result.statusVerifying">検証中...</div>
+                        <div class="result-status-filename" id="result-status-filename"></div>
+                      </div>
                     </div>
-                    <div class="result-status-info">
-                      <div class="result-status-title" id="result-status-title" data-i18n="result.statusVerifying">検証中...</div>
-                      <div class="result-status-filename" id="result-status-filename"></div>
+                    <div class="result-status-pattern" id="result-status-pattern" style="display: none;">
+                      <div class="pattern-mini-gauge" id="pattern-mini-gauge"></div>
+                      <div class="pattern-mini-info">
+                        <div class="pattern-mini-label" data-i18n="pattern.title">タイピングパターン</div>
+                        <div class="pattern-mini-judgment" id="pattern-mini-judgment">-</div>
+                      </div>
                     </div>
                   </div>
-                  <!-- 三層保証語彙 (ADR-0020): 整合性 × 時刻アンカー × 著述性(advisory) -->
+                  <!-- 三層保証語彙 (ADR-0020): 整合性 × 時刻アンカー × 著述性(advisory)。全幅で下段に置く -->
                   <div class="assurance-strip" id="assurance-strip" style="display: none;">
                     <!-- Rendered by ResultPanel.renderAssurance -->
                   </div>
-                  <div class="result-status-pattern" id="result-status-pattern" style="display: none;">
-                    <div class="pattern-mini-gauge" id="pattern-mini-gauge"></div>
-                    <div class="pattern-mini-info">
-                      <div class="pattern-mini-label" data-i18n="pattern.title">タイピングパターン</div>
-                      <div class="pattern-mini-judgment" id="pattern-mini-judgment">-</div>
+                </div>
+
+                <!-- Chart Section -->
+                <div class="chart-section" id="chart-section">
+                  <div class="chart-tabs">
+                    <button class="chart-tab active" data-tab="integrated" id="tab-integrated">
+                      <i class="fas fa-chart-line"></i> <span data-i18n="charts.integrated">統合チャート</span>
+                    </button>
+                    <button class="chart-tab" data-tab="timeline" id="tab-timeline">
+                      <i class="fas fa-keyboard"></i> <span data-i18n="charts.timeline">タイムライン</span>
+                    </button>
+                    <button class="chart-tab" data-tab="mouse" id="tab-mouse">
+                      <i class="fas fa-mouse"></i> <span data-i18n="charts.mouseTrajectory">マウス軌跡</span>
+                    </button>
+                    <!-- Event Filter -->
+                    <div class="chart-event-selector-container" id="chart-event-selector-container">
+                      <button class="chart-event-selector-btn" id="chart-event-selector-btn" data-i18n-title="charts.eventFilter">
+                        <i class="fas fa-filter"></i>
+                      </button>
+                      <div class="chart-event-selector-dropdown" id="chart-event-selector-dropdown"></div>
+                    </div>
+                  </div>
+                  <div class="chart-content">
+                    <div class="chart-panel active" id="panel-integrated">
+                      <div class="integrated-chart-container">
+                        <canvas id="integrated-chart"></canvas>
+                      </div>
+                    </div>
+                    <div class="chart-panel" id="panel-timeline">
+                      <div class="integrated-timeline">
+                        <canvas id="integrated-timeline-chart"></canvas>
+                      </div>
+                    </div>
+                    <div class="chart-panel" id="panel-mouse">
+                      <div class="mouse-trajectory">
+                        <canvas id="mouse-trajectory-chart"></canvas>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="chart-stats" id="chart-stats">
+                    <span><span data-i18n="charts.keys">キー</span>: <strong id="keydown-count">0</strong></span>
+                    <span><span data-i18n="charts.dwell">Dwell</span>: <strong id="avg-dwell-time">0ms</strong></span>
+                    <span><span data-i18n="charts.flight">Flight</span>: <strong id="avg-flight-time">0ms</strong></span>
+                    <span><span data-i18n="charts.mouse">マウス</span>: <strong id="mouse-event-count">0</strong></span>
+                  </div>
+                  <!-- Integrated Seekbar -->
+                  <div class="chart-seekbar" id="chart-seekbar" style="display: none;">
+                    <div class="seekbar-controls">
+                      <button class="seek-btn" id="seekbar-start" data-i18n-title="seekbar.start">
+                        <i class="fas fa-backward-fast"></i>
+                      </button>
+                      <button class="seek-btn" id="seekbar-prev" data-i18n-title="seekbar.prev">
+                        <i class="fas fa-backward-step"></i>
+                      </button>
+                      <button class="seek-btn seek-btn-play" id="seekbar-play" data-i18n-title="seekbar.play">
+                        <i class="fas fa-play" id="play-icon"></i>
+                      </button>
+                      <button class="seek-btn" id="seekbar-next" data-i18n-title="seekbar.next">
+                        <i class="fas fa-forward-step"></i>
+                      </button>
+                      <button class="seek-btn" id="seekbar-end" data-i18n-title="seekbar.end">
+                        <i class="fas fa-forward-fast"></i>
+                      </button>
+                      <button class="seek-btn seek-btn-speed" id="seekbar-speed" data-i18n-title="seekbar.speed">=</button>
+                    </div>
+                    <div class="seekbar-track-container">
+                      <div class="seek-track">
+                        <input type="range" class="seek-slider" id="seekbar-slider" min="0" max="100" value="100" step="1">
+                        <div class="seek-progress" id="seekbar-progress"></div>
+                        <div class="seek-markers" id="seekbar-markers"></div>
+                      </div>
+                    </div>
+                    <div class="seekbar-info">
+                      <span class="seek-time" id="seekbar-time">0:00</span>
+                      <span class="seek-count" id="seekbar-event-count">0/0</span>
                     </div>
                   </div>
                 </div>
@@ -644,82 +723,6 @@
                   </div>
                 </div>
 
-                <!-- Chart Section -->
-                <div class="chart-section" id="chart-section">
-                  <div class="chart-tabs">
-                    <button class="chart-tab active" data-tab="integrated" id="tab-integrated">
-                      <i class="fas fa-chart-line"></i> <span data-i18n="charts.integrated">統合チャート</span>
-                    </button>
-                    <button class="chart-tab" data-tab="timeline" id="tab-timeline">
-                      <i class="fas fa-keyboard"></i> <span data-i18n="charts.timeline">タイムライン</span>
-                    </button>
-                    <button class="chart-tab" data-tab="mouse" id="tab-mouse">
-                      <i class="fas fa-mouse"></i> <span data-i18n="charts.mouseTrajectory">マウス軌跡</span>
-                    </button>
-                    <!-- Event Filter -->
-                    <div class="chart-event-selector-container" id="chart-event-selector-container">
-                      <button class="chart-event-selector-btn" id="chart-event-selector-btn" data-i18n-title="charts.eventFilter">
-                        <i class="fas fa-filter"></i>
-                      </button>
-                      <div class="chart-event-selector-dropdown" id="chart-event-selector-dropdown"></div>
-                    </div>
-                  </div>
-                  <div class="chart-content">
-                    <div class="chart-panel active" id="panel-integrated">
-                      <div class="integrated-chart-container">
-                        <canvas id="integrated-chart"></canvas>
-                      </div>
-                    </div>
-                    <div class="chart-panel" id="panel-timeline">
-                      <div class="integrated-timeline">
-                        <canvas id="integrated-timeline-chart"></canvas>
-                      </div>
-                    </div>
-                    <div class="chart-panel" id="panel-mouse">
-                      <div class="mouse-trajectory">
-                        <canvas id="mouse-trajectory-chart"></canvas>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="chart-stats" id="chart-stats">
-                    <span><span data-i18n="charts.keys">キー</span>: <strong id="keydown-count">0</strong></span>
-                    <span><span data-i18n="charts.dwell">Dwell</span>: <strong id="avg-dwell-time">0ms</strong></span>
-                    <span><span data-i18n="charts.flight">Flight</span>: <strong id="avg-flight-time">0ms</strong></span>
-                    <span><span data-i18n="charts.mouse">マウス</span>: <strong id="mouse-event-count">0</strong></span>
-                  </div>
-                  <!-- Integrated Seekbar -->
-                  <div class="chart-seekbar" id="chart-seekbar" style="display: none;">
-                    <div class="seekbar-controls">
-                      <button class="seek-btn" id="seekbar-start" data-i18n-title="seekbar.start">
-                        <i class="fas fa-backward-fast"></i>
-                      </button>
-                      <button class="seek-btn" id="seekbar-prev" data-i18n-title="seekbar.prev">
-                        <i class="fas fa-backward-step"></i>
-                      </button>
-                      <button class="seek-btn seek-btn-play" id="seekbar-play" data-i18n-title="seekbar.play">
-                        <i class="fas fa-play" id="play-icon"></i>
-                      </button>
-                      <button class="seek-btn" id="seekbar-next" data-i18n-title="seekbar.next">
-                        <i class="fas fa-forward-step"></i>
-                      </button>
-                      <button class="seek-btn" id="seekbar-end" data-i18n-title="seekbar.end">
-                        <i class="fas fa-forward-fast"></i>
-                      </button>
-                      <button class="seek-btn seek-btn-speed" id="seekbar-speed" data-i18n-title="seekbar.speed">=</button>
-                    </div>
-                    <div class="seekbar-track-container">
-                      <div class="seek-track">
-                        <input type="range" class="seek-slider" id="seekbar-slider" min="0" max="100" value="100" step="1">
-                        <div class="seek-progress" id="seekbar-progress"></div>
-                        <div class="seek-markers" id="seekbar-markers"></div>
-                      </div>
-                    </div>
-                    <div class="seekbar-info">
-                      <span class="seek-time" id="seekbar-time">0:00</span>
-                      <span class="seek-count" id="seekbar-event-count">0/0</span>
-                    </div>
-                  </div>
-                </div>
               </div>
 
               <!-- Result Panel Resize Handle -->

--- a/packages/verify/src/charts/SeekbarController.ts
+++ b/packages/verify/src/charts/SeekbarController.ts
@@ -124,9 +124,11 @@ export class SeekbarController {
     if (!events || events.length === 0) return;
 
     this.events = events;
-    this.finalContent = finalContent;
-    this.currentIndex = events.length;
     this.contentCache.clear();
+    // content が渡されない (proof.json 単体 = ソースファイルなし) ときは events から
+    // 最終状態を再構成する。これがないと最終インデックスの再生が空になる。
+    this.finalContent = finalContent || this.reconstructFinalContent(events);
+    this.currentIndex = events.length;
 
     // シークバーを表示
     if (this.options.floatingSeekbar) {
@@ -495,6 +497,21 @@ export class SeekbarController {
       this.contentCache.set(cacheKey, content);
     }
 
+    return content;
+  }
+
+  /**
+   * 全イベントを順に適用して最終コンテンツを再構成する (content 未提供時のフォールバック)。
+   */
+  private reconstructFinalContent(events: StoredEvent[]): string {
+    let content = '';
+    for (const event of events) {
+      if (event.type === 'contentChange') {
+        content = this.applyContentChange(content, event);
+      } else if (event.type === 'templateInjection') {
+        content = this.applyTemplateInjection(event);
+      }
+    }
     return content;
   }
 

--- a/packages/verify/src/i18n/translations/en.ts
+++ b/packages/verify/src/i18n/translations/en.ts
@@ -338,6 +338,9 @@ export const en: VerifyTranslationKeys = {
     dimensionKeystrokeContent: 'Keystroke–content consistency',
     dimensionTranscriptionTopology: 'Construction shape (transcription/authoring)',
     dimensionFocusBurst: 'Focus-loss / burst correlation',
+    summary: {
+      externalInput: 'External input present: ${paste} paste, ${drop} drop',
+    },
   },
 
   pattern: {
@@ -348,8 +351,8 @@ export const en: VerifyTranslationKeys = {
     human: 'Human-like',
     uncertain: 'Uncertain',
     suspicious: 'Suspicious',
-    criticalIssues: 'Critical Issues',
-    warnings: 'Warnings',
+    criticalIssues: 'Points to review',
+    warnings: 'Notes',
     summary: {
       human: 'Typing pattern shows human-like characteristics',
       suspicious: 'Possible automated or fraudulent input detected',

--- a/packages/verify/src/i18n/translations/ja.ts
+++ b/packages/verify/src/i18n/translations/ja.ts
@@ -338,6 +338,9 @@ export const ja: VerifyTranslationKeys = {
     dimensionKeystrokeContent: '打鍵と内容の整合',
     dimensionTranscriptionTopology: '構築の形 (転写/著述)',
     dimensionFocusBurst: '離脱とバーストの相関',
+    summary: {
+      externalInput: '外部入力あり: ペースト ${paste} 件 / ドロップ ${drop} 件',
+    },
   },
 
   pattern: {
@@ -348,8 +351,8 @@ export const ja: VerifyTranslationKeys = {
     human: '人間らしい',
     uncertain: '不明確',
     suspicious: '疑わしい',
-    criticalIssues: '重大な問題',
-    warnings: '警告',
+    criticalIssues: '特に確認したい点',
+    warnings: '気になる点',
     summary: {
       human: 'タイピングパターンは人間らしい特徴を示しています',
       suspicious: '自動入力や不正入力の可能性があります',

--- a/packages/verify/src/i18n/types.ts
+++ b/packages/verify/src/i18n/types.ts
@@ -362,6 +362,9 @@ export interface VerifyTranslationKeys {
     dimensionKeystrokeContent: string;
     dimensionTranscriptionTopology: string;
     dimensionFocusBurst: string;
+    summary: {
+      externalInput: string;
+    };
   };
 
   pattern: {

--- a/packages/verify/src/styles/components/_result-panel.css
+++ b/packages/verify/src/styles/components/_result-panel.css
@@ -46,7 +46,7 @@
   width: 50%;
   min-width: 350px;
   max-width: 70%;
-  padding: 16px;
+  padding: 16px 16px 32px;
   overflow-y: auto;
   flex-shrink: 0;
 }
@@ -76,14 +76,23 @@
 /* Status header card */
 .result-status-card {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: stretch;
   gap: 12px;
   padding: 16px;
   background-color: var(--card-bg);
   border: 1px solid var(--card-border);
   border-radius: 8px;
   margin-bottom: 16px;
+}
+
+/* 上段: アイコン+タイトル と ミニゲージ を横並び */
+.result-status-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
 }
 
 .result-status-main {
@@ -101,6 +110,13 @@
   gap: 10px;
   padding-left: 16px;
   border-left: 1px solid var(--border-color);
+  flex-shrink: 0;
+}
+
+/* 三層保証バッジは下段に全幅。上段とは区切り線で分ける (表示時のみ) */
+#assurance-strip {
+  padding: 10px 0 0;
+  border-top: 1px solid var(--border-color);
 }
 
 .pattern-mini-gauge {

--- a/packages/verify/src/styles/layout/_sidebar.css
+++ b/packages/verify/src/styles/layout/_sidebar.css
@@ -44,11 +44,15 @@
   letter-spacing: 0.5px;
   color: var(--text-secondary);
   margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .sidebar-actions {
   display: flex;
   gap: 4px;
+  flex-shrink: 0;
 }
 
 .sidebar-action-btn {

--- a/packages/verify/src/ui/AnalysisReportCard.ts
+++ b/packages/verify/src/ui/AnalysisReportCard.ts
@@ -88,10 +88,20 @@ export class AnalysisReportCard {
             ${t('analysis.confidence')} ${(signal.confidence * 100).toFixed(0)}%
           </span>
         </div>
-        <div class="analysis-summary">${escapeHtml(signal.summary)}</div>
+        <div class="analysis-summary">${escapeHtml(this.summaryText(signal))}</div>
         ${evidence ? `<div class="analysis-evidence-row"><span class="analysis-evidence-label">${t('analysis.evidence')}:</span>${evidence}</div>` : ''}
       </li>
     `;
+  }
+
+  /** summaryKey があればローカライズし、無ければ summary をそのまま使う。 */
+  private summaryText(signal: AnalysisSignal): string {
+    if (signal.summaryKey) {
+      const localized = t(signal.summaryKey, signal.summaryParams);
+      // t() はキー未登録だとキー文字列をそのまま返すので、その場合は summary にフォールバック。
+      if (localized && localized !== signal.summaryKey) return localized;
+    }
+    return signal.summary;
   }
 
   private renderEvidence(ev: EvidenceRef): string {

--- a/packages/verify/src/ui/TypingPatternCard.ts
+++ b/packages/verify/src/ui/TypingPatternCard.ts
@@ -73,6 +73,10 @@ export class TypingPatternCard {
    */
   private renderContent(analysis: TypingPatternAnalysis): string {
     return `
+      <div class="analysis-advisory-note">
+        <i class="fas fa-info-circle"></i>
+        <span>${t('analysis.advisory')}</span>
+      </div>
       <div class="pattern-overview">
         <div class="pattern-gauge-container">
           ${this.renderGauge(analysis.overallScore, analysis.overallJudgment)}

--- a/packages/verify/src/ui/controllers/TabController.ts
+++ b/packages/verify/src/ui/controllers/TabController.ts
@@ -348,16 +348,14 @@ export class TabController {
       // SeekbarControllerにIntegratedChartを連携し、イベントで初期化
       if (seekbarController) {
         seekbarController.setIntegratedChart(integratedChart);
-        // アクティブなタブのコンテンツを取得してシークバーを初期化
+        // content の有無に関わらず常に初期化する。proof.json 単体 (ソースファイルなし =
+        // 標準エクスポートの proof.json) では content が無いが、再生は events から再構成できる。
+        // content を初期化のガードにすると JSON 単体読込で再生/マーカーが死ぬ (回帰修正)。
         const activeTabId = this.deps.tabBar.getActiveTabId();
-        if (activeTabId) {
-          const tabState = this.deps.tabManager.getTab(activeTabId);
-          if (tabState?.proofData?.content) {
-            seekbarController.initialize(events, tabState.proofData.content);
-            // 見どころマーカー (W3-C): プロセス要約の moments をトラックに重ねる。
-            seekbarController.setKeyMoments(summarizeProcess(events).moments);
-          }
-        }
+        const tabState = activeTabId ? this.deps.tabManager.getTab(activeTabId) : null;
+        seekbarController.initialize(events, tabState?.proofData?.content ?? '');
+        // 見どころマーカー (W3-C): プロセス要約の moments をトラックに重ねる。
+        seekbarController.setKeyMoments(summarizeProcess(events).moments);
       }
     }
 

--- a/packages/verify/src/ui/controllers/VerificationController.ts
+++ b/packages/verify/src/ui/controllers/VerificationController.ts
@@ -113,6 +113,10 @@ export class VerificationController {
       this.deps.resultPanel.finishProgress();
       // 強制更新フラグを渡して結果を確実に表示
       this.deps.tabController.showTabContent(id, true);
+    } else if (this.deps.tabBar.getActiveTabId() === null) {
+      // まだ何も開いていなければ最初に完了した proof を自動で開く。
+      // 以降は別タブがアクティブになるのでフォーカスを奪わない (UX: 読込直後の空白を解消)。
+      this.deps.tabController.openTabForFile(id);
     }
   }
 


### PR DESCRIPTION
実ブラウザ (Playwright) での通しレビューで見つけた verify UI の不具合をまとめて修正し、動作検証を自動化する合成 proof 生成器を同梱します。

## P1 — 機能影響あり

1. **ステータスカードの三層チップ重なり/縦書き崩れ** (W2 起因): 横 1 列 → 上段 (アイコン+タイトル+ミニゲージ) / 下段 (三層バッジ全幅・区切り線) の 2 段に
2. **proof.json 単体読込でシークバー/見どころマーカーが死ぬ**: `content` を初期化ガードにしていた → 外し、`SeekbarController` が events から最終状態を再構成 (標準エクスポートの proof.json はソースファイル別添で content を持たない)
3. **チャート/シークバーが 9 枚のカードの下に埋もれる**: 採点の主要ツールなのでステータスカード直後に引き上げ
4. **読込後に結果が自動で開かない**: `handleComplete` で「アクティブタブが無ければ最初の完了 proof を自動オープン」

## P2 — 分かりにくさ・ADR 整合

5. **pureTypingAnalyzer の placeholder/英語を実装に格上げ**: paste/drop の **event index を evidence** に載せ、`summaryKey` でローカライズ (`AnalysisSignal.summaryKey` 追加。shared は i18n を持たないため表示側で解決)
6. **「データ不足」の羅列**: 計算不能は所見ではないので issue から除外 (警告 6 → 1)
7. **旧 TypingPatternCard の断定表示**: advisory 注記を追加、「重大な問題」→「特に確認したい点」へ軟化 (ADR-0020 の「advisory を判定に見せない」を旧カードにも適用。ADR-0009 への完全統合は follow-up)
8. **連続削除が「1 文字」と出る**: Backspace 連打を 1 つの書き直しランに集約 (実 span を表示)

## P3
- サイドバー見出しの折返しを省略表示に

## 動作検証の自動化 (議論への回答)

`genFixtureProof.test.ts` (`GEN_FIXTURES=1` で起動・通常 `test:run` では skip) が、実 `TypingProof` で現実的なセッション (長い停止・復帰バースト・失敗→成功のデバッグサイクル・ペースト・振り返りノート) を脚本どおり演じた**検証可能な proof JSON** を数百 ms で生成します。手打ち不要で verify-cli の golden テストや verify(web) の Playwright スモークに使えます。

> 注: PoSW はテスト環境のモック値なので fast モード検証専用 (full は PoSW 再計算で落ちる)。

## テスト
- shared 338 passed / editor 95 passed、全ワークスペース typecheck green
- 上記すべて実ブラウザで表示確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)