### PR TITLE
fix(shared): --require-root-anchor の exam 免除を検証済み束縛に限定する (#131)

### DIFF
--- a/docs/system-spec.md
+++ b/docs/system-spec.md
@@ -509,7 +509,7 @@ interface ExamProofBlock {
 - `verifyProofFile` 全レイヤを `&&` で組み合わせる
 - 署名済み checkpoint は `anchored=true` のとき必須レイヤ。`anchored=false` (旧 proof など) では他レイヤで成立すれば valid
 - **アンカー密度 (ADR-0016)** は既定 warning。`requireAnchorDensity` (verify-cli の `--require-anchor-density` 等) を渡したときのみ `sparse` を signed checkpoint レイヤの fail に合流させる (exam/採点で opt-in)
-- **root サーバアンカー (ADR-0017)**: `sessionStartToken` があるとき token↔署名 cp の `sessionId` 一致も要求する (アンカーとチェーンの結びつき)。`rootAnchored=false` (token 無し = オフライン劣化 / 旧 proof) は既定 warning。`requireRootAnchor` (verify-cli の `--require-root-anchor`) を渡したときのみ fail に合流させる (exam は独自束縛のため対象外。high-stakes 採点で opt-in)
+- **root サーバアンカー (ADR-0017)**: `sessionStartToken` があるとき token↔署名 cp の `sessionId` 一致も要求する (アンカーとチェーンの結びつき)。`rootAnchored=false` (token 無し = オフライン劣化 / 旧 proof) は既定 warning。`requireRootAnchor` (verify-cli の `--require-root-anchor`) を渡したときのみ fail に合流させる (exam の免除は `examBindingVerified` = 束縛検証合格が条件。自己申告の exam ブロックだけでは免除しない #131。high-stakes 採点で opt-in)
 - レイヤ間優先順位: metadata → chain → finalHash → checkpoint → content → signedCheckpoint
 - いずれかが false なら、エラー位置 (event index) とメッセージを返す
 
@@ -669,7 +669,7 @@ typedcode-verify my-code.zip --mode audit    # 将来用 (現状 full と同等)
 | **post-hoc batch signing** | proof 完成後に複数 envelope を短時間で一括取得する攻撃。temporal ratio で検出試行 |
 | **anchor density / sparse (ADR-0016)** | 署名 cp が主張イベント数/時間に対し十分密かを見る指標。`maxGapEvents>500` / `maxGapServerMs>50s` / `firstAnchorLatencyEvents>500` で `sparse`。末尾 1 点アンカー (coverageRatio=1.0 でも疎) を検出。既定 warning、`requireAnchorDensity` で strict-fail |
 | **session start token / serverNonce (ADR-0017)** | session/start が Turnstile 後に発行する ECDSA 署名トークン。`serverNonce` を root (`SHA256(fp ‖ localNonce ‖ serverNonce)`) に焼き、開始時刻をサーバアンカーする。完全オフライン捏造を封じる。Turnstile ゲート + root アンカー + 人間ゲートを兼ね、HMAC attestation の作成経路を置換 |
-| **rootAnchored (ADR-0017)** | proof の root が serverNonce トークンでアンカーされているか。`sessionStartToken` 同梱で true。false (旧 proof / オフライン劣化) は warning、`requireRootAnchor` で strict-fail。exam は対象外 |
+| **rootAnchored (ADR-0017)** | proof の root が serverNonce トークンでアンカーされているか。`sessionStartToken` 同梱で true。false (旧 proof / オフライン劣化) は warning、`requireRootAnchor` で strict-fail。exam の免除は束縛検証合格 (`examBindingVerified`) が条件 (#131) |
 | **isTrusted / 合成打鍵 (ADR-0018)** | keyDown/keyUp の `data.isTrusted===false` = JS dispatch (拡張/ページスクリプト) の合成打鍵。keystroke data 経由で hash chain に焼かれ改ざん耐性あり。`automationAnalyzer` が数えて advisory signal。**限界**: CDP/ハード注入は isTrusted=true で捕捉不可 (部分的) |
 | **(試験) 試験モード** | URL パス `/exam` で入る anti-AI-cheating モード (ADR-0011 でモードを path 分岐化、旧 `?exam=1` sticky を置換)。封印問題 + 監督コード + チェーン根束縛。ADR-0006〜0011 |
 | **モード (casual/class/assignment/exam)** | URL パスで確定する動作モード (ADR-0011/0015)。`/casual` `/class` `/assignment` `/exam`。能力 (スクショ/封印/フルスクリーン等) と storage 名前空間がモード別。proof に自己申告 `mode` を記録 |

--- a/packages/shared/src/__tests__/assurance.test.ts
+++ b/packages/shared/src/__tests__/assurance.test.ts
@@ -106,6 +106,36 @@ describe('deriveAssurance — temporal', () => {
     };
     expect(deriveAssurance(input).temporal).toBe('exam-t0');
   });
+
+  it('does not grant exam-t0 to a self-declared exam block without the package (#131)', () => {
+    const input: AssuranceInput = {
+      ...healthyInput(),
+      rootAnchored: false,
+      signedCheckpoints: undefined,
+      exam: { present: true, packageProvided: false },
+    };
+    expect(deriveAssurance(input).temporal).toBe('unanchored');
+  });
+
+  it('does not grant exam-t0 when the provided exam package fails binding verification (#131)', () => {
+    const input: AssuranceInput = {
+      ...healthyInput(),
+      rootAnchored: false,
+      signedCheckpoints: undefined,
+      exam: { present: true, packageProvided: true, bindingValid: false },
+    };
+    expect(deriveAssurance(input).temporal).toBe('unanchored');
+  });
+
+  it('still derives server time evidence for an unverified exam claim (#131)', () => {
+    // 未検証 exam でも実在するサーバ時刻証拠 (有効な署名 cp) は通常どおり数える。
+    const input: AssuranceInput = {
+      ...healthyInput(),
+      rootAnchored: false,
+      exam: { present: true, packageProvided: false },
+    };
+    expect(deriveAssurance(input).temporal).toBe('partial');
+  });
 });
 
 describe('deriveAssurance — provenance (advisory)', () => {

--- a/packages/shared/src/__tests__/rootAnchorGate.test.ts
+++ b/packages/shared/src/__tests__/rootAnchorGate.test.ts
@@ -1,0 +1,128 @@
+/**
+ * root アンカー必須 gate (ADR-0017 / #131) のテスト。
+ *
+ * #131: gate の exam 免除が `proof.exam` の**存在だけ**で成立していた。exam root は proof 内の
+ * 宣言値から自己完結で再計算されるため、完全オフラインで捏造した proof に架空の exam ブロックを
+ * 付けるだけで `--require-root-anchor` を回避できた。免除は「束縛が実際に検証済み
+ * (`examBindingVerified`)」のときのみに限定する。
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  TypingProof,
+  computeHash,
+  verifyProofFile,
+  type ExamSessionContext,
+  type FingerprintComponents,
+} from '../index.js';
+
+const createMockFingerprintComponents = (): FingerprintComponents => ({
+  userAgent: 'Mozilla/5.0 (RootAnchorGate Test)',
+  language: 'en',
+  languages: ['en'],
+  platform: 'TestOS',
+  hardwareConcurrency: 4,
+  deviceMemory: 8,
+  screen: {
+    width: 1440,
+    height: 900,
+    availWidth: 1440,
+    availHeight: 860,
+    colorDepth: 24,
+    pixelDepth: 24,
+    devicePixelRatio: 2,
+  },
+  timezone: 'UTC',
+  timezoneOffset: 0,
+  canvas: 'mock-canvas',
+  webgl: { vendor: 'Mock', renderer: 'Mock' },
+  fonts: ['Arial'],
+  cookieEnabled: true,
+  doNotTrack: 'unspecified',
+  maxTouchPoints: 0,
+});
+
+/** 攻撃シナリオそのもの: 架空の束縛値で exam root を自己整合させた捏造 proof。 */
+const forgedExamContext = (): ExamSessionContext => ({
+  examId: 'forged-exam',
+  problemId: 'p1',
+  variant: null,
+  packageHash: 'f'.repeat(64),
+  problemContentHash: 'e'.repeat(64),
+  startToken: 'FORGED-TOKEN',
+});
+
+async function buildProof(examContext?: ExamSessionContext) {
+  const components = createMockFingerprintComponents();
+  const fingerprintHash = await computeHash(JSON.stringify(components, null, 0));
+  const proof = new TypingProof();
+  if (examContext) {
+    await proof.initializeExam(fingerprintHash, components, examContext);
+  } else {
+    await proof.initialize(fingerprintHash, components);
+  }
+  let content = '';
+  for (const ch of ['a', 'b', 'c']) {
+    await proof.recordEvent({
+      type: 'contentChange',
+      inputType: 'insertText',
+      data: ch,
+      rangeOffset: content.length,
+      rangeLength: 0,
+    });
+    content += ch;
+  }
+  const exported = await proof.exportProof(content);
+  return { ...exported, content, language: 'text' };
+}
+
+describe('verifyProofFile requireRootAnchor gate (ADR-0017 / #131)', () => {
+  it('accepts an unanchored casual proof when the gate is off (default)', async () => {
+    const proofFile = await buildProof();
+    const result = await verifyProofFile(proofFile, undefined, { mode: 'fast' });
+    expect(result.valid).toBe(true);
+    expect(result.rootAnchored).toBe(false);
+  });
+
+  it('fails an unanchored casual proof when root anchoring is required', async () => {
+    const proofFile = await buildProof();
+    const result = await verifyProofFile(proofFile, undefined, {
+      mode: 'fast',
+      requireRootAnchor: true,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errorMessage).toMatch(/root anchoring is required/i);
+  });
+
+  it('fails a self-declared exam proof whose binding is not verified (#131)', async () => {
+    // 架空の exam ブロック付き捏造 proof。root は exam 式で自己整合するが、束縛は未検証。
+    const proofFile = await buildProof(forgedExamContext());
+    const result = await verifyProofFile(proofFile, undefined, {
+      mode: 'fast',
+      requireRootAnchor: true,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errorMessage).toMatch(/exam binding is not verified/i);
+  });
+
+  it('exempts an exam proof when the caller attests the binding is verified', async () => {
+    const proofFile = await buildProof(forgedExamContext());
+    const result = await verifyProofFile(proofFile, undefined, {
+      mode: 'fast',
+      requireRootAnchor: true,
+      examBindingVerified: true,
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('does not exempt a non-exam proof even when examBindingVerified is passed', async () => {
+    // 呼び出し側の配線ミス (無条件 true 渡し) が casual proof の gate を殺さないこと。
+    const proofFile = await buildProof();
+    const result = await verifyProofFile(proofFile, undefined, {
+      mode: 'fast',
+      requireRootAnchor: true,
+      examBindingVerified: true,
+    });
+    expect(result.valid).toBe(false);
+  });
+});

--- a/packages/shared/src/assurance.ts
+++ b/packages/shared/src/assurance.ts
@@ -23,7 +23,9 @@ export type IntegrityLevel = 'proven' | 'failed';
  * - anchored:   root サーバアンカー + 署名 cp が密 (申告セッション全体が時刻固定)
  * - partial:    何らかのサーバアンカーはあるが弱い (疎 / post-hoc 疑い / root か cp の片方のみ)
  * - unanchored: サーバ由来の時刻証拠なし (完全オフライン捏造の余地)
- * - exam-t0:    試験 proof。T0 束縛 (封印 + 監督コード) が時刻の regime を担う (ADR-0006)
+ * - exam-t0:    試験 proof。T0 束縛 (封印 + 監督コード) が時刻の regime を担う (ADR-0006)。
+ *               **束縛が実際に検証済み (package 提供 + verifyExamBinding 合格) のときのみ** —
+ *               自己申告の exam ブロックだけでは名乗れない (#131、ADR-0020)
  */
 export type TemporalLevel = 'anchored' | 'partial' | 'unanchored' | 'exam-t0';
 
@@ -109,7 +111,11 @@ export function deriveAssurance(input: AssuranceInput): AssuranceResult {
 function deriveTemporal(input: AssuranceInput): TemporalLevel {
   // 試験 proof は T0 束縛 (封印 + 監督コード = proctor) が時刻 regime を担う (ADR-0006)。
   // 署名 cp は best-effort の補強であり、有無で regime は変わらない。
-  if (input.exam?.present) {
+  // ただし exam-t0 を名乗れるのは束縛が**実際に検証済み**のときだけ (#131)。exam ブロックは
+  // 自己申告で root が自己整合するため、存在だけで昇格させると捏造 proof が時刻 regime を
+  // 詐称できる (ADR-0020「自己申告を判定に昇格させない」)。未検証 (package 未提供含む) は
+  // 通常のサーバ時刻証拠の導出に落とす。
+  if (input.exam?.present && input.exam.packageProvided && input.exam.bindingValid === true) {
     return 'exam-t0';
   }
 

--- a/packages/shared/src/verification.ts
+++ b/packages/shared/src/verification.ts
@@ -88,9 +88,16 @@ export interface VerifyProofFileOptions {
   /**
    * root アンカー必須 (ADR-0017)。true のとき、casual/class で root がサーバアンカーされていない
    * (`sessionStartToken` 無し = オフライン劣化 / 旧 proof) proof を fail させる。既定 false = warning のみ。
-   * exam proof は独自の root 束縛を持つため、この gate の対象外 (常に通す)。high-stakes 採点で opt-in。
+   * exam proof の免除は `examBindingVerified` に基づく (下記)。high-stakes 採点で opt-in。
    */
   requireRootAnchor?: boolean;
+  /**
+   * exam 束縛が実際に検証済みか (#131)。呼び出し側が `verifyExamBinding` (署名→packageHash→root→
+   * 内容ハッシュ) に合格したときのみ true を渡す。`requireRootAnchor` の exam 免除はこのフラグに
+   * 基づく — `proof.exam` の**存在だけ**では免除しない (架空の exam ブロックを付けるだけで gate を
+   * 回避できてしまうため。ADR-0020「自己申告を判定に昇格させない」)。
+   */
+  examBindingVerified?: boolean;
 }
 
 /**
@@ -839,9 +846,12 @@ export async function verifyProofFile(
     }
   }
 
-  // 5. ADR-0017: root アンカー必須 (strict, opt-in)。exam は独自束縛のため対象外。
+  // 5. ADR-0017: root アンカー必須 (strict, opt-in)。exam の免除は「束縛が実際に検証済み」の
+  //    ときだけ (#131)。exam ブロックの存在だけで免除すると、架空の exam ブロック (root は exam 式で
+  //    自己整合する) を付けるだけで gate を回避できてしまう。
+  const examExempt = !!proof.exam && options.examBindingVerified === true;
   const rootAnchorBlocks =
-    !!options.requireRootAnchor && !proof.exam && metadataValid && !rootAnchored;
+    !!options.requireRootAnchor && !examExempt && metadataValid && !rootAnchored;
 
   // signed checkpoint が存在しつつ無効なら全体も無効。存在しない (anchored=false) のは
   // 「補助情報が無い」だけで、tamper resistance は他レイヤで担保される。
@@ -862,7 +872,9 @@ export async function verifyProofFile(
               : signedCheckpointBlocks
                 ? signedCheckpointResult.reason
                 : rootAnchorBlocks
-                  ? 'Root is not server-anchored (ADR-0017) but root anchoring is required'
+                  ? proof.exam
+                    ? 'Root anchoring is required and the exam binding is not verified (provide and verify the exam package to exempt an exam proof)'
+                    : 'Root is not server-anchored (ADR-0017) but root anchoring is required'
                   : chainResult.message;
 
   return {

--- a/packages/verify-cli/CLAUDE.md
+++ b/packages/verify-cli/CLAUDE.md
@@ -51,8 +51,8 @@ src/
 
 ## root アンカー gate (ADR-0017)
 
-- `--require-root-anchor` (任意・boolean): root がサーバアンカーされていない (`sessionStartToken` 無し = オフライン劣化 / 旧 proof) proof を **exit 1** にする (採点向け opt-in)。既定は warning のみで `Root anchor: unanchored` を出す。**exam proof は対象外** (独自の T0 束縛を持つ)
-- 判定は shared の `verifyProofFile` (`requireRootAnchor`) に委譲。CLI はフラグを通すだけ。proof は `PROOF_FORMAT_VERSION` 1.2.0 (`MIN_SUPPORTED` 1.0.0 据置) なので **旧 proof もそのまま検証**でき、`rootAnchored:false` で受理 (後方互換)
+- `--require-root-anchor` (任意・boolean): root がサーバアンカーされていない (`sessionStartToken` 無し = オフライン劣化 / 旧 proof) proof を **exit 1** にする (採点向け opt-in)。既定は warning のみで `Root anchor: unanchored` を出す。**exam proof の免除は束縛が検証済み (`--exam-package` で `verifyExamBinding` 合格) のときのみ** (#131) — 自己申告の exam ブロックだけでは gate を回避できない
+- 判定は shared の `verifyProofFile` (`requireRootAnchor` + `examBindingVerified`) に委譲。CLI は `verifyExamBinding` を先に実行して結果フラグを通すだけ。proof は `PROOF_FORMAT_VERSION` 1.2.0 (`MIN_SUPPORTED` 1.0.0 据置) なので **旧 proof もそのまま検証**でき、`rootAnchored:false` で受理 (後方互換)
 
 ## 分析層の出力 (ADR-0009)
 

--- a/packages/verify-cli/src/output.ts
+++ b/packages/verify-cli/src/output.ts
@@ -381,7 +381,9 @@ ${c('cyan', 'Options:')}
   --require-root-anchor
                    Fail (exit 1) when the chain root is not server-anchored (ADR-0017) —
                    i.e. no session start token (offline/degraded or old proof). Off by
-                   default (unanchored root is only a warning). exam proofs are exempt.
+                   default (unanchored root is only a warning). Exam proofs are exempt
+                   ONLY when their binding is verified via --exam-package (#131); a
+                   self-declared exam block alone does not bypass the gate.
   --analysis-json  Write the advisory analysis report (ADR-0009) for every verified
                    proof to the given file as JSON, for aggregation / evaluation
                    tooling. Advisory only — never affects the exit code.

--- a/packages/verify-cli/src/verify.ts
+++ b/packages/verify-cli/src/verify.ts
@@ -105,11 +105,22 @@ export async function verifyProof(
     progressBar.update(current);
   };
 
+  // 試験モード (ADR-0006): exam ブロックがあれば束縛を先に検証する。
+  // root アンカー gate (#131) の exam 免除は「検証済み束縛」に基づくため verifyProofFile より前に計算する。
+  const binding = proof.exam && options.examPackageManifest
+    ? await verifyExamBinding(proof, options.examPackageManifest, {
+        examAuthorityRegistry: EXAM_AUTHORITY_KEYS,
+        submissionTimeMs: options.submittedAtMs,
+      })
+    : undefined;
+
   // Run verification using shared utilities
   const result = await verifyProofFile(proof, onProgress, {
     mode,
     requireAnchorDensity: options.requireAnchorDensity,
     requireRootAnchor: options.requireRootAnchor,
+    // 免除は検証済み束縛のみ。package 未提供 (binding=undefined) の exam proof は gate 対象。
+    examBindingVerified: binding?.valid === true,
   });
 
   progressBar.complete();
@@ -119,17 +130,10 @@ export async function verifyProof(
   // options.analyzers が渡れば (採点者/研究者の外部アナライザ) それを使う。未指定なら shared 既定。
   const analysis = await runAnalysis({ proof, verification: result }, options.analyzers);
 
-  // 試験モード (ADR-0006): exam ブロックがあれば束縛を検証する。
-  // root 束縛は proof 自己完結 (verifyProofFile が rootValid で既に検証済み)。
-  // package が渡されたときのみ署名/復号/内容まで完全検証する。
+  // 試験モード (ADR-0006): root 束縛は proof 自己完結 (verifyProofFile が rootValid で検証済み)。
+  // package が渡されたときのみ署名/復号/内容まで完全検証する (binding は上で計算済み)。
   let exam: CLIExamResult | undefined;
   if (proof.exam) {
-    const binding = options.examPackageManifest
-      ? await verifyExamBinding(proof, options.examPackageManifest, {
-          examAuthorityRegistry: EXAM_AUTHORITY_KEYS,
-          submissionTimeMs: options.submittedAtMs,
-        })
-      : undefined;
     exam = {
       present: true,
       examId: proof.exam.examId,


### PR DESCRIPTION
## 概要

`requireRootAnchor` strict gate (ADR-0017) が**検証されていない自己申告の exam ブロックの存在だけ**で免除されていた (#131)。exam root は proof 内の宣言値から自己完結で再計算されるため、完全オフラインで捏造した proof に架空の exam ブロック (任意の packageHash / startToken) を付けるだけで gate を回避でき、さらに `deriveTemporal` が `exam-t0` 時刻 regime まで名乗らせていた — ADR-0020「自己申告を判定に昇格させない」原則への違反。

## 変更

### shared
- `verifyProofFile` に `examBindingVerified?: boolean` を追加。gate の exam 免除は「呼び出し側が `verifyExamBinding` 合格を確認した」ときのみ (`proof.exam` の存在だけでは免除しない)
- exam claim が未検証のまま gate に落ちたときは専用のエラーメッセージ (exam package の提供・検証を促す)
- `deriveTemporal` (ADR-0020): `exam-t0` は `present && packageProvided && bindingValid === true` のときのみ。未検証 exam claim は通常のサーバ時刻証拠の導出 (anchored/partial/unanchored) に落とす — verify (web) の三層バッジにも自動反映

### verify-cli
- `verifyExamBinding` を `verifyProofFile` より先に実行し、結果を `examBindingVerified` として配線 (package 未提供 = 未検証 = gate 対象)
- help テキストの「exam proofs are exempt.」を検証済み束縛条件に修正

### docs
- `verify-cli/CLAUDE.md` / `docs/system-spec.md` (§6.3 + 用語集) の「exam は対象外」記述を同期

## テスト

- 新規 `rootAnchorGate.test.ts`: 捏造 exam proof (攻撃シナリオそのもの) が gate で fail / `examBindingVerified` で免除 / 非 exam proof はフラグ渡しでも免除されない、の 5 ケース
- `assurance.test.ts`: 未検証 exam claim が `exam-t0` を名乗れない 3 ケース追加
- `@typedcode/shared` 400 passed / `@typedcode/workers` 43 passed / `tsc --noEmit` (shared, verify-cli, verify) clean

## 互換性

- 既定動作 (gate off) は不変。`--require-root-anchor` を課す採点フローで、exam proof は `--exam-package` による束縛検証が新たに必要になる (それが本修正の意図)

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)