### PR TITLE
fix(editor): tab.filename の innerHTML XSS を修正 (#133)

### DIFF
--- a/packages/editor/src/ui/tabs/TabUIController.ts
+++ b/packages/editor/src/ui/tabs/TabUIController.ts
@@ -4,6 +4,7 @@
  */
 
 import type { TabManager, TabState } from './TabManager.js';
+import { escapeHtml } from '@typedcode/shared';
 import {
   getLanguageDefinition,
   FILE_EXTENSIONS,
@@ -118,7 +119,7 @@ export class TabUIController {
 
     tabEl.innerHTML = `
       ${iconHtml}
-      <span class="tab-filename">${tab.filename}</span>
+      <span class="tab-filename">${escapeHtml(tab.filename)}</span>
       <span class="tab-extension">${ext}</span>
       ${verificationIndicator}
       <button class="tab-close-btn" title="Close Tab"><i class="fas fa-times"></i></button>


### PR DESCRIPTION
## 概要

2026-07 レビュー #133 (high/security)。タブバー描画 ([TabUIController.ts:122](https://github.com/shinyaoguri/typedcode/blob/develop/packages/editor/src/ui/tabs/TabUIController.ts)) で `tab.filename` が未エスケープのまま `innerHTML` に挿入されていた。

`.tcclass` は署名検証なし (構造検証のみ・`parseClassPackage` は filename の文字制限なし) で配布可能なため、細工した `starter.filename` でエディタコンテキストの任意 JS 実行 → 合成イベント注入・チェーン汚染が可能だった。

## 修正

- shared の `escapeHtml` を適用 (SessionRecoveryDialog / AuthorPage と同じ前例)
- 描画時エスケープなので、既に IndexedDB に保存済みの悪性 filename も無害化される
- 他の filename 出力箇所 (リネーム表示・閉じる確認) は `textContent` 経由で安全なことを確認済み

`parseClassPackage` 側での filename 文字制限 (defense-in-depth) は挙動変更 (パース拒否の厳格化) を伴うため本 PR には含めない。

## テスト

- editor ユニット 95 件 pass、typecheck pass

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)