### PR TITLE
fix(verify-cli): 未知フラグ・タイポを exit 1 で拒否 (#148)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4484,7 +4484,8 @@
       },
       "devDependencies": {
         "@types/node": "^26.1.0",
-        "typescript": "^6.0.2"
+        "typescript": "^6.0.2",
+        "vitest": "^4.1.9"
       },
       "engines": {
         "node": ">=24.0.0"

--- a/packages/verify-cli/package.json
+++ b/packages/verify-cli/package.json
@@ -13,14 +13,17 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "@typedcode/shared": "*"
   },
   "devDependencies": {
     "@types/node": "^26.1.0",
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.9"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/packages/verify-cli/src/__tests__/args.test.ts
+++ b/packages/verify-cli/src/__tests__/args.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { findFlagError, flagValue, flagValues, nonFlagArgs } from '../args.js';
+
+/**
+ * #148: 未知フラグ・タイポの黙殺はセキュリティゲートのサイレント無効化になる。
+ * ホワイトリスト検証の挙動を固定する。
+ */
+describe('findFlagError', () => {
+  it('accepts a known boolean gate flag', () => {
+    expect(findFlagError(['proof.zip', '--require-root-anchor'])).toBeNull();
+  });
+
+  it('accepts value flags in both space and equals forms', () => {
+    expect(findFlagError(['proof.zip', '--mode', 'fast'])).toBeNull();
+    expect(findFlagError(['proof.zip', '--mode=fast'])).toBeNull();
+    expect(findFlagError(['p.zip', '--analyzer', 'a.mjs', '--analyzer=b.mjs'])).toBeNull();
+  });
+
+  it('rejects a typo of a security gate flag instead of silently ignoring it', () => {
+    expect(findFlagError(['proof.zip', '--require-root-anchr'])).toContain('Unknown option');
+  });
+
+  it('rejects an unknown short flag', () => {
+    expect(findFlagError(['proof.zip', '-x'])).toContain('Unknown option');
+  });
+
+  it('rejects equals form on a boolean flag instead of silently ignoring it', () => {
+    expect(findFlagError(['proof.zip', '--require-anchor-density=true'])).toContain(
+      'does not take a value'
+    );
+  });
+
+  it('rejects a value flag with a missing value', () => {
+    expect(findFlagError(['proof.zip', '--mode'])).toContain('requires a value');
+    expect(findFlagError(['proof.zip', '--mode', '--require-root-anchor'])).toContain(
+      'requires a value'
+    );
+  });
+});
+
+describe('flagValue / flagValues', () => {
+  it('reads a value in both forms', () => {
+    expect(flagValue(['--mode', 'fast'], '--mode')).toBe('fast');
+    expect(flagValue(['--mode=audit'], '--mode')).toBe('audit');
+    expect(flagValue([], '--mode')).toBeUndefined();
+  });
+
+  it('collects repeated values across both forms', () => {
+    expect(flagValues(['--analyzer', 'a.mjs', '--analyzer=b.mjs'], '--analyzer')).toEqual([
+      'a.mjs',
+      'b.mjs',
+    ]);
+  });
+});
+
+describe('nonFlagArgs', () => {
+  it('keeps positionals and skips flags together with their values', () => {
+    expect(
+      nonFlagArgs(['proof.zip', '--mode', 'fast', '--require-root-anchor', '--analysis-json=o.json'])
+    ).toEqual(['proof.zip']);
+  });
+});

--- a/packages/verify-cli/src/args.ts
+++ b/packages/verify-cli/src/args.ts
@@ -1,0 +1,98 @@
+/**
+ * CLI 引数の解析と検証 (純関数)。
+ *
+ * 未知フラグ・タイポ・値欠落を黙って無視すると、`--require-root-anchr` のような
+ * タイポでセキュリティゲートが無効のまま exit 0 になる (#148)。フラグは
+ * ここのホワイトリストで検証し、cli.ts は結果を使うだけにする。
+ * 新しいフラグを足すときは VALUE_FLAGS / BOOLEAN_FLAGS のどちらかに必ず登録する。
+ */
+
+/** value を取る flag。`--name value` と `--name=value` の両方を許す。`--analyzer` は反復可。 */
+export const VALUE_FLAGS = new Set([
+  '--mode',
+  '--exam-package',
+  '--submitted-at',
+  '--analysis-json',
+  '--analysis-bundle',
+  '--analyzer',
+]);
+
+/** 値を取らない boolean flag。`=` 付きは拒否する。 */
+export const BOOLEAN_FLAGS = new Set([
+  '--require-anchor-density',
+  '--require-root-anchor',
+  '--no-default-analyzers',
+  '--help',
+  '-h',
+]);
+
+/**
+ * フラグ列を検証し、問題があればエラーメッセージを返す (なければ null)。
+ * - 未知の `-`/`--` 引数 → エラー (タイポの黙殺防止)
+ * - value flag の値欠落 (末尾、または次の引数がフラグ) → エラー
+ * - boolean flag への `=` 付与 (`--require-root-anchor=true`) → エラー (黙って無視しない)
+ */
+export function findFlagError(args: string[]): string | null {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (!arg.startsWith('-')) continue;
+    if (BOOLEAN_FLAGS.has(arg)) continue;
+    if (VALUE_FLAGS.has(arg)) {
+      const value = args[i + 1];
+      if (value === undefined || value.startsWith('-')) {
+        return `${arg} requires a value.`;
+      }
+      i++; // 値をスキップ
+      continue;
+    }
+    const eq = arg.indexOf('=');
+    if (eq > 0) {
+      const name = arg.slice(0, eq);
+      if (VALUE_FLAGS.has(name)) continue;
+      if (BOOLEAN_FLAGS.has(name)) {
+        return `${name} does not take a value (got: ${arg}).`;
+      }
+    }
+    return `Unknown option: ${arg}`;
+  }
+  return null;
+}
+
+/** value flag の値を取り出す (`--name value` / `--name=value`)。 */
+export function flagValue(args: string[], name: string): string | undefined {
+  const i = args.findIndex((a) => a === name || a.startsWith(`${name}=`));
+  if (i === -1) return undefined;
+  const arg = args[i]!;
+  return arg.startsWith(`${name}=`) ? arg.slice(name.length + 1) : args[i + 1];
+}
+
+/** 反復可能な value flag の値をすべて集める (`--analyzer a --analyzer b`)。 */
+export function flagValues(args: string[], name: string): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg === name) {
+      const v = args[i + 1];
+      if (v !== undefined) out.push(v);
+      i++;
+    } else if (arg.startsWith(`${name}=`)) {
+      out.push(arg.slice(name.length + 1));
+    }
+  }
+  return out;
+}
+
+/** フラグとその値を除いた位置引数 (検証対象ファイル)。 */
+export function nonFlagArgs(args: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (VALUE_FLAGS.has(arg)) {
+      i++; // skip the flag's value
+      continue;
+    }
+    if (arg.startsWith('-')) continue; // --flag=value or boolean flag (検証済み前提)
+    out.push(arg);
+  }
+  return out;
+}

