### PR TITLE
fix(verify): Web の ZIP 展開に zip 爆弾ガードを適用 (#149)

### DIFF
--- a/packages/shared/src/__tests__/zipBudget.test.ts
+++ b/packages/shared/src/__tests__/zipBudget.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import JSZip from 'jszip';
+import { assertZipWithinBudget } from '../fileProcessing/parser.js';
+
+/**
+ * zip 爆弾ガード (#149)。verify の ZipFileProcessor など shared の parser を経由しない
+ * 消費者からも呼ばれる public API なので、上限判定そのものを固定する。
+ */
+describe('assertZipWithinBudget', () => {
+  it('accepts a real zip round-tripped through JSZip', async () => {
+    const zip = new JSZip();
+    zip.file('proof.json', '{"proof":{}}');
+    zip.file('screenshots/1.png', new Uint8Array(1024));
+    const buf = await zip.generateAsync({ type: 'uint8array' });
+    const loaded = await JSZip.loadAsync(buf);
+
+    expect(() => assertZipWithinBudget(loaded)).not.toThrow();
+  });
+
+  it('rejects a zip with more entries than the entry budget', () => {
+    const files: Record<string, unknown> = {};
+    for (let i = 0; i <= 5000; i++) {
+      files[`f${i}`] = { _data: { uncompressedSize: 1 } };
+    }
+    const fake = { files } as unknown as JSZip;
+
+    expect(() => assertZipWithinBudget(fake)).toThrow(/too many entries/);
+  });
+
+  it('rejects a zip whose declared uncompressed total exceeds the size budget', () => {
+    const fake = {
+      files: {
+        'a.bin': { _data: { uncompressedSize: 200 * 1024 * 1024 } },
+        'b.bin': { _data: { uncompressedSize: 200 * 1024 * 1024 } },
+      },
+    } as unknown as JSZip;
+
+    expect(() => assertZipWithinBudget(fake)).toThrow(/uncompressed size exceeds/);
+  });
+});

--- a/packages/shared/src/fileProcessing/index.ts
+++ b/packages/shared/src/fileProcessing/index.ts
@@ -29,4 +29,5 @@ export {
   parseZipBuffer,
   extractFirstProofFromZip,
   extractAllProofsFromZip,
+  assertZipWithinBudget,
 } from './parser.js';

--- a/packages/shared/src/fileProcessing/parser.ts
+++ b/packages/shared/src/fileProcessing/parser.ts
@@ -28,8 +28,11 @@ const MAX_ZIP_ENTRIES = 5000;
  * 高圧縮率の悪意ある ZIP (zip bomb) で grader / 検証 UI を OOM/ハングさせないための事前ガード。
  * `JSZip.loadAsync` は解凍前のメタデータを持つので、エントリの解凍後サイズ合計を**展開前に**
  * 検査して上限超過なら throw する。
+ *
+ * parser 内の各エントリポイントが呼ぶほか、shared を経由せず JSZip を直接使う消費者
+ * (verify の ZipFileProcessor 等) も loadAsync 直後に必ず呼ぶこと (#149)。
  */
-function assertZipWithinBudget(zip: JSZip): void {
+export function assertZipWithinBudget(zip: JSZip): void {
   const names = Object.keys(zip.files);
   if (names.length > MAX_ZIP_ENTRIES) {
     throw new Error(`ZIP has too many entries (${names.length} > ${MAX_ZIP_ENTRIES})`);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -219,6 +219,7 @@ export {
   parseZipBuffer,
   extractFirstProofFromZip,
   extractAllProofsFromZip,
+  assertZipWithinBudget,
 } from './fileProcessing/index.js';
 
 // UI共通コンポーネント

--- a/packages/verify/src/services/ZipFileProcessor.ts
+++ b/packages/verify/src/services/ZipFileProcessor.ts
@@ -5,6 +5,7 @@
  */
 
 import JSZip from 'jszip';
+import { assertZipWithinBudget } from '@typedcode/shared';
 import type { ProofFile, ScreenshotManifest, VerifyScreenshot } from '../types.js';
 import type { ParsedFileData, FileProcessResult, FileProcessCallbacks } from './FileProcessor.js';
 import { ScreenshotService } from './ScreenshotService.js';
@@ -35,6 +36,10 @@ export class ZipFileProcessor {
       this.callbacks.onReadComplete?.(file.name, sizeKb);
 
       const zip = await JSZip.loadAsync(arrayBuffer);
+
+      // zip 爆弾ガード (#149): shared の parser 経由ではなく JSZip を直接使うため、
+      // 展開 (extractFiles) 前に解凍後サイズ・エントリ数の上限を検査する。
+      assertZipWithinBudget(zip);
 
       // ZIPファイル名をルートフォルダ名として使用
       const rootFolderName = file.name.replace(/\.zip$/i, '');


### PR DESCRIPTION
## 概要

2026-07 レビュー #149 (medium/security)。shared の `parseZipBuffer` 系には zip 爆弾ガード (`assertZipWithinBudget`: 解凍後合計 256MB / 5000 エントリを**展開前に**検査) が実装済みで verify-cli はこれを通るが、verify (Web) の `ZipFileProcessor` は `JSZip.loadAsync` を直接呼んで `extractFiles` で全エントリを展開するためガードを完全にバイパスしていた。高圧縮の悪意ある ZIP で採点者のブラウザタブを OOM/ハングさせられる。

## 修正

- `assertZipWithinBudget` を shared の public API として export (parser.ts → fileProcessing/index.ts → index.ts)
- `ZipFileProcessor.process` の `loadAsync` 直後・展開前に適用
- verify 内で JSZip を直接使うのはこの 1 箇所だけであることを grep で確認済み
- 上限判定 (正常 ZIP 受理 / エントリ数超過 / 解凍後サイズ超過) のユニットテストを shared に追加

正規 proof (スクショ込み) は上限内なので互換影響なし。

## テスト

- shared: 394 件 pass (新規 3 件含む)、shared / verify typecheck pass

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)