### PR TITLE
docs(workers): checkpoint sign の rate limit 運用手順を明文化 (#136 運用対応)

### DIFF
--- a/packages/workers/CLAUDE.md
+++ b/packages/workers/CLAUDE.md
@@ -84,9 +84,20 @@ CORS は `ALLOWED_ORIGINS` (env var, カンマ区切り) による**許可リス
 
 **CORS の限界と濫用防止**: CORS はブラウザのクロスオリジン**読み取り**のみを制限し、サーバ間アクセス (curl 等) は防げない。`/api/checkpoint/sign` は「任意 content への serverTimestamp 付き署名」を返すだけで、それ自体は何の権限も与えない (署名は『この内容がこのサーバ時刻に提示された』ことしか証明しない)。署名 API の濫用に対する実際の防御線は:
 
-- **per-session 上限**: `SESSION_MAX_CHECKPOINTS` (50,000) と `SESSION_TTL_SECONDS` (7 日)
+- **per-session 上限**: `SESSION_MAX_CHECKPOINTS` (50,000) と `SESSION_TTL_SECONDS` (7 日)。ただし `sessionId`/`tabId` はクライアント任意文字列なので**新規 sessionId を連打されると効かない** (per-key 上限のため)
 - **入力サイズ上限**: `MAX_BODY_BYTES` (8KB) + スキーマ厳格化 (64-hex / 最大長)
-- **IP / グローバル rate limit**: Cloudflare の WAF / Rate Limiting Rules に委譲 (Worker コード外。必要に応じてダッシュボードで設定)
+- **IP / グローバル rate limit**: Cloudflare の WAF / Rate Limiting Rules に委譲 (Worker コード外。下記の通り**必ず設定する**)
+
+### Rate Limiting の設定 (#136・必須の運用対応)
+
+`/api/checkpoint/sign` は無認証で、1 リクエストごとに KV read 1 + ECDSA 署名 1 + KV write 1 を消費する。新規 `sessionId` を連打すると per-session 上限を回避して **KV write を増幅させる DoS** になり、初回 checkpoint が `SESSION_PERSIST_FAILED` (503) を返して全新規セッションの時刻アンカリングが止まりうる。恒久対策 (session/start トークンの sign 前提化) は別途の設計課題 (ADR 要) だが、それまでの防御線として **Cloudflare Rate Limiting Rule を必ず入れる**:
+
+1. Cloudflare ダッシュボード → 対象 Worker のゾーン → Security → WAF → Rate limiting rules
+2. Rule: `URI Path eq "/api/checkpoint/sign"` かつ method POST に対し、**同一 IP から 60 秒あたり N リクエスト** (署名 API の実利用は 1 セッション数秒〜十数秒に 1 回程度なので N=60 程度から始め、正規利用のログを見て調整) を超えたら `Block` (または `Managed Challenge`)
+3. `/api/session/start` にも同様の Rule を推奨 (Turnstile ゲートはあるが署名を伴う)
+4. 設定後、正規の連続 checkpoint (長時間セッション) が誤ブロックされないことを staging で確認する
+
+> この Rule は Worker コード外 (ダッシュボード管理) なのでリポジトリに設定証跡が残らない。**新環境 (staging/production) を立てるたびに手動で入れること。** 未設定だと上記 DoS に開いたままになる。
 
 ## KV ネームスペース
 


### PR DESCRIPTION
## 概要

2026-07 レビュー #136 (high/security) の **運用対応パート**。無認証の `/api/checkpoint/sign` は 1 リクエストで KV read + ECDSA 署名 + KV write を消費し、`sessionId`/`tabId` はクライアント任意文字列なので**新規 sessionId 連打で per-session 上限を回避した KV write 増幅 DoS** になる (初回 checkpoint が `SESSION_PERSIST_FAILED` を返し全新規セッションの時刻アンカリングが停止しうる)。

## 対応

- `packages/workers/CLAUDE.md` の「CORS と濫用防止の設計」に **Rate Limiting の設定手順** を追記:
  - per-session 上限が「新規 sessionId 連打には効かない」限界を明記
  - `/api/checkpoint/sign`・`/api/session/start` への Cloudflare Rate Limiting Rule の具体手順 (URI Path + method + per-IP しきい値 + Block/Challenge)
  - Worker コード外 (ダッシュボード管理) ゆえ新環境ごとに手動設定が必要な旨

## スコープと follow-up

- **実際の Rule 設定は運用者の Cloudflare ダッシュボード作業** (リポジトリ外)。本 PR はその手順の文書化まで。
- **恒久対応** (session/start トークンを sign の前提にする API 変更) は工数 L・フォールバック劣化モードと旧クライアント互換の ADR を要するため別 PR (Wave 5 で #151 の Durable Objects 化と同じ設計判断として扱う)。

このため #136 は close せず **Refs** に留めます (恒久対応の実装で close 予定)。

Refs #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)