### PR TITLE
fix(verify): ResultPanel / StatusBarUI の innerHTML XSS を修正 (#134)

### DIFF
--- a/packages/verify/src/ui/ResultPanel.ts
+++ b/packages/verify/src/ui/ResultPanel.ts
@@ -518,7 +518,7 @@ export class ResultPanel {
         const url = URL.createObjectURL(data.imageBlob);
         codeEl.innerHTML = `
           <div class="image-preview-container">
-            <img src="${url}" alt="${data.filename}" class="image-preview" onload="URL.revokeObjectURL(this.src)" />
+            <img src="${url}" alt="${escapeHtml(data.filename)}" class="image-preview" onload="URL.revokeObjectURL(this.src)" />
           </div>
         `;
       } else {
@@ -1476,8 +1476,8 @@ export class ResultPanel {
       const iconClass = issue.severity === 'error' ? 'fa-times-circle' : 'fa-exclamation-triangle';
       issueEl.innerHTML = `
         <i class="fas ${iconClass}"></i>
-        <span class="trust-issue-component">${this.getComponentLabel(issue.component)}</span>
-        <span class="trust-issue-message">${issue.message}</span>
+        <span class="trust-issue-component">${escapeHtml(this.getComponentLabel(issue.component))}</span>
+        <span class="trust-issue-message">${escapeHtml(issue.message)}</span>
       `;
 
       issuesContainer.appendChild(issueEl);

--- a/packages/verify/src/ui/StatusBarUI.ts
+++ b/packages/verify/src/ui/StatusBarUI.ts
@@ -1,6 +1,7 @@
 /**
  * StatusBarUI - Bottom status bar
  */
+import { escapeHtml } from '@typedcode/shared';
 import { t } from '../i18n/index.js';
 
 export class StatusBarUI {
@@ -13,7 +14,8 @@ export class StatusBarUI {
   }
 
   setQueueStatus(text: string, icon: string = 'check-circle'): void {
-    this.queueStatus.innerHTML = `<i class="fas fa-${icon}"></i><span>${text}</span>`;
+    // text には ZIP エントリ名やパースエラーメッセージ (攻撃者制御文字列) が入りうるため必ずエスケープする
+    this.queueStatus.innerHTML = `<i class="fas fa-${icon}"></i><span>${escapeHtml(text)}</span>`;
   }
 
   setFileCount(count: number): void {


### PR DESCRIPTION
## 概要

2026-07 レビュー #134 (high/security)。検証対象 ZIP は攻撃者が自由に作れる (学生が提出物を細工できる) ため、ZIP 由来の文字列が未エスケープで innerHTML に入ると**採点者のブラウザ**で XSS になる。3 箇所を修正:

1. **ResultPanel.renderIssuesList** — `issue.message` (TrustCalculator がソース不一致時に ZIP 内ファイル名を埋め込む) を `escapeHtml`。`getComponentLabel` も防御的にエスケープ
2. **ResultPanel.renderImage** — `alt="${data.filename}"` (ZIP 画像名)。`"` で属性ブレイクアウト可能だった
3. **StatusBarUI.setQueueStatus** — `setError` 経由で `JSONパースエラー: ${filename}` や V8 SyntaxError (入力断片をエコー) が HTML として入っていた

いずれも表示テキストは同一 (エスケープのみ) で互換影響なし。CSP 追加 (defense-in-depth) は別途。

## テスト

- verify の typecheck / build pass (verify はユニットテスト未整備 — #135 で器を作る際にエスケープ回帰テストを載せる予定)

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)