### PR TITLE
test(e2e): Phase C モード/復元/画面共有シナリオ + リロード root アンカー喪失バグ修正

### DIFF
--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -79,6 +79,17 @@ shared の main が raw TypeScript のため `node dist/cli.js` は動かない
 | 4 | tab-switch.spec.ts | フォーカス喪失→復帰 → focusChange 記録・focus loss 計上 |
 | 7 | synthetic-keystroke.spec.ts | 合成打鍵に isTrusted=false が付く (ADR-0018)・信頼打鍵には付かない |
 
-Phase C 以降でフルスクリーン/画面共有/Turnstile 分岐/リロード復元/モードルーティング、
-Phase D で敵対的パック (複数行 AI 一括投入など) / staging カナリア / ブラウザマトリクスを追加予定
-(設計の全体像は本リポジトリの方針メモを参照)。
+**Phase C (モード/復元/メディア)**
+
+| ファイル | 検証内容 |
+|---|---|
+| mode-routing.spec.ts | `/`・未知パスはランディング (エディタ非初期化・4カード)、`/casual` は明示ルート、カードから遷移 |
+| reload-recovery.spec.ts | 編集→リロード→復元→追記→export、チェーンがリロードをまたいで検証 pass |
+| screen-share.spec.ts | 画面共有有効化 → screenShareStart + スクショ記録 → ZIP に screenshots/ → 検証 pass |
+
+> reload-recovery は実装の **sessionStartToken 喪失バグ** (リロードで root アンカーが落ち
+> proof が検証不能になる) を発見し、`editor` 側で修正した (editor↔shared をまたぐ統合バグ)。
+
+Phase D で敵対的パック (複数行 AI 一括投入など) / フルスクリーン (exam ゲート + .tcexam fixture) /
+Turnstile 失敗分岐 / staging カナリア / ブラウザマトリクスを追加予定。
+macOS ネイティブ全画面・実 Turnstile チャレンジ・実ディスプレイの画面共有ピッカーは手動スモーク。

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -45,7 +45,18 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: {
+          args: [
+            // getDisplayMedia (画面共有) を headless でも自動許可・自動ソース選択する。
+            // ピッカー UI を出さず本物の MediaStream を得てキャプチャ経路を検証する。
+            '--use-fake-ui-for-media-stream',
+            '--use-fake-device-for-media-stream',
+            '--auto-select-desktop-capture-source=Entire screen',
+          ],
+        },
+      },
     },
   ],
 

--- a/packages/e2e/tests/helpers/app.ts
+++ b/packages/e2e/tests/helpers/app.ts
@@ -148,6 +148,17 @@ export class EditorApp {
     await this.page.waitForTimeout(200);
   }
 
