### PR TITLE
fix(shared): exam バンドルの v1 ダウングレード偽造を拒否 (#137)

### DIFF
--- a/packages/shared/src/__tests__/examBundleBinding.test.ts
+++ b/packages/shared/src/__tests__/examBundleBinding.test.ts
@@ -141,6 +141,38 @@ describe('verifyExamBinding (v2 bundle)', () => {
     expect(result.reason).toContain('does-not-exist');
   });
 
+  it('rejects a v1-claiming proof over a bundle-sealed package (downgrade forgery)', async () => {
+    // バンドル封印 package に対し rootBinding 未設定 (v1) の proof を捏造する:
+    // problemContentHash = 平文全体ハッシュ、root = v1 式。#137 のダウングレード攻撃。
+    const { signer, registry } = await makeExamAuthority();
+    const bundle = sampleBundle();
+    const plaintext = encodeExamBundle(bundle);
+    const { manifest, token } = await buildSamplePackage(signer, { plaintext });
+    const packageHash = await computeExamPackageHash(manifest);
+    // v1 経路の内容ハッシュ = 平文全体の SHA-256 を proof に自己申告する。
+    const wholePlaintextHash = await computeHash(plaintext);
+    const components = { lang: 'en-US', tz: 'UTC' };
+    const fpHash = await computeHash(deterministicStringify(components));
+    const nonce = '7'.repeat(64);
+    // v1 root: per-problem ハッシュを連結しない。
+    const root = await computeExamChainRoot(fpHash, nonce, packageHash, token);
+    const exam: ExamProofBlock = buildExamProofBlock({
+      examId: manifest.examId, problemId: 'anything-i-like', variant: null,
+      packageHash, problemContentHash: wholePlaintextHash, startToken: token,
+    });
+    const proof = {
+      typingProofData: { deviceId: fpHash, initialHashNonce: nonce, initialEventChainHash: root },
+      proof: { events: [{ previousHash: root }], finalHash: root },
+      fingerprint: { hash: fpHash, components },
+      exam,
+    };
+    const result = await verifyExamBinding(proof as unknown as BindingArg, manifest, {
+      examAuthorityRegistry: registry,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('must use v2');
+  });
+
   it('rejects a v2 proof when the decrypted plaintext is not a bundle (legacy markdown)', async () => {
     // 平文を生 markdown にして封印するが、proof は v2 を主張する。
     const { signer, registry } = await makeExamAuthority();

--- a/packages/shared/src/exam/examPackage.ts
+++ b/packages/shared/src/exam/examPackage.ts
@@ -602,6 +602,14 @@ export async function verifyExamBinding(
     }
     contentHash = await computeBundleProblemHash(problem);
   } else {
+    // ダウングレード拒否 (#137): バンドル封印された package は per-problem 束縛 (v2) でしか
+    // 検証させない。rootBinding を落とした proof が平文全体ハッシュで problemId 束縛を
+    // 回避できてしまう (上の「v2 主張 + 非バンドル平文」拒否と対称のガード)。
+    // 旧 v1 単一問題 package の平文は legacy (非バンドル) なので後方互換は保たれる。
+    const decoded = decodeExamPlaintext(decrypted.plaintext);
+    if (decoded.kind === 'bundle') {
+      return { ...result, reason: 'Package plaintext is an exam bundle; proof must use v2 per-problem root binding' };
+    }
     contentHash = await computeProblemContentHash(decrypted.plaintext);
   }
   result.problemContentHashMatches = contentHash === exam.problemContentHash;


### PR DESCRIPTION
## 概要

2026-07 レビュー #137 (medium)。`verifyExamBinding` は proof 側の自己申告 `exam.rootBinding` で v1/v2 の検証パスを選ぶが、逆方向のガードが非対称だった:

- v2 主張 + 非バンドル平文 → reject (実装済み)
- **v1 主張 (rootBinding 未設定) + バンドル平文 → 素通り** ← 本 PR で修正

このため、バンドル封印 (v2) された package に対して `rootBinding` を落とし `problemContentHash = SHA-256(バンドル平文全体)`・`problemId = 任意` とした偽造 proof が全ステップを pass し、per-problem 束縛 (ADR-0012 B-2) を丸ごと回避できた。

## 修正

- v1 パスで復号平文を `decodeExamPlaintext` し、バンドルなら `valid=false` (理由: `must use v2 per-problem root binding`)
- 旧 v1 単一問題 package の平文は legacy (非バンドル) なので後方互換は不変
- PROOF_FORMAT_VERSION の bump 不要 (検証側のみの変更)

## テスト

- ダウングレード偽造の回帰テストを追加 (修正前なら pass してしまう忠実な偽造 fixture: v1 root 式 + 平文全体ハッシュ)
- shared 全 389 件 pass、typecheck pass

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)