### PR TITLE
fix(shared): isSuspiciousBulkInsert を structuralEdit の単一定義に一元化 (#140)

### DIFF
--- a/packages/shared/src/typingProof/StatisticsCalculator.ts
+++ b/packages/shared/src/typingProof/StatisticsCalculator.ts
@@ -4,6 +4,7 @@
  */
 
 import type { StoredEvent, TypingStats, TypingStatistics, EventType } from '../types.js';
+import { isSuspiciousBulkInsert } from './structuralEdit.js';
 
 export class StatisticsCalculator {
   /**
@@ -49,7 +50,9 @@ export class StatisticsCalculator {
       if (event.inputType === 'insertFromDrop') dropEvents++;
       if (event.type === 'contentChange' && event.data) insertEvents++;
       if (event.inputType?.startsWith('delete')) deleteEvents++;
-      if (this.isSuspiciousBulkInsert(event)) bulkInsertEvents++;
+      // bulkInsertEvents は verifier (verifyProofMetadata) が完全一致を要求するため、
+      // 判定は必ず structuralEdit の単一定義を使う (#140。二重実装のドリフト防止)。
+      if (isSuspiciousBulkInsert(event)) bulkInsertEvents++;
       if (event.type === 'templateInjection') templateEvents++;
     }
 
@@ -70,17 +73,4 @@ export class StatisticsCalculator {
     };
   }
 
-  private isSuspiciousBulkInsert(event: StoredEvent): boolean {
-    if (event.type !== 'contentChange') return false;
-
-    if (event.inputType === 'replaceContent' || event.inputType === 'insertReplacementText') {
-      return true;
-    }
-
-    return (
-      event.inputType === 'insertText' &&
-      typeof event.data === 'string' &&
-      event.data.length > 1
-    );
-  }
 }

--- a/packages/shared/src/typingProof/__tests__/structuralEdit.test.ts
+++ b/packages/shared/src/typingProof/__tests__/structuralEdit.test.ts
@@ -4,8 +4,10 @@ import {
   isBenignEditorInsert,
   isMultiLineBulkInsert,
   isFlaggedBulkInsert,
+  isSuspiciousBulkInsert,
   collectInternalPasteContents,
 } from '../structuralEdit.js';
+import { StatisticsCalculator } from '../StatisticsCalculator.js';
 import type { StoredEvent, EditorAssistDeclaration } from '../../types.js';
 
 function insert(data: unknown, inputType: string, rangeLength = 0): StoredEvent {
@@ -143,5 +145,48 @@ describe('getEditorAssistDeclaration', () => {
   it('returns null when no environmentProbe event is present', () => {
     const events = [{ type: 'contentChange', inputType: 'insertText', data: 'a' } as unknown as StoredEvent];
     expect(getEditorAssistDeclaration(events)).toBeNull();
+  });
+});
+
+describe('isSuspiciousBulkInsert (#140: verifier/editor 単一定義)', () => {
+  it('flags replaceContent / insertReplacementText / multi-char insertText', () => {
+    expect(isSuspiciousBulkInsert(insert(')', 'replaceContent'))).toBe(true);
+    expect(isSuspiciousBulkInsert(insert('foo', 'insertReplacementText'))).toBe(true);
+    expect(isSuspiciousBulkInsert(insert('ab', 'insertText'))).toBe(true);
+  });
+
+  it('does not flag a single-char insertText', () => {
+    expect(isSuspiciousBulkInsert(insert('a', 'insertText'))).toBe(false);
+  });
+
+  it('flags a rangeOffset-bearing internal paste that actually inserts content', () => {
+    // #140 のドリフト源。editor がこれを出したとき申告と再計算が一致する必要がある。
+    const ev = { type: 'contentChange', inputType: 'insertFromInternalPaste', data: 'pasted', rangeOffset: 5 } as unknown as StoredEvent;
+    expect(isSuspiciousBulkInsert(ev)).toBe(true);
+  });
+
+  it('does not flag the internal-paste audit marker (rangeOffset == null)', () => {
+    const marker = { type: 'contentChange', inputType: 'insertFromInternalPaste', data: 'pasted', rangeOffset: null } as unknown as StoredEvent;
+    expect(isSuspiciousBulkInsert(marker)).toBe(false);
+  });
+});
+
+describe('bulkInsertEvents parity: StatisticsCalculator (editor 申告) と isSuspiciousBulkInsert (verifier 再計算)', () => {
+  // editor の申告 (StatisticsCalculator.bulkInsertEvents) と verifier の再計算が
+  // 同じ定義から出ることを固定する。ズレると verifyProofMetadata の完全一致照合で
+  // 正規 proof が invalid になる (#140)。
+  it('StatisticsCalculator counts exactly the events isSuspiciousBulkInsert flags', () => {
+    const events: StoredEvent[] = [
+      insert('a', 'insertText'),                    // single char → not bulk
+      insert('foo()', 'insertReplacementText'),     // completion → bulk
+      insert(')', 'replaceContent'),                // type-over → bulk
+      insert('xy', 'insertText'),                   // multi char → bulk
+      { type: 'contentChange', inputType: 'insertFromInternalPaste', data: 'block', rangeOffset: 3 } as unknown as StoredEvent, // rangeOffset paste → bulk
+      { type: 'contentChange', inputType: 'insertFromInternalPaste', data: 'block', rangeOffset: null } as unknown as StoredEvent, // marker → not bulk
+    ];
+    const expected = events.filter((e) => isSuspiciousBulkInsert(e)).length;
+    const stats = new StatisticsCalculator().getTypingStatistics(events, 0);
+    expect(stats.bulkInsertEvents).toBe(expected);
+    expect(stats.bulkInsertEvents).toBe(4);
   });
 });

--- a/packages/shared/src/typingProof/structuralEdit.ts
+++ b/packages/shared/src/typingProof/structuralEdit.ts
@@ -88,6 +88,45 @@ export function isMultiLineBulkInsert(event: StoredEvent): boolean {
 }
 
 /**
+ * 「疑わしい一括挿入」か (bulkInsertEvents メタデータのカウント対象)。
+ *
+ * verifier (`verification.ts` の再計算) と editor (`StatisticsCalculator` の申告) の
+ * **単一の真実源**。過去に両者へ別実装で置かれ、verifier だけが `insertFromInternalPaste`
+ * (rangeOffset 付き・実挿入) を数える分岐を持ってドリフトしていた (#140)。editor が
+ * rangeOffset 付き内部ペーストを出し始めた瞬間、申告 < 再計算で `verifyProofMetadata` の
+ * bulkInsertEvents 照合が失敗し、正規 proof が invalid になる時限バグだった。
+ *
+ * **この定義を変えると既存 proof の bulkInsertEvents 照合が壊れ後方互換を失う** (verifier の
+ * 再計算値が変わるため)。変更時は proof フォーマット互換性を必ず検討すること。
+ */
+export function isSuspiciousBulkInsert(event: StoredEvent): boolean {
+  if (event.type !== 'contentChange') return false;
+
+  if (event.inputType === 'replaceContent' || event.inputType === 'insertReplacementText') {
+    return true;
+  }
+
+  // 内容を実際に挿入する大きな insertFromInternalPaste は怪しい。手製 proof がバルク挿入を
+  // 「内部ペースト」と偽装して isPureTyping 判定を回避するのを防ぐ (verifier は inputType ラベルを
+  // 信用するしかないため)。editor が出す正規の内部ペースト監査イベントは rangeOffset==null で
+  // verifyContentReplay 上スキップされる (内容を挿入しない) ので、ここには該当しない。
+  if (
+    event.inputType === 'insertFromInternalPaste' &&
+    event.rangeOffset != null &&
+    typeof event.data === 'string' &&
+    event.data.length > 1
+  ) {
+    return true;
+  }
+
+  return (
+    event.inputType === 'insertText' &&
+    typeof event.data === 'string' &&
+    event.data.length > 1
+  );
+}
+
+/**
  * events から内部ペースト (自分のコードのコピペ = 許可) の挿入内容を集める。
  * 内部ペーストは `insertFromInternalPaste` の監査マーカー (rangeOffset==null) を伴い、
  * 実際の挿入は別途 contentChange (複数行なら insertParagraph) として記録される。後者を

--- a/packages/shared/src/verification.ts
+++ b/packages/shared/src/verification.ts
@@ -23,7 +23,7 @@ export {
 
 import { deterministicStringify, computeHash } from './utils/hashUtils.js';
 import { computeExamChainRoot } from './exam/examPackage.js';
-import { isBenignEditorInsert, isFlaggedBulkInsert, collectInternalPasteContents } from './typingProof/structuralEdit.js';
+import { isBenignEditorInsert, isFlaggedBulkInsert, collectInternalPasteContents, isSuspiciousBulkInsert } from './typingProof/structuralEdit.js';
 import { POSW_ITERATIONS, EXAM_ROOT_BINDING_V2 } from './version.js';
 import {
   verifyProofSignedCheckpoints,
@@ -383,33 +383,6 @@ export function verifyFinalChainHash(
   }
 
   return { valid: true, computedFinalHash: finalHash, expectedFinalHash: finalHash };
-}
-
-function isSuspiciousBulkInsert(event: StoredEvent): boolean {
-  if (event.type !== 'contentChange') return false;
-
-  if (event.inputType === 'replaceContent' || event.inputType === 'insertReplacementText') {
-    return true;
-  }
-
-  // 内容を実際に挿入する大きな insertFromInternalPaste は怪しい。手製 proof がバルク挿入を
-  // 「内部ペースト」と偽装して isPureTyping 判定を回避するのを防ぐ (verifier は inputType ラベルを
-  // 信用するしかないため)。editor が出す正規の内部ペースト監査イベントは rangeOffset==null で
-  // verifyContentReplay 上スキップされる (内容を挿入しない) ので、ここには該当しない。
-  if (
-    event.inputType === 'insertFromInternalPaste' &&
-    event.rangeOffset != null &&
-    typeof event.data === 'string' &&
-    event.data.length > 1
-  ) {
-    return true;
-  }
-
-  return (
-    event.inputType === 'insertText' &&
-    typeof event.data === 'string' &&
-    event.data.length > 1
-  );
 }
 
 function recomputeProofMetadata(events: StoredEvent[]): ProofMetadataVerificationResult {


### PR DESCRIPTION
## 概要

`isSuspiciousBulkInsert` が verifier (`verification.ts`) と editor (`StatisticsCalculator`) の 2 箇所に別実装で存在し、既にドリフトしていた (#140)。verifier だけが rangeOffset 付き `insertFromInternalPaste` (実挿入) をカウントする分岐を持つため、editor がこのイベントを出した瞬間に申告 (`bulkInsertEvents`) < 再計算となり、`verifyProofMetadata` の完全一致照合で**正規 proof が invalid になる時限バグ**だった。

## 変更

- `typingProof/structuralEdit.ts` に**単一の真実源**として export (verifier 版 = より厳しい定義を採用。既存 proof の照合結果は不変)
- `verification.ts` / `StatisticsCalculator.ts` の private 実装を削除し import に差し替え
- 定義変更が proof 後方互換を壊す旨の警告 doc をコメントに明記
- テスト追加: 単体の判定境界 (marker / rangeOffset paste 含む) + 申告/再計算のパリティ固定

## テスト

- `@typedcode/shared`: 397 passed
- `@typedcode/editor`: 95 passed
- `tsc --noEmit`: clean

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)