+  /**
+   * casual の「画面共有を有効にする」バナーを押して画面共有を開始する。
+   * fake-media フラグ (playwright.config) により getDisplayMedia は monitor の
+   * fake ストリームを返すので、ピッカー無しで本物のキャプチャ経路が回る。
+   */
+  async enableScreenShare(): Promise<void> {
+    const btn = this.page.locator('#screen-share-opt-out-banner .banner-btn');
+    await btn.waitFor({ state: 'visible', timeout: 10_000 });
+    await btn.click();
+  }
+
   /** 新規タブを追加する。 */
   async addTab(): Promise<void> {
     const before = await this.page.locator('#editor-tabs .editor-tab, #editor-tabs [role="tab"]').count();
@@ -202,6 +213,13 @@ export async function listProofEntries(zipPath: string): Promise<string[]> {
   const buf = await readFileBuffer(zipPath);
   const zip = await JSZip.loadAsync(buf);
   return Object.keys(zip.files).filter((n) => n.endsWith('_proof.json'));
+}
+
+/** ZIP 内の全エントリ名一覧 (screenshots/ の有無確認などに使う)。 */
+export async function listZipEntries(zipPath: string): Promise<string[]> {
+  const buf = await readFileBuffer(zipPath);
+  const zip = await JSZip.loadAsync(buf);
+  return Object.keys(zip.files);
 }
 
 /**

--- a/packages/e2e/tests/helpers/app.ts
+++ b/packages/e2e/tests/helpers/app.ts
@@ -42,6 +42,41 @@ export class EditorApp {
   }
 
   /**
+   * IndexedDB 同期と PoSW キューの掃けを待つ。リロード前に呼ぶことで、未 flush の
+   * イベントが取り残されてチェーンが途切れるのを防ぐ (打鍵直後の即リロード対策)。
+   */
+  async waitForSynced(): Promise<void> {
+    await expect(this.page.locator('#sync-status-item')).toHaveClass(/synced/, { timeout: 30_000 });
+    // event-count が 2 回連続で同じ = PoSW キューが掃けてチェーン確定。
+    let prev = -1;
+    for (let i = 0; i < 30; i++) {
+      const c = await this.eventCount();
+      if (c === prev) return;
+      prev = c;
+      await this.page.waitForTimeout(300);
+    }
+  }
+
+  /**
+   * ページをリロードして前回セッションを復元する。リロード時は通常 sessionStorage 経由で
+   * 自動復元されるが、復元モーダル (#session-recovery-overlay) が出た場合は「再開する」を押す。
+   * リロード前に同期完了を待ち、未 flush イベントの取り残しを防ぐ。
+   */
+  async reloadAndResume(): Promise<void> {
+    await this.waitForSynced();
+    await this.page.reload();
+    const resume = this.page.locator('#session-resume-btn');
+    try {
+      await resume.waitFor({ state: 'visible', timeout: 5_000 });
+      await resume.click();
+    } catch {
+      /* 自動復元 (モーダル無し) */
+    }
+    await this.page.locator('.monaco-editor .view-lines').first().waitFor({ state: 'visible' });
+    await expect.poll(() => this.eventCount(), { timeout: 30_000 }).toBeGreaterThan(0);
+  }
+
+  /**
    * エディタに実キーストロークで入力する。Playwright の keyboard は CDP 経由で
    * isTrusted=true の本物のイベントを発火するので、信頼打鍵として記録される。
    */

--- a/packages/e2e/tests/mode-routing.spec.ts
+++ b/packages/e2e/tests/mode-routing.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+import { EditorApp } from './helpers/app.js';
+
+/**
+ * モードルーティング (ADR-0011 / ADR-0015): `/` と未知パスはモード選択ランディング、
+ * `/casual` は明示ルートでエディタ起動、`?reset` でクリーン起動。タイポを黙って casual に
+ * しない (事故防止) ことを実ブラウザで担保する。
+ */
+
+test('ルート / はランディング (エディタ非初期化・4モードカード)', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('#landing-page')).toBeVisible();
+  // エディタ (#app) は landing では display:none で不可視化される。
+  await expect(page.locator('#app')).toBeHidden();
+  await expect(page.locator('.landing-card-mode[data-mode]')).toHaveCount(4);
+  for (const mode of ['casual', 'class', 'assignment', 'exam']) {
+    await expect(page.locator(`.landing-card-mode[data-mode="${mode}"]`)).toBeVisible();
+  }
+});
+
+test('未知パスはランディングに落ちる (タイポを黙って casual にしない)', async ({ page }) => {
+  await page.goto('/exsm');
+  await expect(page.locator('#landing-page')).toBeVisible();
+  await expect(page.locator('#app')).toBeHidden();
+  await expect(page.locator('.landing-card-mode[data-mode]')).toHaveCount(4);
+});
+
+test('/casual は明示ルートでエディタを起動し記録を開始する', async ({ page }) => {
+  const app = new EditorApp(page);
+  await app.openCasualFresh();
+  await expect(page.locator('#app')).toBeVisible();
+  await expect(page.locator('.monaco-editor .view-lines').first()).toBeVisible();
+  await expect(page.locator('#landing-page')).toHaveCount(0);
+  // #0 humanAttestation が記録され、event-count が 1 以上。
+  expect(await app.eventCount()).toBeGreaterThan(0);
+});
+
+test('ランディングの casual カードから /casual へ遷移する', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('#landing-page')).toBeVisible();
+  await page.locator('.landing-card-mode[data-mode="casual"] .lc-open').click();
+  await expect(page).toHaveURL(/\/casual$/);
+  await expect(page.locator('.monaco-editor .view-lines').first()).toBeVisible();
+});

