### PR TITLE
fix(workers): dev Worker 名分離 + 未捕捉例外の最終防衛 (#152, #153)

### DIFF
--- a/packages/workers/CLAUDE.md
+++ b/packages/workers/CLAUDE.md
@@ -57,6 +57,7 @@ src/
 | `SIGNING_KEY_UNKNOWN` | 500 | `keyId` がレジストリに存在しない |
 | `SIGNING_ERROR` | 500 | 署名計算で予期しない失敗 |
 | `SESSION_PERSIST_FAILED` | 503 | **初回** checkpoint の KV 書き込み失敗。`firstSeenAt` が固定されないため署名済み envelope は返さずクライアントにリトライさせる (2 回目以降の書き込み失敗は best-effort で 200) |
+| `SESSION_STATE_UNAVAILABLE` | 503 | KV の**読み取り**失敗。「existing = null」と混同すると既存セッションに別の `firstSeenAt` で署名してしまう (#151/#153) ため、署名せずリトライさせる |
 
 ## CORS と濫用防止の設計
 
@@ -212,5 +213,6 @@ main ブランチ push
 
 - **`.dev.vars` を git に入れない**: `.gitignore` に登録済み。`wrangler.toml` の KV ID は skip-worktree で隠す
 - **`compatibility_date` を勝手に動かさない**: 後方互換性のために固定。新機能のために動かす必要があるときは ADR を書く
-- **本番 / preview の KV ID 分離**: `wrangler.toml` の `[env.production]` ブロックで本番用 ID を別途指定
+- **環境ごとの KV ID 分離**: 3 ファイル方式。dev は `wrangler.toml` (skip-worktree)、staging / production は `wrangler.staging.toml` / `wrangler.production.toml` に直接 commit。旧 `[env.production]` ブロック方式は廃止済み (#152)
+- **dev の Worker 名は `typedcode-api-dev`**: 本番と同名にすると素の `npx wrangler deploy` が本番を dev 設定で上書きする (#152)。ローカルの skip-worktree 版 `wrangler.toml` も `typedcode-api-dev` に揃えること
 - **`gen-checkpoint-key` で出る秘密鍵は JWK の JSON 文字列**: `.dev.vars` に貼るときは改行を含めず 1 行に

--- a/packages/workers/src/__tests__/checkpoint.test.ts
+++ b/packages/workers/src/__tests__/checkpoint.test.ts
@@ -25,8 +25,13 @@ const REGISTERED_KEY_ID = 'tcp-202605-fd6d42';
 class MockKV {
   store = new Map<string, string>();
   failNextPut = false;
+  failNextGet = false;
 
   async get<T = unknown>(key: string, type?: 'json' | 'text'): Promise<T | null> {
+    if (this.failNextGet) {
+      this.failNextGet = false;
+      throw new Error('simulated KV read failure');
+    }
     const v = this.store.get(key);
     if (v === undefined) return null;
     return (type === 'json' ? (JSON.parse(v) as T) : (v as unknown as T));
@@ -301,6 +306,23 @@ describe('handleSignCheckpoint', () => {
     expect(res.status).toBe(429);
     const body = (await res.json()) as ErrorResponseBody;
     expect(body.code).toBe('SESSION_LIMIT_EXCEEDED');
+  });
+
+  it('rejects with SESSION_STATE_UNAVAILABLE when the KV read fails (must not fork firstSeenAt)', async () => {
+    // 既存セッションを固定してから read を失敗させる。read 失敗を「existing = null」と
+    // 混同すると既存セッションに別の firstSeenAt で署名し proof 全体が無効化される (#151/#153)。
+    const res1 = await handleSignCheckpoint(makeRequest(makeInput()), env, responder);
+    expect(res1.status).toBe(200);
+
+    kv.failNextGet = true;
+    const res2 = await handleSignCheckpoint(
+      makeRequest(makeInput({ checkpointIndex: 1, previousSignedCheckpointHash: 'e'.repeat(64) })),
+      env,
+      responder
+    );
+    expect(res2.status).toBe(503);
+    const body = (await res2.json()) as ErrorResponseBody;
+    expect(body.code).toBe('SESSION_STATE_UNAVAILABLE');
   });
 
   it('rejects with SESSION_PERSIST_FAILED when the FIRST KV write fails', async () => {

--- a/packages/workers/src/__tests__/fetchGuard.test.ts
+++ b/packages/workers/src/__tests__/fetchGuard.test.ts
@@ -1,0 +1,49 @@
+/**
+ * fetch エントリの最終防衛 try/catch (#153)。
+ *
+ * ハンドラ内の未捕捉例外が Workers の 1101 (CORS ヘッダなし・非 JSON) に落ちると、
+ * ブラウザからは不透明な CORS エラーに見え、クライアントの意図したエラー経路に乗らない。
+ * 最終防衛は「どんな例外でも構造化 JSON 500 を返し、自身は絶対に throw しない」こと。
+ */
+
+import { describe, it, expect } from 'vitest';
+import worker from '../index.js';
+
+type TestEnv = Parameters<typeof worker.fetch>[1];
+
+describe('fetch top-level guard', () => {
+  it('wraps an unhandled handler exception into JSON 500 and never rethrows', async () => {
+    // env の変数参照自体が throw する最悪ケース: ハンドラ内 (responder.cors) で例外が
+    // 発生し、最終防衛の CORS ヘッダ計算も失敗する。それでも JSON 500 が返ること。
+    const env = {} as Record<string, unknown>;
+    Object.defineProperty(env, 'ALLOWED_ORIGINS', {
+      get() {
+        throw new Error('simulated env failure');
+      },
+    });
+    Object.defineProperty(env, 'ENVIRONMENT', {
+      get() {
+        throw new Error('simulated env failure');
+      },
+    });
+
+    const req = new Request('https://workers.test/api/checkpoint/public-keys', {
+      method: 'GET',
+      headers: { Origin: 'https://typedcode.dev' },
+    });
+
+    const res = await worker.fetch(req, env as unknown as TestEnv);
+    expect(res.status).toBe(500);
+    expect(res.headers.get('Content-Type')).toBe('application/json');
+    const body = (await res.json()) as { success: boolean };
+    expect(body.success).toBe(false);
+  });
+
+  it('serves /health normally with the guard in place (no behavior change on the happy path)', async () => {
+    const env = { ENVIRONMENT: 'development' } as unknown as TestEnv;
+    const res = await worker.fetch(new Request('https://workers.test/health'), env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe('ok');
+  });
+});

--- a/packages/workers/src/__tests__/sessionStart.test.ts
+++ b/packages/workers/src/__tests__/sessionStart.test.ts
@@ -102,6 +102,18 @@ describe('handleSessionStart (POST /api/session/start)', () => {
     expect(body.token!.algorithm).toBe('ECDSA-P256');
   });
 
+  it('returns JSON 503 when the Turnstile upstream is unreachable (no uncaught 1101)', async () => {
+    // siteverify への fetch が reject する一時障害。未捕捉例外 (1101) にせず 503 で返し、
+    // editor が明示的なエラー経路 (非アンカーへのフォールバック) に乗れるようにする (#153)。
+    globalThis.fetch = (async () => {
+      throw new Error('network unreachable');
+    }) as typeof fetch;
+    const res = await worker.fetch(sessionStartReq(validBody), makeEnv());
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as SessionStartResponse;
+    expect(body.success).toBe(false);
+  });
+
   it('issues a different serverNonce on each call (nonce is server-random)', async () => {
     const a = (await (await worker.fetch(sessionStartReq(validBody), makeEnv())).json()) as SessionStartResponse;
     const b = (await (await worker.fetch(sessionStartReq(validBody), makeEnv())).json()) as SessionStartResponse;

--- a/packages/workers/src/checkpoint.ts
+++ b/packages/workers/src/checkpoint.ts
@@ -68,7 +68,8 @@ interface ErrorBody {
     | 'SIGNING_KEY_NOT_CONFIGURED'
     | 'SIGNING_KEY_UNKNOWN'
     | 'SIGNING_ERROR'
-    | 'SESSION_PERSIST_FAILED';
+    | 'SESSION_PERSIST_FAILED'
+    | 'SESSION_STATE_UNAVAILABLE';
 }
 
 function jsonResponse(
@@ -196,7 +197,23 @@ export async function handleSignCheckpoint(
   // NON_MONOTONIC となり 1 つも署名されない。verifier は firstSeenAt をタブ間で共有要求しない
   // (proof = 1 タブ) ので、firstSeenAt がタブ毎に確定するのは安全。
   const sessionKey = `session:${input.sessionId}:${input.tabId}`;
-  const existing = await env.CHECKPOINT_SESSIONS.get<SessionRecord>(sessionKey, 'json');
+  // KV read の失敗は「existing = null」と混同してはいけない (#153/#151): null 扱いにすると
+  // 既存セッションに新しい firstSeenAt で署名してしまい、verifier の firstSeenAt 完全一致
+  // 要求により proof 全体が検証不能になる。必ず 503 でクライアントにリトライさせる。
+  let existing: SessionRecord | null;
+  try {
+    existing = await env.CHECKPOINT_SESSIONS.get<SessionRecord>(sessionKey, 'json');
+  } catch (err) {
+    console.error('[checkpoint] KV read failed:', err);
+    return jsonResponse(
+      {
+        error: 'Failed to read session state; retry the signing request',
+        code: 'SESSION_STATE_UNAVAILABLE',
+      } satisfies ErrorBody,
+      503,
+      responder.cors()
+    );
+  }
 
   // このセッションで初めて署名する checkpoint か。初回は firstSeenAt が
   // まだ KV に固定されていないため、KV 永続化を「成功条件」として扱う必要がある。

--- a/packages/workers/src/index.ts
+++ b/packages/workers/src/index.ts
@@ -476,7 +476,16 @@ async function handleSessionStart(request: Request, env: Env): Promise<Response>
   const input = validation.input;
 
   // Turnstile 検証 + hostname 照合 (verify-captcha と同方針)。
-  const result = await verifyTurnstile(turnstileToken, env.TURNSTILE_SECRET_KEY);
+  // 上流 (Turnstile API) の fetch reject / 非 JSON 応答は未捕捉例外 (1101) にせず 503 で返す (#153)。
+  // editor は失敗時に非アンカーへフォールバックするため、一時障害を不透明な 1101 にすると
+  // 不必要にアンカーを失う。
+  let result: Awaited<ReturnType<typeof verifyTurnstile>>;
+  try {
+    result = await verifyTurnstile(turnstileToken, env.TURNSTILE_SECRET_KEY);
+  } catch (err) {
+    console.error('[session/start] Turnstile verification unavailable:', err);
+    return json({ success: false, message: 'Turnstile verification temporarily unavailable' }, 503);
+  }
   const hostnameOk = isTurnstileHostnameAllowed(result.hostname, env);
   if (!result.success || !hostnameOk) {
     if (result.success && !hostnameOk) {
@@ -521,47 +530,70 @@ async function handleSessionStart(request: Request, env: Env): Promise<Response>
   return json({ success: true, token }, 200);
 }
 
+async function route(request: Request, env: Env): Promise<Response> {
+  const url = new URL(request.url);
+
+  // CORS preflight
+  if (request.method === 'OPTIONS') {
+    return handleCORS(request, env);
+  }
+
+  // ルーティング
+  if (url.pathname === '/api/verify-captcha' && request.method === 'POST') {
+    return handleVerifyCaptcha(request, env);
+  }
+
+  // セッション開始トークン発行 (ADR-0017)
+  if (url.pathname === '/api/session/start' && request.method === 'POST') {
+    return handleSessionStart(request, env);
+  }
+
+  // 証明書検証エンドポイント
+  if (url.pathname === '/api/verify-attestation' && request.method === 'POST') {
+    return handleVerifyAttestation(request, env);
+  }
+
+  // Signed checkpoint endpoints
+  if (url.pathname === '/api/checkpoint/sign' && request.method === 'POST') {
+    const origin = request.headers.get('Origin');
+    return handleSignCheckpoint(request, env, checkpointResponder(origin, env));
+  }
+  if (url.pathname === '/api/checkpoint/public-keys' && request.method === 'GET') {
+    const origin = request.headers.get('Origin');
+    return handlePublicKeys(checkpointResponder(origin, env));
+  }
+
+  // ヘルスチェック
+  if (url.pathname === '/health') {
+    return new Response(JSON.stringify({ status: 'ok', environment: env.ENVIRONMENT }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  return new Response('Not Found', { status: 404 });
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
-    const url = new URL(request.url);
-
-    // CORS preflight
-    if (request.method === 'OPTIONS') {
-      return handleCORS(request, env);
+    // 最終防衛 (#153): 未捕捉例外を Workers の 1101 (CORS/JSON なし) に落とさない。
+    // ブラウザからは 1101 が不透明な CORS エラーに見え、意図したエラー経路に乗らない。
+    try {
+      return await route(request, env);
+    } catch (err) {
+      console.error('[worker] unhandled exception:', err);
+      // 最終防衛は絶対に throw しない: CORS ヘッダ計算 (env 参照) 自体が失敗しても
+      // JSON 500 を返す (ヘッダなしのフォールバック)。
+      let headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      try {
+        const origin = request.headers.get('Origin');
+        headers = { ...headers, ...(corsHeaders(origin, env) as Record<string, string>) };
+      } catch {
+        /* env が壊れていても応答は返す */
+      }
+      return new Response(
+        JSON.stringify({ success: false, message: 'Internal server error' }),
+        { status: 500, headers }
+      );
     }
-
-    // ルーティング
-    if (url.pathname === '/api/verify-captcha' && request.method === 'POST') {
-      return handleVerifyCaptcha(request, env);
-    }
-
-    // セッション開始トークン発行 (ADR-0017)
-    if (url.pathname === '/api/session/start' && request.method === 'POST') {
-      return handleSessionStart(request, env);
-    }
-
-    // 証明書検証エンドポイント
-    if (url.pathname === '/api/verify-attestation' && request.method === 'POST') {
-      return handleVerifyAttestation(request, env);
-    }
-
-    // Signed checkpoint endpoints
-    if (url.pathname === '/api/checkpoint/sign' && request.method === 'POST') {
-      const origin = request.headers.get('Origin');
-      return handleSignCheckpoint(request, env, checkpointResponder(origin, env));
-    }
-    if (url.pathname === '/api/checkpoint/public-keys' && request.method === 'GET') {
-      const origin = request.headers.get('Origin');
-      return handlePublicKeys(checkpointResponder(origin, env));
-    }
-
-    // ヘルスチェック
-    if (url.pathname === '/health') {
-      return new Response(JSON.stringify({ status: 'ok', environment: env.ENVIRONMENT }), {
-        headers: { 'Content-Type': 'application/json' },
-      });
-    }
-
-    return new Response('Not Found', { status: 404 });
   },
 };

--- a/packages/workers/wrangler.toml
+++ b/packages/workers/wrangler.toml
@@ -1,4 +1,10 @@
-name = "typedcode-api"
+# ローカル開発専用の config (skip-worktree で各開発者の dev KV ID を保持する)。
+# staging / production は wrangler.staging.toml / wrangler.production.toml (3 ファイル方式)。
+#
+# Worker 名は本番 (typedcode-api) と必ず分けること (#152) — 同名だと素の
+# `npx wrangler deploy` がこのファイルを既定読込みし、本番 Worker を dev 設定
+# (localhost origin 自動許可・Turnstile hostname 強制なし) で上書きしてしまう。
+name = "typedcode-api-dev"
 main = "src/index.ts"
 compatibility_date = "2025-12-26"
 
@@ -11,12 +17,5 @@ ENVIRONMENT = "development"
 #   wrangler kv namespace create CHECKPOINT_SESSIONS --preview
 [[kv_namespaces]]
 binding = "CHECKPOINT_SESSIONS"
-id = "REPLACE_WITH_PRODUCTION_ID"
+id = "REPLACE_WITH_DEV_ID"
 preview_id = "REPLACE_WITH_PREVIEW_ID"
-
-[env.production]
-vars = { ENVIRONMENT = "production" }
-
-[[env.production.kv_namespaces]]
-binding = "CHECKPOINT_SESSIONS"
-id = "REPLACE_WITH_PRODUCTION_ID"


### PR DESCRIPTION
## 概要

2026-07 レビューの workers 2 件をまとめて修正。

### #152 — dev wrangler.toml の Worker 名が本番と同一 (security)

`npm run deploy` はガード済みだが、素の `npx wrangler deploy` は `wrangler.toml` を既定読込みして **本番 Worker (typedcode-api) を dev 設定で上書き**できた (localhost origin 自動許可・Turnstile hostname 強制なし・シークレットは残存)。

- Worker 名を `typedcode-api-dev` に分離 (事故時も dev Worker が新規登録されるだけ)
- 3 ファイル方式と矛盾する死に設定 `[env.production]` ブロック (placeholder ID) を削除
- CLAUDE.md の stale な「`[env.production]` で本番 ID 指定」記述を 3 ファイル方式に更新

**⚠️ 各開発者のローカル作業**: skip-worktree の `wrangler.toml` の `name` を `typedcode-api-dev` に手動で揃えてください (この環境のローカル版は更新済み)。

### #153 — 未捕捉例外が 1101 (CORS/JSON なし) に落ちる

- **fetch エントリに最終防衛 try/catch**: 未捕捉例外を JSON 500 + CORS で返す。ヘッダ計算 (env 参照) 自体が失敗しても throw しないフォールバック付き
- **handleSessionStart**: `verifyTurnstile` の上流障害 (fetch reject / 非 JSON 応答) を 503 に。1101 だと editor から不透明な CORS エラーに見え、一時障害で不必要にアンカーを失う
- **checkpoint の KV read を try/catch**: 失敗は新設 `SESSION_STATE_UNAVAILABLE` (503) でリトライさせる。「read 失敗 = existing null」と誤マップすると既存セッションに別の firstSeenAt で署名し、verifier の完全一致要求で proof 全体が検証不能になる (#151 の分裂経路の一つを封鎖)

## テスト

- 新規 4 件を含む workers 43 件 pass (KV read 失敗 → 503 / Turnstile 不達 → 503 / 最終防衛 500 / health 正常系)
- typecheck pass、`wrangler deploy --dry-run` (staging config) pass
- クライアント互換: editor の `SignedCheckpointService` は非 200 を一律リトライ対象にするため新 code の追加は安全

Closes #152
Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)