### PR TITLE
fix(editor): IndexedDB 復旧で sessionStartToken 消失 + 復旧分岐の配線漏れを修正 (#130, #141)

### DIFF
--- a/packages/e2e/tests/close-tab-recovery.spec.ts
+++ b/packages/e2e/tests/close-tab-recovery.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+import { EditorApp, readProofEvents, readProofJson } from './helpers/app.js';
+import { runVerifyCli } from './helpers/verifyCli.js';
+
+/**
+ * タブ閉じ復旧 (#130 回帰): ブラウザタブを閉じると sessionStorage は消えるが IndexedDB は
+ * 残る。再訪時に SessionRecoveryDialog から「再開」した場合も sessionStartToken (ADR-0017)
+ * が引き継がれ、アンカー済みセッションの proof が root 不一致にならず検証が pass する。
+ * リロード復元 (sessionStorage 経路 = reload-recovery.spec) と対になる IndexedDB 経路のテスト。
+ *
+ * 検証は `--mode fast`: #130 の破綻は root (initial event chain hash) 不一致であり
+ * PoSW 再計算とは無関係なので fast で検出できる (CI 時間の節約)。
+ */
+test('タブを閉じて復旧ダイアログから再開しても root アンカーが保持され検証が pass する', async ({ page, context }) => {
+  const app = new EditorApp(page);
+  await app.openCasualFresh();
+
+  await app.typeCode('int a = 1;\n');
+  await app.waitForSynced();
+
+  // ブラウザタブを閉じる = sessionStorage 消滅・IndexedDB は残る。
+  await page.close();
+
+  // 再訪 (?reset なし)。sessionStorage が無いので SessionRecoveryDialog が出るはず。
+  const page2 = await context.newPage();
+  const app2 = new EditorApp(page2);
+  await page2.goto('/casual');
+
+  // この経路では復旧ダイアログの出現自体がテストの前提 (出なければ復旧経路を通っていない)。
+  const resume = page2.locator('#session-resume-btn');
+  await resume.waitFor({ state: 'visible', timeout: 15_000 });
+  await resume.click();
+
+  await page2.locator('.monaco-editor .view-lines').first().waitFor({ state: 'visible' });
+  await expect.poll(() => app2.eventCount(), { timeout: 30_000 }).toBeGreaterThan(0);
+
+  // 復元されたエディタに前回の内容が残っている。
+  expect(await app2.editorValue()).toContain('int a = 1;');
+
+  // 復旧後にさらに打鍵してチェーンを伸ばし、export する。
+  await app2.typeCode('int b = 2;\n');
+  await app2.waitForSynced();
+  const zipPath = await app2.exportCurrentTab();
+
+  // #130 の核心: アンカー済みセッションの token が IndexedDB 復旧をまたいで proof に残る。
+  const proof = await readProofJson(zipPath);
+  expect(proof.rootAnchored, 'sessionStartToken must survive IndexedDB recovery').toBe(true);
+  expect(proof.sessionStartToken, 'proof must carry the session start token').toBeTruthy();
+
+  // チェーンは復旧をまたいでも valid (root 不一致なら fast でも即 fail する)。
+  const result = runVerifyCli(zipPath, ['--mode', 'fast']);
+  expect(result.passed, result.stdout + result.stderr).toBe(true);
+  expect(result.stdout).toContain('Verification PASSED');
+
+  // sessionResumed イベントが記録されている (復旧の痕跡)。
+  const events = await readProofEvents(zipPath);
+  expect(events.some((e) => e.type === 'sessionResumed')).toBe(true);
+});

--- a/packages/e2e/tests/helpers/app.ts
+++ b/packages/e2e/tests/helpers/app.ts
@@ -267,6 +267,15 @@ export interface ProofEvent {
   [k: string]: unknown;
 }
 
+/** ZIP 内の最初の proof.json 全体を読み出す (rootAnchored / sessionStartToken 等のトップレベル assert 用)。 */
+export async function readProofJson(zipPath: string): Promise<Record<string, unknown>> {
+  const buf = await readFileBuffer(zipPath);
+  const zip = await JSZip.loadAsync(buf);
+  const entryName = Object.keys(zip.files).find((n) => n.endsWith('_proof.json'));
+  if (!entryName) throw new Error(`no *_proof.json in ${zipPath}`);
+  return JSON.parse(await zip.files[entryName]!.async('string')) as Record<string, unknown>;
+}
+
 /** ZIP 内の最初の proof.json から events 配列を読み出す (イベント種別/isTrusted の検証用)。 */
 export async function readProofEvents(zipPath: string): Promise<ProofEvent[]> {
   const buf = await readFileBuffer(zipPath);

--- a/packages/editor/src/main.ts
+++ b/packages/editor/src/main.ts
@@ -405,9 +405,15 @@ async function initializeDeviceInfo(): Promise<{
   return { deviceId, fingerprintHash, fingerprintComponents };
 }
 
+/**
+ * TabManager と関連 UI/コールバックの配線を行う。
+ * recoverySessionId が渡された場合は IndexedDB からのセッション復旧として読み込む。
+ * 通常初期化と復旧で配線を共有する (分岐をコピペすると #141 のような配線漏れが再発する)。
+ */
 async function initializeTabManager(
   fingerprintHash: string,
-  fingerprintComponents: Awaited<ReturnType<typeof Fingerprint.collectComponents>>
+  fingerprintComponents: Awaited<ReturnType<typeof Fingerprint.collectComponents>>,
+  recoverySessionId?: string
 ): Promise<boolean> {
   ctx.tabManager = new TabManager(ctx.editor);
 
@@ -472,8 +478,19 @@ async function initializeTabManager(
     updateSyncStatusUI(status);
   });
 
-  updateInitMessage(t('notifications.initializingEditor'));
-  const initialized = await ctx.tabManager.initialize(fingerprintHash, fingerprintComponents);
+  let initialized: boolean;
+  if (recoverySessionId) {
+    // セッション復旧モード: IndexedDBからタブを読み込む
+    updateInitMessage(t('sessionRecovery.resuming'));
+    initialized = await ctx.tabManager.loadFromIndexedDB(
+      recoverySessionId,
+      fingerprintHash,
+      fingerprintComponents
+    );
+  } else {
+    updateInitMessage(t('notifications.initializingEditor'));
+    initialized = await ctx.tabManager.initialize(fingerprintHash, fingerprintComponents);
+  }
 
   // ContentRegistryに全タブのコンテンツ取得コールバックを設定
   // これにより、ペースト時に全タブのコンテンツから内部ペーストを判定できる
@@ -1328,74 +1345,13 @@ async function initializeApp(): Promise<void> {
   const { fingerprintHash, fingerprintComponents } = await initializeDeviceInfo();
 
   // Phase 4: TabManager初期化
-  let initialized: boolean;
-  if (sessionRecovered && sessionId) {
-    // セッション復旧モード: IndexedDBからタブを読み込む
-    ctx.tabManager = new TabManager(ctx.editor);
-
-    const editorTabsContainer = document.getElementById('editor-tabs');
-    if (editorTabsContainer) {
-      ctx.tabUIController = new TabUIController({
-        container: editorTabsContainer,
-        tabManager: ctx.tabManager,
-        basePath: import.meta.env.BASE_URL,
-      });
-    }
-
-    // ProofExporterの初期化
-    ctx.proofExporter.setTabManager(ctx.tabManager);
-    ctx.proofExporter.setProcessingDialog(ctx.processingDialog);
-    ctx.proofExporter.setCallbacks({ onNotification: showNotification });
-    if (ctx.trackers.screenshot) {
-      ctx.proofExporter.setScreenshotTracker(ctx.trackers.screenshot);
-    }
-
-    // ProofStatusDisplayのコールバックを設定
-    ctx.proofStatusDisplay.setGetStats(() => {
-      const activeProof = ctx.tabManager?.getActiveProof();
-      if (!activeProof) return null;
-      return activeProof.getStats();
-    });
-
-    ctx.proofStatusDisplay.setSnapshotCallback(
-      (content) => {
-        const activeProof = ctx.tabManager?.getActiveProof();
-        if (!activeProof) return Promise.reject(new Error('No active proof'));
-        return activeProof.recordContentSnapshot(content);
-      },
-      () => ctx.editor.getValue()
-    );
-
-    // タブ変更コールバックを設定
-    ctx.tabManager.setOnTabChange((tab, previousTab) => {
-      console.log('[TypedCode] Tab switched:', previousTab?.filename, '->', tab.filename);
-      handleTabChange(ctx, tab);
-
-      // ScreenshotTrackerのstartTimeを新しいタブのTypingProofに合わせて更新
-      if (ctx.trackers.screenshot) {
-        ctx.trackers.screenshot.setProofStartTime(tab.typingProof.startTime);
-      }
-    });
-
-    ctx.tabManager.setOnTabUpdate(() => {
-      ctx.tabUIController?.updateUI();
-      const activeTab = ctx.tabManager?.getActiveTab();
-      if (activeTab) {
-        document.title = `${activeTab.filename} - TypedCode`;
-      }
-    });
-
-    ctx.tabManager.setOnVerification(() => {
-      ctx.tabUIController?.updateUI();
-    });
-
-    // IndexedDBからタブを読み込む
-    updateInitMessage(t('sessionRecovery.resuming'));
-    initialized = await ctx.tabManager.loadFromIndexedDB(sessionId, fingerprintHash, fingerprintComponents);
-  } else {
-    // 通常モード: sessionStorageから読み込み or 新規作成
-    initialized = await initializeTabManager(fingerprintHash, fingerprintComponents);
-  }
+  // セッション復旧時は IndexedDB から読み込み、通常時は sessionStorage から読み込み or 新規作成。
+  // 配線は initializeTabManager に共通化 (復旧分岐のコピペは #141 の配線漏れを生んだ)
+  const initialized = await initializeTabManager(
+    fingerprintHash,
+    fingerprintComponents,
+    sessionRecovered && sessionId ? sessionId : undefined
+  );
 
   if (!initialized) {
     updateInitMessage(t('notifications.authFailedReload'));

--- a/packages/editor/src/ui/tabs/TabManager.ts
+++ b/packages/editor/src/ui/tabs/TabManager.ts
@@ -951,6 +951,7 @@ export class TabManager {
         verificationDetails: tab.verificationDetails,
         checkpoints: proofState.checkpoints,
         examContext: proofState.examContext,
+        sessionStartToken: proofState.sessionStartToken,
       };
       await this.sessionService.saveTab(tabData);
     }
@@ -1305,6 +1306,9 @@ export class TabManager {
             pendingEvents: [], // IndexedDB復元時はpendingEventsなし
             checkpoints: storedTab.checkpoints,
             examContext: storedTab.examContext,
+            // sessionStartToken (ADR-0017) を必ず引き継ぐ。落とすと casual/class の
+            // サーバアンカーが失われ、復旧後の proof が root 不一致で検証不能になる。
+            sessionStartToken: storedTab.sessionStartToken ?? null,
           },
           this.fingerprint,
           this.fingerprintComponents,


### PR DESCRIPTION
## 概要

2026-07 多角レビュー由来の critical #130 と、同じ復旧経路の medium #141 をまとめて修正する (Wave 1)。

### #130 — IndexedDB 復旧経路で sessionStartToken が消失 (critical)

`saveToIndexedDB` / `loadFromIndexedDB` が `sessionStartToken` (ADR-0017) を保存・復元しないため、casual/class/assignment のアンカー済みセッションで「ブラウザタブを閉じる → SessionRecoveryDialog で再開 → export」すると、チェーン根はアンカー済み root のままなのに proof は token 無し (`rootAnchored:false`) で出力され、verifier が root 不一致で **proof 全体を invalid** にしていた。学生に過失がないのに提出物が壊れる。

- `StoredTabData.sessionStartToken` (型フィールドは既存・未使用だった) に保存・復元を配線
- sessionStorage 経路 (リロード) は既に引き継いでおり、IDB 経路だけの欠落だった

### #141 — 復旧分岐のコールバック配線漏れ

復旧分岐が `initializeTabManager` のコピペで、`setOnSyncStatusChange` (同期 UI) と `contentRegistry.setGetAllContentsCallback` (内部ペースト判定) の 2 つだけ漏れていた。後者は復旧後に自コードの部分内部ペーストが `insertFromPaste` (禁止) 判定になり、正当な作業でピュアタイピング判定を壊す。

- `initializeTabManager` に `recoverySessionId` 引数を追加して復旧読み込みを共通化し、コピペ分岐を削除 (配線漏れの再発余地をなくす)

## テスト

- **e2e 回帰テスト追加**: `close-tab-recovery.spec.ts` — タブ閉じ → 復旧ダイアログ「再開」→ export → `rootAnchored:true` + verify-cli pass を assert。既存の `reload-recovery.spec.ts` (sessionStorage 経路) と対になる IndexedDB 経路のカバー
- **負のコントロール確認済み**: TabManager の修正を外すと本 spec は fail し、修正ありで pass する
- ローカルで `close-tab-recovery` + `reload-recovery` 両 spec pass、editor ユニット 95 件 pass、全パッケージ typecheck pass

Closes #130
Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)