--- a/packages/e2e/tests/reload-recovery.spec.ts
+++ b/packages/e2e/tests/reload-recovery.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+import { EditorApp, readProofEvents } from './helpers/app.js';
+import { runVerifyCli } from './helpers/verifyCli.js';
+
+/**
+ * リロード復元: 編集途中でリロードしても IndexedDB / sessionStorage からセッションが復元され、
+ * ハッシュチェーンが途切れず継続することを検証する (export → verify-cli が pass)。
+ * 永続化と復元時のチェーン整合 (editor 不変条件 #5) の回帰テスト。
+ */
+test('リロード後もセッションが復元され、チェーンが途切れず検証が pass する', async ({ page }) => {
+  const app = new EditorApp(page);
+  await app.openCasualFresh();
+
+  await app.typeCode('int a = 1;\n');
+  const beforeCount = await app.eventCount();
+  expect(beforeCount).toBeGreaterThan(1);
+
+  await app.reloadAndResume();
+
+  // 復元されたエディタに前回の内容が残っている。
+  expect(await app.editorValue()).toContain('int a = 1;');
+  // 記録は復元後も継続 (リセットされていない)。
+  expect(await app.eventCount()).toBeGreaterThanOrEqual(beforeCount);
+
+  // 復元後にさらに打鍵してチェーンを伸ばす。
+  await app.typeCode('int b = 2;\n');
+  expect(await app.editorValue()).toContain('int b = 2;');
+
+  const zipPath = await app.exportCurrentTab();
+
+  // チェーンは復元をまたいでも valid。
+  const result = runVerifyCli(zipPath);
+  expect(result.passed, result.stdout + result.stderr).toBe(true);
+  expect(result.stdout).toContain('Verification PASSED');
+
+  // sessionResumed イベントが記録されている (復元の痕跡)。
+  const events = await readProofEvents(zipPath);
+  expect(events.some((e) => e.type === 'sessionResumed')).toBe(true);
+});

