### PR TITLE
test(e2e): Phase D 敵対的パック (AI 一括投入検出 + proof 偽造) + insertParagraph 検出漏れ修正

### DIFF
--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -90,6 +90,18 @@ shared の main が raw TypeScript のため `node dist/cli.js` は動かない
 > reload-recovery は実装の **sessionStartToken 喪失バグ** (リロードで root アンカーが落ち
 > proof が検証不能になる) を発見し、`editor` 側で修正した (editor↔shared をまたぐ統合バグ)。
 
-Phase D で敵対的パック (複数行 AI 一括投入など) / フルスクリーン (exam ゲート + .tcexam fixture) /
-Turnstile 失敗分岐 / staging カナリア / ブラウザマトリクスを追加予定。
-macOS ネイティブ全画面・実 Turnstile チャレンジ・実ディスプレイの画面共有ピッカーは手動スモーク。
+**Phase D (敵対的パック)**
+
+| ファイル | 検証内容 |
+|---|---|
+| ai-bulk-insert.spec.ts | Copilot/snippet 相当の単一編集での複数行コード投入 → Pure Typing: NO / 外部入力 / bulk として検出。打鍵は YES (区別) |
+| proof-forgery.spec.ts | export 済み proof への 5 種の偽造 (nonce/fingerprint/複製/順序入替/切り詰め) を verify-cli が全て exit 1 で拒否 |
+
+> ai-bulk-insert は実装の **検出漏れ** (executeEdits の複数行投入が insertParagraph で記録され
+> bulk 検出を素通り) を発見し `shared` で修正した。内部ペースト (自分のコード) は監査マーカーと
+> 同一内容を許可リスト化して誤検知を回避。AI 一括投入を実ブラウザで再現するため editor に
+> dev 限定フック `__tcTestInsertBlock` (本番ビルドで除去) を追加。
+
+残り (フルスクリーン = exam ゲート + .tcexam fixture / Turnstile 失敗分岐 / staging カナリア /
+ブラウザマトリクス) は今後。macOS ネイティブ全画面・実 Turnstile チャレンジ・実ディスプレイの
+画面共有ピッカーは手動スモーク。

--- a/packages/e2e/tests/ai-bulk-insert.spec.ts
+++ b/packages/e2e/tests/ai-bulk-insert.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+import { EditorApp, readProofEvents } from './helpers/app.js';
+import { runVerifyCliWithAnalysis } from './helpers/verifyCli.js';
+
+const CODE_BLOCK = 'int compute(int a, int b) {\n  int r = a * b;\n  return r;\n}\n';
+
+/**
+ * 敵対的: Copilot/Cursor のように「AI が生成したコード全体を 1 つの編集で一気に投入する」
+ * 挙動 (snippet 展開も同型) を再現し、proof に痕跡が残り後から検出できることを実ブラウザで
+ * 実証する。Monaco の executeEdits は複数行を単一の insertParagraph として記録するため、
+ * 1 文字ずつの打鍵 (benign) とは区別される。
+ */
+test('複数行コードの一括投入は記録され Pure Typing: NO / 外部入力として検出される', async ({ page }) => {
+  const app = new EditorApp(page);
+  await app.openCasualFresh();
+  await app.typeCode('// solution\n');
+  await app.injectCodeBlock(CODE_BLOCK);
+  await app.waitForSynced();
+
+  const zipPath = await app.exportCurrentTab();
+
+  // 単一の contentChange に複数行コードが載っている (1 文字ずつではない)。
+  const events = await readProofEvents(zipPath);
+  const bulk = events.find(
+    (e) => e.type === 'contentChange' && typeof e.data === 'string' && /[\r\n]/.test(e.data) && /\S/.test(e.data),
+  );
+  expect(bulk, 'a multi-line code contentChange should be recorded').toBeTruthy();
+  expect(bulk?.data).toContain('int compute');
+
+  const result = runVerifyCliWithAnalysis(zipPath);
+  // チェーンは valid (実際の編集なので改ざんではない) が、advisory で確実に検出される。
+  expect(result.passed, result.stdout + result.stderr).toBe(true);
+  expect(result.stdout).toContain('Pure Typing: NO');
+  expect(result.stdout).toMatch(/[1-9]\d* external input/);
+  // 分析シグナルに外部入力 (bulk insertion) が立つ。
+  expect(result.analysis[0]!.valid).toBe(true);
+});
+
+/**
+ * 対照: 同じコードを 1 文字ずつ打鍵すると (括弧自動閉じ等を含んでも) Pure Typing: YES。
+ * 「一括投入」と「正規の打鍵」を分析層が区別できることを示す。
+ */
+test('同じコードを打鍵した場合は Pure Typing: YES (一括投入と区別される)', async ({ page }) => {
+  const app = new EditorApp(page);
+  await app.openCasualFresh();
+  await app.typeCode('int g() {\n  return 1;\n}\n');
+  await app.waitForSynced();
+
+  const zipPath = await app.exportCurrentTab();
+  const result = runVerifyCliWithAnalysis(zipPath);
+  expect(result.passed, result.stdout + result.stderr).toBe(true);
+  expect(result.stdout).toContain('Pure Typing: YES');
+  expect(result.stdout).toMatch(/0 external input/);
+});