--- a/packages/verify-cli/src/cli.ts
+++ b/packages/verify-cli/src/cli.ts
@@ -22,31 +22,7 @@ import {
   type AnalysisBundle,
 } from '@typedcode/shared';
 
-/** value を取る flag。`--name value` と `--name=value` の両方を許す。`--analyzer` は反復可。 */
-const VALUE_FLAGS = new Set(['--mode', '--exam-package', '--submitted-at', '--analysis-json', '--analysis-bundle', '--analyzer']);
-
-function flagValue(args: string[], name: string): string | undefined {
-  const i = args.findIndex((a) => a === name || a.startsWith(`${name}=`));
-  if (i === -1) return undefined;
-  const arg = args[i]!;
-  return arg.startsWith(`${name}=`) ? arg.slice(name.length + 1) : args[i + 1];
-}
-
-/** 反復可能な value flag の値をすべて集める (`--analyzer a --analyzer b`)。 */
-function flagValues(args: string[], name: string): string[] {
-  const out: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i]!;
-    if (arg === name) {
-      const v = args[i + 1];
-      if (v !== undefined) out.push(v);
-      i++;
-    } else if (arg.startsWith(`${name}=`)) {
-      out.push(arg.slice(name.length + 1));
-    }
-  }
-  return out;
-}
+import { findFlagError, flagValue, flagValues, nonFlagArgs } from './args.js';
 
 function parseModeFlag(args: string[]): VerificationMode {
   const value = flagValue(args, '--mode');
@@ -55,26 +31,21 @@ function parseModeFlag(args: string[]): VerificationMode {
   throw new Error(`Invalid --mode value: ${value}. Use fast | audit | full.`);
 }
 
-function nonFlagArgs(args: string[]): string[] {
-  const out: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i]!;
-    if (VALUE_FLAGS.has(arg)) {
-      i++; // skip the flag's value
-      continue;
-    }
-    if (arg.startsWith('--')) continue; // --flag=value or boolean flag
-    out.push(arg);
-  }
-  return out;
-}
-
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
 
   if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
     printUsage();
     process.exit(args.length === 0 ? 1 : 0);