--- a/packages/e2e/tests/screen-share.spec.ts
+++ b/packages/e2e/tests/screen-share.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+import { EditorApp, readProofEvents, listZipEntries } from './helpers/app.js';
+import { runVerifyCli } from './helpers/verifyCli.js';
+
+/**
+ * 画面共有: casual のバナーから画面共有を有効化すると getDisplayMedia で本物の
+ * MediaStream を取得し、screenShareStart と初期キャプチャ (screenshotCapture) が
+ * チェーンに記録され、export ZIP に screenshots/ が含まれ、検証が pass する。
+ *
+ * headless では fake-media フラグ (playwright.config) で getDisplayMedia が monitor の
+ * fake ストリームを返すため、ピッカー UI 無しでキャプチャ経路を end-to-end 検証できる。
+ */
+test('画面共有を有効化すると screenShareStart とスクショがチェーンに記録される', async ({ page }) => {
+  const app = new EditorApp(page);
+  await app.openCasualFresh();
+
+  await app.enableScreenShare();
+  await app.typeCode('int s = 1;\n');
+  // 画面共有開始時の初期キャプチャがチェーンと IndexedDB に載るのを待つ。
+  await app.waitForSynced();
+
+  const zipPath = await app.exportCurrentTab();
+  const events = await readProofEvents(zipPath);
+
+  // 画面共有開始とスクショキャプチャが記録されている。
+  expect(events.some((e) => e.type === 'screenShareStart'), 'screenShareStart recorded').toBe(true);
+  expect(
+    events.filter((e) => e.type === 'screenshotCapture').length,
+    'screenshotCapture recorded',
+  ).toBeGreaterThan(0);
+
+  // export ZIP に screenshots/ が含まれる (実画像が同梱される)。
+  const entries = await listZipEntries(zipPath);
+  expect(entries.some((n) => /screenshots?\//i.test(n)), 'zip should contain screenshots/').toBe(true);
+
+  // チェーンは valid。
+  const result = runVerifyCli(zipPath);
+  expect(result.passed, result.stdout + result.stderr).toBe(true);
+  expect(result.stdout).toContain('Verification PASSED');
+});

--- a/packages/editor/src/ui/tabs/TabManager.ts
+++ b/packages/editor/src/ui/tabs/TabManager.ts
@@ -1171,6 +1171,8 @@ export class TabManager {
       }
 
       // 3. SerializedProofStateを構築（pendingEventsは復元しない）
+      // sessionStartToken (ADR-0017) を必ず引き継ぐ。落とすと casual/class の
+      // サーバアンカーが失われ、リロード後の proof が root 不一致で検証不能になる。
       const proofState: SerializedProofState = {
         events,
         currentHash,
@@ -1178,6 +1180,7 @@ export class TabManager {
         startTime: lightweightTab.proofState.startTime,
         checkpoints: lightweightTab.proofState.checkpoints,
         examContext: lightweightTab.proofState.examContext,
+        sessionStartToken: lightweightTab.proofState.sessionStartToken ?? null,
       };
 
       // 4. TypingProofを復元


### PR DESCRIPTION
## 概要

E2E ハーネス Phase C。モードルーティング・リロード復元・画面共有を追加し、**リロードで proof が検証不能になる実バグを発見・修正**した。

## 🐛 発見・修正したバグ (重要)

**リロードすると casual/class の proof が検証不能になる** (`fix(editor)`)。

`TabManager.loadFromStorageV2` が sessionStorage の lightweight 状態から `SerializedProofState` を手組みする際、`examContext` は引き継ぐのに **`sessionStartToken` (ADR-0017) を落としていた**。このため casual/class でページをリロードすると serverNonce ベースの root アンカーが失われ、proof の root が「fingerprint と nonce に一致しない」となり検証が FAIL する。

`serializeLightweightState` は token を保存済み・型も持つので、復元側で 1 行引き継ぐだけで修正。V1 経路は完全状態を渡すため元から無問題。**editor の復元ロジックと shared の検証ロジックをまたぐため単体テストでは捕捉できず、E2E reload-recovery (編集→リロード→export→verify) で初めて発覚した。**

## E2E シナリオ (Phase C: 6本・全 green。A+B 含め計 13本 green)

- **mode-routing** (4): `/`・未知パスはランディング (エディタ非初期化・4モードカード)、`/casual` は明示ルートでエディタ起動、ランディングカードから `/casual` へ遷移
- **reload-recovery**: 編集→リロード→復元→追記→export→verify-cli が pass、チェーンがリロードをまたいで継続し sessionResumed が記録される
- **screen-share**: 画面共有を有効化 → getDisplayMedia で本物の MediaStream 取得 → screenShareStart + 初期スクショがチェーンに記録 → ZIP に screenshots/ 同梱 → 検証 pass

## インフラ
- `playwright.config`: chromium に fake-media フラグを追加し、headless でも getDisplayMedia が monitor の fake ストリームを返すようにした (画面共有のキャプチャ経路を end-to-end 検証)。他テストは getDisplayMedia を呼ばないため影響なし。
- `app.ts`: reloadAndResume / waitForSynced (リロード前に IndexedDB 同期 + PoSW キューの掃けを待ち、未 flush イベントの取り残しを防ぐ) / enableScreenShare / listZipEntries。

## Phase D 以降に送るもの
フルスクリーン (exam ゲート + .tcexam fixture が必要) / Turnstile 失敗分岐 / 敵対的パック (複数行 AI 一括投入) / staging カナリア / ブラウザマトリクス。macOS ネイティブ全画面・実 Turnstile チャレンジ・実ディスプレイの画面共有ピッカーは手動スモーク。

## テスト
- E2E 13 シナリオ全 green (ローカル)
- editor 95 / shared 381 ユニットテスト pass、全ワークスペース typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)