### PR TITLE
ci: editor テスト組込み + 全 job timeout + e2e の docs 反映 (#156, #158, #155)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # 構成:
-#   test                   — どのトリガでも必ず走る (shared / workers のユニットテスト)
+#   test                   — どのトリガでも必ず走る (test:run を持つ全 workspace のユニットテスト)
 #   check                  — どのトリガでも必ず走る (全 package typecheck/build + Worker config dry-run)
 #   deploy-preview         — feature → develop PR で Pages のプレビュー URL を発行 (Workers staging 向け)
 #   comment-staging-preview— develop → main PR に staging URL をコメント (新規 preview は作らない)
@@ -34,6 +34,7 @@ jobs:
   # --------------------------------------------------------------------
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 
@@ -45,11 +46,11 @@ jobs:
       - name: Install dependencies
         run: npm ci --include=optional
 
-      - name: Run tests (shared)
-        run: npm run test:run -w @typedcode/shared
-
-      - name: Run tests (workers)
-        run: npm run test:run -w @typedcode/workers
+      # `test:run` script を持つ全 workspace を回す (#156)。パッケージ名の個別列挙だと
+      # 新パッケージのテストが CI 外に取り残される (editor がそうなっていた)。
+      # e2e は `test` のみで `test:run` を持たないため誤って拾わない。
+      - name: Run unit tests (all workspaces with test:run)
+        run: npm run test:run --workspaces --if-present
 
   # --------------------------------------------------------------------
   # 品質ゲート (merge 前に全 package を typecheck/build + Worker config 検証)
@@ -59,6 +60,7 @@ jobs:
   # --------------------------------------------------------------------
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 
@@ -92,6 +94,9 @@ jobs:
   # --------------------------------------------------------------------
   e2e:
     runs-on: ubuntu-latest
+    # e2e は wrangler dev + vite dev を Playwright が起動する構成でハングの余地があり、
+    # 過去に PoSW full 検証でタイムアウト間際になった実績もある (a6079d0)。実測 ~18 分。
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
 
@@ -134,6 +139,7 @@ jobs:
     # 通常の feature/* → develop PR では head_ref が feature 名になるので衝突しない。
     if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.head_ref != 'develop'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment:
       name: staging
     permissions:
@@ -233,6 +239,7 @@ jobs:
     needs: [test, check]
     if: github.event_name == 'pull_request' && github.head_ref == 'develop' && github.base_ref == 'main'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       pull-requests: write
     steps:
@@ -283,6 +290,7 @@ jobs:
     needs: [test, check, e2e]
     if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment:
       name: staging
     permissions:
@@ -338,6 +346,9 @@ jobs:
     needs: [test, check, e2e]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    # 注: Environment "production" の承認待ち時間は timeout-minutes に含まれない
+    # (job 開始 = 承認後)。実行時間のみの上限。
+    timeout-minutes: 20
     environment:
       name: production
     permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,8 @@ packages/
 ├── editor/     # Monaco ベースのエディタ
 ├── verify/     # 証明検証用 Web アプリ
 ├── verify-cli/ # CLI 検証ツール (Node.js ≥24)
-└── workers/    # Cloudflare Workers (Turnstile + 署名チェックポイント)
+├── workers/    # Cloudflare Workers (Turnstile + 署名チェックポイント)
+└── e2e/        # Playwright E2E (編集→export→verify-cli round-trip、CI deploy ゲート)
 ```
 
 サブシステムを触る場合は **必ず該当パッケージの `CLAUDE.md`** を読むこと。各パッケージの責務 / 境界 / 不変条件 / 罠が記述されています。
@@ -30,6 +31,7 @@ packages/
 | verify | [packages/verify/CLAUDE.md](packages/verify/CLAUDE.md) | 証明検証 UI、Worker ベースの検証 |
 | verify-cli | [packages/verify-cli/CLAUDE.md](packages/verify-cli/CLAUDE.md) | CLI 検証ツール |
 | workers | [packages/workers/CLAUDE.md](packages/workers/CLAUDE.md) | Turnstile + 署名チェックポイントの API |
+| e2e | [packages/e2e/CLAUDE.md](packages/e2e/CLAUDE.md) | ブラウザ E2E (実エディタ → 証明 export → verify-cli 検証) |
 
 ## ビルド・開発コマンド
 
@@ -51,12 +53,14 @@ npm run build:editor
 npm run build:verify
 npm run build:verify-cli
 
-# テスト (shared / workers / editor にテストあり。verify / verify-cli は未整備)
-npm run test:run -w @typedcode/shared
-npm run test:run -w @typedcode/workers
-npm run test:run -w @typedcode/editor
+# ユニットテスト (test:run を持つ全パッケージ。CI の test job も同じコマンド)
+npm run test:run --workspaces --if-present
+npm run test:run -w @typedcode/shared      # 個別実行
 npm run test:coverage -w @typedcode/shared
-# 注: CI が回すのは shared / workers (editor のテストは CI 未組込み)
+
+# E2E (Playwright。workers + editor の dev サーバを自動起動して round-trip 検証)
+npm run test -w @typedcode/e2e
+# 注: CI は「ユニット (test job) + e2e (e2e job)」を全 deploy のゲートにしている
 ```
 
 ## ドキュメント階層

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 | [@typedcode/verify-cli](packages/verify-cli/) | CLI 検証ツール (Node.js ≥24) |
 | [@typedcode/shared](packages/shared/) | コアライブラリ: TypingProof / Fingerprint / 検証 / 型定義 |
 | [@typedcode/workers](packages/workers/) | Cloudflare Workers API (Turnstile 連携・チェックポイント署名) |
+| [@typedcode/e2e](packages/e2e/) | Playwright E2E テスト (実エディタで証明を生成し verify-cli で round-trip 検証) |
 
 ## ライブデモ
 

--- a/packages/e2e/CLAUDE.md
+++ b/packages/e2e/CLAUDE.md
@@ -1,0 +1,46 @@
+# packages/e2e — CLAUDE.md
+
+`@typedcode/e2e` は **実物のエディタをブラウザで動かし、証明を export して verify-cli で検証する round-trip E2E**。editor の記録系・shared の検証系・CLI を 1 本で同時に検証する。
+
+## 責務と境界
+
+- **持つ**: Playwright (Chromium) でのシナリオ駆動、export ZIP の取得、verify-cli の spawn と exit code / `--analysis-json` 判定、敵対的パック (偽造・改竄・合成打鍵・AI 一括投入) の負のオラクル
+- **持たない**: UI の見た目 assert (暗号的に検証可能な成果物をオラクルにするので flaky になりにくい)、ユニットテスト (各パッケージの `__tests__` が担う)、proof 生成/検証ロジック本体 (editor / shared)
+
+## 重要な不変条件
+
+1. **オラクルは verify-cli の結論**: 「編集 → export → verify-cli が pass/fail」を軸にする。DOM の見た目ではなくチェーン検証の exit code / analysis JSON で判定する
+2. **負のオラクルを必ず持つ**: 改竄シナリオは verify-cli が **exit 1 で拒否する**ことを assert する (1 種でも素通りすると「壊れた検証器」を緑と誤認する)。positive control (無改竄が pass) と対で置く
+3. **信頼打鍵と合成打鍵を区別**: Playwright の `keyboard.type` は CDP 経由で `isTrusted=true`。合成打鍵 (ADR-0018) は `page.evaluate(dispatchEvent)` で `isTrusted=false` を注入する
+4. **CI 時間を意識**: PoSW full 検証は重い。改竄など PoSW 無関係なシナリオは `--mode fast` を使い、happy 系はコードを短くする (deploy.yml の e2e job は `timeout-minutes: 30`、実測 ~18 分)
+
+## 構成
+
+```
+tests/
+├── helpers/app.ts        # EditorApp ページオブジェクト + ZIP/proof 読み出しヘルパ
+├── helpers/verifyCli.ts  # tsx で verify-cli/src/cli.ts を直接実行 (raw TS の ESM 解決回避)
+├── happy-path / multi-tab-export / reload-recovery / close-tab-recovery / ...
+└── proof-forgery / tamper-detection / ai-bulk-insert / synthetic-keystroke  (敵対的パック)
+playwright.config.ts      # webServer で workers(:8787) + editor(:5173) を自動起動
+scripts/setup-env.mjs     # CI 用: Turnstile 公開テストキー配置 + checkpoint 署名鍵を実行時生成
+```
+
+## 実行
+
+```bash
+npm run install-browsers -w @typedcode/e2e   # 初回のみ
+npm run setup -w @typedcode/e2e              # CI: テストキー + 署名鍵の用意
+npm run test -w @typedcode/e2e               # 全シナリオ (サーバは Playwright が自動起動)
+npm run test:headed -w @typedcode/e2e        # 失敗調査 (ブラウザ表示)
+```
+
+CI では `deploy.yml` の `e2e` job が実行し、`deploy-preview` / `deploy-staging` / `deploy-production` の **必須ゲート** (`needs: [test, check, e2e]`) になっている。
+
+## よくある罠
+
+- **`verify-cli` は tsx で src を直接実行**: shared が raw TS (`src/index.ts`) のため `node dist/cli.js` は `ERR_MODULE_NOT_FOUND`。`helpers/verifyCli.ts` が `tsx cli.ts` で回避する
+- **打鍵直後の即リロードはイベント取り残し**: PoSW / IndexedDB flush 前に reload するとチェーンが途切れる。`waitForSynced` (`#sync-status-item.synced` + event-count 安定) を挟む
+- **headless では本物の window blur が出ない**: `window.dispatchEvent(new Event('blur'))` で発火させる (handleBlur は isTrusted 非依存)
+- **画面共有は fake-media フラグで動く**: `playwright.config.ts` の chromium 引数で `getDisplayMedia` が monitor の fake stream を返す
+- **AI 一括投入の再現は dev フック経由**: `keyboard.insertText` は Monaco が 1 文字ずつ分解するため再現にならない。`window.__tcTestInsertBlock` (dev 限定) で `executeEdits` を 1 回適用する


### PR DESCRIPTION
## 概要

同じ `deploy.yml` と root ドキュメントを触る CI 衛生 3 件をまとめて修正。

### #156 — editor のユニットテストが CI 未組込み
test job が `-w @typedcode/shared` / `-w @typedcode/workers` を個別列挙しており、editor の 8 ファイル 95 件が merge ゲートに掛かっていなかった (中核のキーストローク記録のリグレッションを CI が拾えない)。

- `npm run test:run --workspaces --if-present` に置換。`test:run` script を持つ全 workspace (shared/editor/workers、+ #148 マージ後は verify-cli) を回す。e2e は `test` のみで `test:run` を持たないため誤って拾わない
- ローカル確認: editor 95 / shared 391 / workers 39 が 1 コマンドで pass

### #158 — 全 job に timeout-minutes が無い (既定 360 分)
6 job すべてが無指定でデフォルト 360 分だった。ハング時に無駄にランナーを占有する。

- test / check: 15 分、e2e: 30 分 (実測 ~18 分・dev サーバ起動でハング余地)、deploy 系: 20 分、comment: 5 分
- deploy-production の承認待ち時間は job 開始前なので timeout に含まれない旨をコメント

### #155 — packages/e2e が root ドキュメントに未反映
e2e は develop にマージ済みで CI 必須ゲートなのに、CLAUDE.md のツリー/表・README のパッケージ表に載っておらず「CI が回すのは shared / workers」が stale だった。

- CLAUDE.md: ツリー・パッケージ表・テストコマンド節を更新 (`--workspaces` 実行 + e2e job がゲートである旨)
- README: パッケージ表に @typedcode/e2e を追加
- `packages/e2e/CLAUDE.md` を新設 (唯一 CLAUDE.md を欠いていたパッケージ)

## テスト

- `npm run test:run --workspaces --if-present` がローカルで全 pass することを確認
- deploy.yml の全 job に timeout-minutes が付いたことを確認

Closes #156
Closes #158
Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)