### PR TITLE
feat(editor): LogViewer で codeExecution / reflectionNote を可読表示

### DIFF
--- a/packages/editor/src/i18n/translations/en.ts
+++ b/packages/editor/src/i18n/translations/en.ts
@@ -430,6 +430,16 @@ export const en: TranslationKeys = {
     mouseOperation: 'Mouse Operation',
     rangeSelection: 'Range Selection',
     characterInput: 'Character Input',
+    codeExecStart: 'Run (start)',
+    codeExecResult: 'Run: ${outcome}',
+    outcomeSuccess: 'success',
+    outcomeFailure: 'failure',
+    outcomeError: 'error',
+    outcomeAborted: 'aborted',
+    codeExecFile: 'file: ${file}',
+    codeExecExit: 'exit: ${code}',
+    codeExecElapsed: 'elapsed: ${ms}ms',
+    reflectionNote: 'Reflection note',
   },
 
   events: {

--- a/packages/editor/src/i18n/translations/ja.ts
+++ b/packages/editor/src/i18n/translations/ja.ts
@@ -430,6 +430,16 @@ export const ja: TranslationKeys = {
     mouseOperation: 'マウス操作',
     rangeSelection: '範囲選択',
     characterInput: '文字入力',
+    codeExecStart: 'コード実行 (開始)',
+    codeExecResult: 'コード実行: ${outcome}',
+    outcomeSuccess: '成功',
+    outcomeFailure: '失敗',
+    outcomeError: 'エラー',
+    outcomeAborted: '中止',
+    codeExecFile: 'ファイル: ${file}',
+    codeExecExit: 'exit: ${code}',
+    codeExecElapsed: '所要: ${ms}ms',
+    reflectionNote: '振り返りノート',
   },
 
   events: {

--- a/packages/editor/src/i18n/types.ts
+++ b/packages/editor/src/i18n/types.ts
@@ -454,6 +454,16 @@ export interface TranslationKeys {
     mouseOperation: string;
     rangeSelection: string;
     characterInput: string;
+    codeExecStart: string;
+    codeExecResult: string;
+    outcomeSuccess: string;
+    outcomeFailure: string;
+    outcomeError: string;
+    outcomeAborted: string;
+    codeExecFile: string;
+    codeExecExit: string;
+    codeExecElapsed: string;
+    reflectionNote: string;
   };
 
   // Event descriptions (for tracking)

--- a/packages/editor/src/ui/components/LogViewer.ts
+++ b/packages/editor/src/ui/components/LogViewer.ts
@@ -7,6 +7,8 @@ import type {
   StoredEvent,
   LogStats,
   EventType,
+  CodeExecutionEventData,
+  ReflectionNoteData,
 } from '@typedcode/shared';
 import { t } from '../../i18n/index.js';
 import type { ScreenshotStorageService } from '../../services/ScreenshotStorageService.js';
@@ -751,8 +753,33 @@ export class LogViewer {
         return t('logViewer.editorInit');
       case 'contentSnapshot':
         return t('logViewer.snapshot');
+      case 'codeExecution': {
+        const data = event.data as CodeExecutionEventData | null;
+        if (data?.phase === 'result') {
+          return t('logViewer.codeExecResult', { outcome: this.outcomeLabel(data.outcome) });
+        }
+        return t('logViewer.codeExecStart');
+      }
+      case 'reflectionNote':
+        return t('logViewer.reflectionNote');
       default:
         return event.type;
+    }
+  }
+
+  /** codeExecution の result outcome をローカライズ (ADR-0021)。 */
+  private outcomeLabel(outcome: CodeExecutionEventData['outcome']): string {
+    switch (outcome) {
+      case 'success':
+        return t('logViewer.outcomeSuccess');
+      case 'failure':
+        return t('logViewer.outcomeFailure');
+      case 'error':
+        return t('logViewer.outcomeError');
+      case 'aborted':
+        return t('logViewer.outcomeAborted');
+      default:
+        return '-';
     }
   }
 
@@ -761,6 +788,30 @@ export class LogViewer {
    */
   private getEventDetails(event: StoredEvent): string | null {
     const details: string[] = [];
+
+    // codeExecution (ADR-0021): ファイル + (result なら) exit code / 所要時間。
+    if (event.type === 'codeExecution') {
+      const data = event.data as CodeExecutionEventData | null;
+      if (data) {
+        details.push(t('logViewer.codeExecFile', { file: data.filename ?? '-' }));
+        if (data.phase === 'result') {
+          if (data.exitCode !== undefined && data.exitCode !== null) {
+            details.push(t('logViewer.codeExecExit', { code: String(data.exitCode) }));
+          }
+          if (data.elapsedMs !== undefined && data.elapsedMs !== null) {
+            details.push(t('logViewer.codeExecElapsed', { ms: String(data.elapsedMs) }));
+          }
+        }
+      }
+      return details.length > 0 ? details.join(' | ') : null;
+    }
+
+    // reflectionNote (ADR-0022): 本人の振り返りテキスト (切り詰めて表示)。
+    if (event.type === 'reflectionNote') {
+      const data = event.data as ReflectionNoteData | null;
+      if (data?.text) return this.formatData(data.text);
+      return null;
+    }
 
     if (event.range) {
       details.push(


### PR DESCRIPTION
## 概要

LogViewer (操作ログ) で `codeExecution` (ADR-0021) と `reflectionNote` (ADR-0022) が default ケースに落ちて型名のまま表示されていたのを、専用の説明・詳細表示にする follow-up (#3a・表示のみ)。

## 変更

- **`codeExecution`**: 説明を `phase` で出し分け (`開始` / result は outcome=成功/失敗/エラー/中止 をローカライズ)。詳細行に **file / exit code / 所要 ms**。
- **`reflectionNote`**: 説明「振り返りノート」+ 詳細に本文 (切り詰め表示)。
- i18n キーを ja / en / types の 3 ファイル同期で追加 (`logViewer` セクション)。

## テスト

editor typecheck clean / 95 tests green。proof・捕捉ロジックには触らない (表示のみ)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)