+  }
+
+  // 未知フラグ・タイポ・値欠落は黙殺せず usage error (#148)。
+  // タイポでセキュリティゲート (--require-root-anchor 等) が無効のまま exit 0 になるのを防ぐ。
+  const flagError = findFlagError(args);
+  if (flagError !== null) {
+    printError(flagError);
+    printUsage();
+    process.exit(1);
   }
 
   const mode = parseModeFlag(args);

--- a/packages/verify-cli/tsconfig.json
+++ b/packages/verify-cli/tsconfig.json
@@ -24,5 +24,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "src/**/__tests__/**"]
 }

--- a/packages/verify-cli/vitest.config.ts
+++ b/packages/verify-cli/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // 引数解析などの純関数を対象にする。DOM 非依存なので node 環境で十分。
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    globals: true,
+  },
+});


### PR DESCRIPTION
## 概要

2026-07 レビュー #148 (medium)。引数解析が完全一致 (`args.includes`) と `--` prefix skip だけで、以下をすべて**黙って無視**していた:

- セキュリティゲートのタイポ: `--require-root-anchr` → ゲート無効のまま exit 0
- boolean フラグへの `=` 付与: `--require-anchor-density=true` → 無効のまま exit 0
- 未知フラグ全般・value フラグの値欠落 (`--mode` 単独 → 黙って full)

CI で「ゲートを掛けたつもり」の proof 受理はサイレント失敗として危険。

## 修正

- 解析を [args.ts](https://github.com/shinyaoguri/typedcode/blob/fix/cli-unknown-flags/packages/verify-cli/src/args.ts) の純関数に切り出し、`VALUE_FLAGS` / `BOOLEAN_FLAGS` ホワイトリストで検証。違反は `printError` + usage + **exit 1** (CLAUDE.md 不変条件 #2 の 0/1 体系を維持)
- verify-cli に **vitest を導入** (#135「検証層ゼロテスト」の器の一部)。引数解析の挙動を 9 テストで固定
- `tsconfig` の build からテストを除外

**互換性注意**: これまで受理されていた不正な引数が exit 1 になります (意図的な breaking — それが本修正の目的)。e2e が使う `--mode fast` / `--analysis-json` 等は全てホワイトリスト済みで影響なし。

## テスト

- 新規 9 件 pass、typecheck / build pass
- スモーク確認: タイポ → `Unknown option` + exit 1 / `--mode` 値欠落 → exit 1 / `--help` → exit 0
- 注: CI の test job は現状 shared/workers のみ。#156 の修正 (`--workspaces --if-present`) が入ると本パッケージのテストも自動で CI に乗る

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)