--- a/packages/e2e/tests/helpers/app.ts
+++ b/packages/e2e/tests/helpers/app.ts
@@ -159,6 +159,21 @@ export class EditorApp {
     await btn.click();
   }
 
+  /**
+   * Copilot/Cursor や snippet 展開のように「1 つの編集でコード全体を一気に投入する」挙動を
+   * 再現する。dev 限定テストフック (__tcTestInsertBlock) 経由で Monaco の executeEdits を
+   * 1 回だけ適用するので、複数行が単一の contentChange (insertParagraph) として記録される。
+   * 通常のキー入力では Monaco が 1 文字ずつに分解してしまい再現できない。
+   */
+  async injectCodeBlock(code: string): Promise<void> {
+    await this.focusEditor();
+    await this.page.evaluate((text) => {
+      const fn = (window as unknown as { __tcTestInsertBlock?: (t: string) => void }).__tcTestInsertBlock;
+      if (!fn) throw new Error('__tcTestInsertBlock not available (dev hook missing)');
+      fn(text);
+    }, code);
+  }
+
   /** 新規タブを追加する。 */
   async addTab(): Promise<void> {
     const before = await this.page.locator('#editor-tabs .editor-tab, #editor-tabs [role="tab"]').count();

--- a/packages/e2e/tests/proof-forgery.spec.ts
+++ b/packages/e2e/tests/proof-forgery.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '@playwright/test';
+import { EditorApp, extractProofJson } from './helpers/app.js';
+import { runVerifyCli } from './helpers/verifyCli.js';
+
+/**
+ * 敵対的 (負のオラクル群): 本物の export 済み proof に対する代表的な偽造を verify-cli が
+ * すべて拒否する (exit 1) ことを確認する。1 種でも素通りすると「壊れた検証器」になる。
+ * export は重い (PoSW) ので 1 回だけ行い、同じ proof に複数の偽造を適用する。
+ */
+type Proof = Record<string, unknown>;
+interface Tp {
+  initialHashNonce?: string;
+  initialEventChainHash?: string;
+  [k: string]: unknown;
+}
+interface Ev {
+  hash?: string;
+  previousHash?: string;
+  data?: unknown;
+  [k: string]: unknown;
+}
+
+function events(p: Proof): Ev[] {
+  return ((p.proof as { events?: Ev[] })?.events ?? []);
+}
+function tp(p: Proof): Tp {
+  return (p.typingProofData as Tp) ?? {};
+}
+
+test('export した proof への各種偽造を verify-cli がすべて拒否する', async ({ page }) => {
+  const app = new EditorApp(page);
+  await app.openCasualFresh();
+  await app.typeCode('int total = 0;\ntotal = total + 1;\n');
+  await app.waitForSynced();
+  const zipPath = await app.exportCurrentTab();
+
+  // positive control: 無改ざんは pass。
+  const clean = runVerifyCli(await extractProofJson(zipPath));
+  expect(clean.passed, 'unmodified proof should pass\n' + clean.stdout).toBe(true);
+
+  // ① root 偽造: 初期ハッシュ nonce を 1 文字書き換える → root がどちらの式にも一致しない。
+  const nonceForged = await extractProofJson(zipPath, (p) => {
+    const t = tp(p);
+    if (typeof t.initialHashNonce !== 'string') throw new Error('no initialHashNonce');
+    t.initialHashNonce = flip(t.initialHashNonce);
+  });
+  expect(runVerifyCli(nonceForged).exitCode, 'forged nonce must be rejected').toBe(1);
+
+  // ② fingerprint 偽造: deviceId と紐づく fingerprint.hash を書き換える。
+  const fpForged = await extractProofJson(zipPath, (p) => {
+    const fp = p.fingerprint as { hash?: string } | undefined;
+    if (!fp || typeof fp.hash !== 'string') throw new Error('no fingerprint.hash');
+    fp.hash = flip(fp.hash);
+  });
+  expect(runVerifyCli(fpForged).exitCode, 'forged fingerprint must be rejected').toBe(1);
+
+  // ③ リプレイ (イベント複製): 中ほどのイベントを複製挿入 → sequence/チェーンが破綻。
+  const replayed = await extractProofJson(zipPath, (p) => {
+    const ev = events(p);
+    const mid = Math.floor(ev.length / 2);
+    if (ev.length < 4) throw new Error('too few events');
+    ev.splice(mid, 0, JSON.parse(JSON.stringify(ev[mid])));
+  });
+  expect(runVerifyCli(replayed).exitCode, 'duplicated/replayed event must be rejected').toBe(1);
+
+  // ④ 切り貼り (イベント順序入替): 隣接する 2 イベントを入れ替える → previousHash チェーンが切れる。
+  const reordered = await extractProofJson(zipPath, (p) => {
+    const ev = events(p);
+    const i = Math.floor(ev.length / 2);
+    if (i + 1 >= ev.length) throw new Error('too few events');
+    const tmp = ev[i]!;
+    ev[i] = ev[i + 1]!;
+    ev[i + 1] = tmp;
+  });
+  expect(runVerifyCli(reordered).exitCode, 'reordered/spliced events must be rejected').toBe(1);
+
+  // ⑤ 末尾イベント削除 (切り詰め): finalEventChainHash と最終ハッシュが食い違う。
+  const truncated = await extractProofJson(zipPath, (p) => {
+    const ev = events(p);
+    if (ev.length < 2) throw new Error('too few events');
+    ev.pop();
+  });
+  expect(runVerifyCli(truncated).exitCode, 'truncated chain must be rejected').toBe(1);
+});
+
+/** 16 進文字列の先頭 1 文字を別の値へ反転する。 */
+function flip(hex: string): string {
+  const c = hex[0] === '0' ? '1' : '0';
+  return c + hex.slice(1);
+}

--- a/packages/e2e/tests/proof-forgery.spec.ts
+++ b/packages/e2e/tests/proof-forgery.spec.ts
@@ -6,6 +6,10 @@ import { runVerifyCli } from './helpers/verifyCli.js';
  * 敵対的 (負のオラクル群): 本物の export 済み proof に対する代表的な偽造を verify-cli が
  * すべて拒否する (exit 1) ことを確認する。1 種でも素通りすると「壊れた検証器」になる。
  * export は重い (PoSW) ので 1 回だけ行い、同じ proof に複数の偽造を適用する。
+ *
+ * 検証は `--mode fast` (PoSW 再計算をスキップ・改ざん耐性のみ) を使う。ここで試す偽造は
+ * すべて root / ハッシュチェーン / メタデータの破綻であり PoSW とは無関係なので fast で
+ * 検出でき、遅い CI ランナーで full 再計算を 6 回回す必要がない (タイムアウト回避)。
  */
 type Proof = Record<string, unknown>;
 interface Tp {
@@ -35,7 +39,7 @@ test('export した proof への各種偽造を verify-cli がすべて拒否す
   const zipPath = await app.exportCurrentTab();
 
   // positive control: 無改ざんは pass。
-  const clean = runVerifyCli(await extractProofJson(zipPath));
+  const clean = runVerifyCli(await extractProofJson(zipPath), ["--mode", "fast"]);
   expect(clean.passed, 'unmodified proof should pass\n' + clean.stdout).toBe(true);
 
   // ① root 偽造: 初期ハッシュ nonce を 1 文字書き換える → root がどちらの式にも一致しない。
@@ -44,7 +48,7 @@ test('export した proof への各種偽造を verify-cli がすべて拒否す
     if (typeof t.initialHashNonce !== 'string') throw new Error('no initialHashNonce');
     t.initialHashNonce = flip(t.initialHashNonce);
   });
-  expect(runVerifyCli(nonceForged).exitCode, 'forged nonce must be rejected').toBe(1);
+  expect(runVerifyCli(nonceForged, ["--mode", "fast"]).exitCode, 'forged nonce must be rejected').toBe(1);
 
   // ② fingerprint 偽造: deviceId と紐づく fingerprint.hash を書き換える。
   const fpForged = await extractProofJson(zipPath, (p) => {
@@ -52,7 +56,7 @@ test('export した proof への各種偽造を verify-cli がすべて拒否す
     if (!fp || typeof fp.hash !== 'string') throw new Error('no fingerprint.hash');
     fp.hash = flip(fp.hash);
   });
-  expect(runVerifyCli(fpForged).exitCode, 'forged fingerprint must be rejected').toBe(1);
+  expect(runVerifyCli(fpForged, ["--mode", "fast"]).exitCode, 'forged fingerprint must be rejected').toBe(1);
 
   // ③ リプレイ (イベント複製): 中ほどのイベントを複製挿入 → sequence/チェーンが破綻。
   const replayed = await extractProofJson(zipPath, (p) => {
@@ -61,7 +65,7 @@ test('export した proof への各種偽造を verify-cli がすべて拒否す
     if (ev.length < 4) throw new Error('too few events');
     ev.splice(mid, 0, JSON.parse(JSON.stringify(ev[mid])));
   });
-  expect(runVerifyCli(replayed).exitCode, 'duplicated/replayed event must be rejected').toBe(1);
+  expect(runVerifyCli(replayed, ["--mode", "fast"]).exitCode, 'duplicated/replayed event must be rejected').toBe(1);
 
   // ④ 切り貼り (イベント順序入替): 隣接する 2 イベントを入れ替える → previousHash チェーンが切れる。
   const reordered = await extractProofJson(zipPath, (p) => {
@@ -72,7 +76,7 @@ test('export した proof への各種偽造を verify-cli がすべて拒否す
     ev[i] = ev[i + 1]!;
     ev[i + 1] = tmp;
   });
-  expect(runVerifyCli(reordered).exitCode, 'reordered/spliced events must be rejected').toBe(1);
+  expect(runVerifyCli(reordered, ["--mode", "fast"]).exitCode, 'reordered/spliced events must be rejected').toBe(1);
 
   // ⑤ 末尾イベント削除 (切り詰め): finalEventChainHash と最終ハッシュが食い違う。
   const truncated = await extractProofJson(zipPath, (p) => {
@@ -80,7 +84,7 @@ test('export した proof への各種偽造を verify-cli がすべて拒否す
     if (ev.length < 2) throw new Error('too few events');
     ev.pop();
   });
-  expect(runVerifyCli(truncated).exitCode, 'truncated chain must be rejected').toBe(1);
+  expect(runVerifyCli(truncated, ["--mode", "fast"]).exitCode, 'truncated chain must be rejected').toBe(1);
 });
 
 /** 16 進文字列の先頭 1 文字を別の値へ反転する。 */

--- a/packages/editor/src/main.ts
+++ b/packages/editor/src/main.ts
@@ -215,6 +215,21 @@ const editor: MonacoEditor = monaco.editor.create(editorContainer, {
   wrappingIndent: 'indent',
 });
 
+// E2E テスト専用フック (dev ビルドのみ。本番では import.meta.env.DEV=false で除去される)。
+// Copilot/Cursor や snippet 展開のように「1 つの編集でコード全体を一気に投入する」挙動を
+// 再現するため、現在の選択位置に単一の executeEdits を適用する。通常のキー入力 API では
+// Monaco が 1 文字ずつに分解してしまい、この一括投入経路を E2E で再現できないため用意する。
+if (import.meta.env.DEV) {
+  (window as unknown as { __tcTestInsertBlock?: (text: string) => void }).__tcTestInsertBlock = (
+    text: string,
+  ) => {
+    const selection = editor.getSelection();
+    if (!selection) return;
+    editor.focus();
+    editor.executeEdits('e2e-bulk-insert', [{ range: selection, text, forceMoveMarkers: true }]);
+  };
+}
+
 // アプリケーションコンテキストの初期化
 const ctx: AppContext = {
   // Monaco Editor

--- a/packages/shared/src/analysis/analyzers/pureTypingAnalyzer.ts
+++ b/packages/shared/src/analysis/analyzers/pureTypingAnalyzer.ts
@@ -10,7 +10,7 @@
 
 import type { AnalysisInput, AnalysisSignal, Analyzer, EvidenceRef } from '../types.js';
 import { isProhibitedInputType } from '../../typingProof/InputTypeValidator.js';
-import { isBenignEditorInsert, isMultiLineBulkInsert } from '../../typingProof/structuralEdit.js';
+import { isBenignEditorInsert, isFlaggedBulkInsert, collectInternalPasteContents } from '../../typingProof/structuralEdit.js';
 
 const ID = 'example-pure-typing';
 
@@ -28,11 +28,12 @@ export const pureTypingAnalyzer: Analyzer = {
     let dropCount = 0;
     let bulkCount = 0;
     const events = input.proof.proof?.events ?? [];
+    const internalPasteContents = collectInternalPasteContents(events);
     for (let i = 0; i < events.length; i++) {
       const event = events[i];
       if (!event) continue;
       const inputType = event.inputType;
-      if (isMultiLineBulkInsert(event)) {
+      if (isFlaggedBulkInsert(event, internalPasteContents)) {
         // 複数行のコード一括投入 (Copilot/Cursor が Tab で全体投入する類)。最も注視すべき痕跡。
         bulkCount++;
         evidence.push({ fromEventIndex: i, note: `multiline-bulk:${inputType ?? 'insert'}` });

--- a/packages/shared/src/processSummary.ts
+++ b/packages/shared/src/processSummary.ts
@@ -15,7 +15,7 @@
 import type { StoredEvent } from './types/proof.js';
 import type { CodeExecutionEventData, FocusChangeData, ReflectionNoteData } from './types/events.js';
 import { isProhibitedInputType } from './typingProof/InputTypeValidator.js';
-import { isBenignEditorInsert, isMultiLineBulkInsert } from './typingProof/structuralEdit.js';
+import { isBenignEditorInsert, isFlaggedBulkInsert, collectInternalPasteContents } from './typingProof/structuralEdit.js';
 
 /** 編集の停止 (考え中) とみなす contentChange 間ギャップの下限。 */
 export const PROCESS_PAUSE_THRESHOLD_MS = 10_000;
@@ -80,6 +80,8 @@ export interface ProcessSummary {
  */
 export function summarizeProcess(events: readonly StoredEvent[]): ProcessSummary {
   const moments: ProcessKeyMoment[] = [];
+  // 内部ペースト (自分のコード) の実挿入を AI 一括投入と取り違えないための許可リスト。
+  const internalPasteContents = collectInternalPasteContents(events);
 
   let contentChangeCount = 0;
   let insertedChars = 0;
@@ -272,7 +274,7 @@ export function summarizeProcess(events: readonly StoredEvent[]): ProcessSummary
     // 明示的に拾う)。後者は「コード全体を Tab で一気に入れる」類を記録・検出するため。
     if (
       (event.inputType && isProhibitedInputType(event.inputType) && !isBenignEditorInsert(event)) ||
-      isMultiLineBulkInsert(event)
+      isFlaggedBulkInsert(event, internalPasteContents)
     ) {
       externalInputCount++;
       if (externalMoments.length < PROCESS_MAX_EXTERNAL_INPUT_MOMENTS) {

--- a/packages/shared/src/typingProof/__tests__/structuralEdit.test.ts
+++ b/packages/shared/src/typingProof/__tests__/structuralEdit.test.ts
@@ -3,6 +3,8 @@ import {
   getEditorAssistDeclaration,
   isBenignEditorInsert,
   isMultiLineBulkInsert,
+  isFlaggedBulkInsert,
+  collectInternalPasteContents,
 } from '../structuralEdit.js';
 import type { StoredEvent, EditorAssistDeclaration } from '../../types.js';
 
@@ -43,6 +45,14 @@ describe('isBenignEditorInsert', () => {
     expect(isBenignEditorInsert(insert('printf', 'insertFromPaste'))).toBe(false);
   });
 
+  it('accepts a whitespace-only insertParagraph (auto-indent expansion)', () => {
+    expect(isBenignEditorInsert(insert('\r\n      ', 'insertParagraph'))).toBe(true);
+  });
+
+  it('rejects a code-bearing insertParagraph (AI/snippet multi-line block)', () => {
+    expect(isBenignEditorInsert(insert('x = 1;\n  y = 2;', 'insertParagraph'))).toBe(false);
+  });
+
   it('rejects an empty insert', () => {
     expect(isBenignEditorInsert(insert('', 'insertText'))).toBe(false);
   });
@@ -67,6 +77,37 @@ describe('isMultiLineBulkInsert', () => {
 
   it('does NOT flag a real multi-line paste (handled as paste, not editor-internal)', () => {
     expect(isMultiLineBulkInsert(insert('a;\nb;', 'insertFromPaste'))).toBe(false);
+  });
+
+  it('flags a code-bearing insertParagraph (programmatic / AI multi-line insertion)', () => {
+    expect(isMultiLineBulkInsert(insert('int r = a * b;\n  return r;', 'insertParagraph'))).toBe(true);
+  });
+
+  it('does NOT flag a whitespace-only insertParagraph (auto-indent has no code)', () => {
+    expect(isMultiLineBulkInsert(insert('\r\n    \r\n', 'insertParagraph'))).toBe(false);
+  });
+});
+
+describe('isFlaggedBulkInsert (内部ペースト除外)', () => {
+  const code = 'int helper = 7;\r\n';
+
+  it('flags an AI/external multi-line block when no internal-paste audit matches', () => {
+    expect(isFlaggedBulkInsert(insert(code, 'insertParagraph'), new Set())).toBe(true);
+  });
+
+  it('does NOT flag a multi-line insert whose content matches an internal-paste audit', () => {
+    const internal = new Set([code]);
+    expect(isFlaggedBulkInsert(insert(code, 'insertParagraph'), internal)).toBe(false);
+  });
+
+  it('collectInternalPasteContents gathers insertFromInternalPaste data', () => {
+    const events = [
+      insert('a', 'insertText'),
+      insert(code, 'insertFromInternalPaste'),
+    ];
+    const set = collectInternalPasteContents(events as never);
+    expect(set.has(code)).toBe(true);
+    expect(set.size).toBe(1);
   });
 });
 

--- a/packages/shared/src/typingProof/structuralEdit.ts
+++ b/packages/shared/src/typingProof/structuralEdit.ts
@@ -25,11 +25,16 @@ import type { StoredEvent, EditorAssistDeclaration } from '../types.js';
 /** 構造文字: 括弧・クォート・空白。これらだけなら「内容 (コード)」を運べない。 */
 const STRUCTURAL_CHARS = /^[()\[\]{}<>"'`\s]+$/;
 
-/** editor 内部由来の挿入/置換 inputType (実ペースト/ドロップは含めない)。 */
+/**
+ * editor 内部由来の挿入/置換 inputType (実ペースト/ドロップは含めない)。
+ * `insertParagraph` は Monaco が「複数行テキストの単一挿入」(auto-indent 展開・AI/snippet の
+ * 一括投入・programmatic insertText) に付ける。空白のみなら benign、コードを含めば bulk。
+ */
 const EDITOR_INTERNAL_INSERT: ReadonlySet<string> = new Set([
   'insertText',
   'insertReplacementText',
   'replaceContent',
+  'insertParagraph',
 ]);
 
 function isEditorInternalInsert(event: StoredEvent): boolean {
@@ -80,4 +85,34 @@ export function isMultiLineBulkInsert(event: StoredEvent): boolean {
   const data = event.data;
   if (typeof data !== 'string') return false;
   return /[\r\n]/.test(data) && /\S/.test(data);
+}
+
+/**
+ * events から内部ペースト (自分のコードのコピペ = 許可) の挿入内容を集める。
+ * 内部ペーストは `insertFromInternalPaste` の監査マーカー (rangeOffset==null) を伴い、
+ * 実際の挿入は別途 contentChange (複数行なら insertParagraph) として記録される。後者を
+ * AI 一括投入と取り違えないよう、監査マーカーと同一内容を許可リスト化する。
+ */
+export function collectInternalPasteContents(events: readonly StoredEvent[]): Set<string> {
+  const out = new Set<string>();
+  for (const event of events) {
+    if (event?.inputType === 'insertFromInternalPaste' && typeof event.data === 'string') {
+      out.add(event.data);
+    }
+  }
+  return out;
+}
+
+/**
+ * 複数行 bulk 挿入のうち「記録・検出すべきもの」か (内部ペーストの実挿入は除外する)。
+ * `internalPasteContents` は collectInternalPasteContents の結果を渡す。
+ */
+export function isFlaggedBulkInsert(
+  event: StoredEvent,
+  internalPasteContents: ReadonlySet<string>,
+): boolean {
+  if (!isMultiLineBulkInsert(event)) return false;
+  // 内部ペースト (自分のコード) の実挿入は許可。AI/外部の一括投入だけ残す。
+  if (typeof event.data === 'string' && internalPasteContents.has(event.data)) return false;
+  return true;
 }

--- a/packages/shared/src/verification.ts
+++ b/packages/shared/src/verification.ts
@@ -23,7 +23,7 @@ export {
 
 import { deterministicStringify, computeHash } from './utils/hashUtils.js';
 import { computeExamChainRoot } from './exam/examPackage.js';
-import { isBenignEditorInsert } from './typingProof/structuralEdit.js';
+import { isBenignEditorInsert, isFlaggedBulkInsert, collectInternalPasteContents } from './typingProof/structuralEdit.js';
 import { POSW_ITERATIONS, EXAM_ROOT_BINDING_V2 } from './version.js';
 import {
   verifyProofSignedCheckpoints,
@@ -419,12 +419,15 @@ function recomputeProofMetadata(events: StoredEvent[]): ProofMetadataVerificatio
   let insertEvents = 0;
   let deleteEvents = 0;
   const suspiciousBulkInsertEventIndexes: number[] = [];
-  // 「1 キー入力 → 複数文字」の正規な editor 挿入 (括弧自動閉じ・type-over・auto-indent・
-  // 単一行補完) を除いた bulk insert 数。isPureTyping の導出だけに使う。AI による複数行の
-  // 一括投入はここに残るので Pure Typing を崩す (= 検出される)。bulkInsertEvents の申告
-  // メタデータ照合 (verifyProofMetadata) は従来どおり全 bulk を数えるので、既存 proof との
-  // 後方互換と整合性チェックは保たれる。
+  // isPureTyping を崩す「正規でない bulk 挿入」の数。2 種を拾う:
+  //  (a) 従来の suspicious bulk (insertReplacementText/replaceContent/insertText>1/大内部ペースト)
+  //      のうち、括弧自動閉じ・単一行補完などの benign を除いたもの。
+  //  (b) 複数行の実コード一括投入 (AI/snippet)。Monaco は insertParagraph で記録するため
+  //      (a) の suspicious 判定には載らないので別途拾う。空白のみの auto-indent は除外。
+  // bulkInsertEvents の申告メタデータ照合 (verifyProofMetadata) は従来どおり suspicious のみ
+  // 数えるので、既存 proof との後方互換と整合性チェックは保たれる。
   let nonBenignBulkInsertCount = 0;
+  const internalPasteContents = collectInternalPasteContents(events);
 
   for (let i = 0; i < events.length; i++) {
     const event = events[i];
@@ -435,9 +438,11 @@ function recomputeProofMetadata(events: StoredEvent[]): ProofMetadataVerificatio
     if (event.inputType === 'insertFromDrop') dropEvents++;
     if (event.type === 'contentChange' && event.data) insertEvents++;
     if (event.inputType?.startsWith('delete')) deleteEvents++;
-    if (isSuspiciousBulkInsert(event)) {
-      suspiciousBulkInsertEventIndexes.push(i);
-      if (!isBenignEditorInsert(event)) nonBenignBulkInsertCount++;
+
+    const suspicious = isSuspiciousBulkInsert(event);
+    if (suspicious) suspiciousBulkInsertEventIndexes.push(i);
+    if ((suspicious && !isBenignEditorInsert(event)) || isFlaggedBulkInsert(event, internalPasteContents)) {
+      nonBenignBulkInsertCount++;
     }
   }
 


### PR DESCRIPTION
## 概要

E2E ハーネス Phase D。敵対的シナリオ (AI コード一括投入の検出 / proof 偽造の負のオラクル) を追加し、**AI 一括投入の検出漏れを発見・修正**した。

## 🐛 発見・修正した検出漏れ (重要)

**Copilot/Cursor が「コード全体を 1 編集で一気に投入」すると検出を素通りしていた** (`fix(shared)`)。

AI が `executeEdits` で複数行コードを 1 編集で投入すると Monaco は **`insertParagraph`** で記録する。Phase A の bulk 検出は `insertText`/`insertReplacementText`/`replaceContent` のみを対象にしていたため、この insertParagraph 経路を素通りし、**Pure Typing: YES のまま AI 一括投入を見逃していた**。Phase D の敵対的 E2E で発覚。

修正:
- `insertParagraph` を bulk 検出対象に追加。空白のみ (auto-indent) は benign、コードを含めば bulk。
- **内部ペーストの罠**: 自分のコードの内部コピペも実挿入は複数行 insertParagraph になり AI と区別できない。`insertFromInternalPaste` 監査マーカーと同一内容を許可リスト化して 3 経路 (verification / processSummary / pureTypingAnalyzer) で除外。
- `isPureTyping` を複数行 bulk でも崩すよう更新。**`bulkInsertEvents` 申告メタデータ照合・`valid` (暗号的合否) は不変で後方互換。**

## E2E シナリオ (Phase D: 3本・全 green。累計 16本 green)

- **ai-bulk-insert** (2): 単一編集での複数行コード投入 → Pure Typing: NO / 外部入力 / bulk insertion として検出。対照として同じコードの**打鍵は Pure Typing: YES** (一括投入と区別される)
- **proof-forgery**: export 済み proof への 5 種の偽造 (nonce/fingerprint 改ざん、イベント複製=リプレイ、順序入替=切り貼り、末尾切り詰め) を verify-cli が**すべて exit 1 で拒否**

## インフラ
- editor/main.ts に **dev 限定テストフック** `__tcTestInsertBlock` を追加 (executeEdits で単一編集の複数行投入を再現)。通常のキー入力 API では Monaco が 1 文字ずつに分解し再現できないため。`import.meta.env.DEV` ガードで**本番ビルドからは除去される**。
- app.ts: injectCodeBlock。

## テスト
- E2E 16 シナリオ全 green (ローカル)
- shared 388 / editor 95 ユニットテスト pass、全ワークスペース typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)