### PR TITLE
fix(shared): 単一行 benign insert に長さ上限を設ける (#139)

### DIFF
--- a/packages/shared/src/__tests__/verification.test.ts
+++ b/packages/shared/src/__tests__/verification.test.ts
@@ -206,7 +206,7 @@ describe('verification utilities', () => {
     });
   });
 
-  it('treats a single-line editor completion as pure typing while still counting it in bulkInsertEvents', () => {
+  it('treats a single-line editor completion up to the length cap as pure typing while still counting it in bulkInsertEvents', () => {
     // 1 キー入力 → 複数文字の正規な補完 (括弧自動閉じ・Tab 補完)。Pure Typing を崩さないが、
     // bulkInsertEvents の申告メタデータ照合は従来どおり数える (既存 proof と後方互換)。
     const events = [
@@ -221,6 +221,27 @@ describe('verification utilities', () => {
     expect(verifyProofMetadata(proofData, events)).toMatchObject({
       valid: true,
       isPureTyping: true,
+      suspiciousBulkInsertEventIndexes: [0],
+    });
+  });
+
+  it('breaks pure typing for a single-line insert beyond the benign length cap (#139)', () => {
+    // minify した 1 行のプログラム全体を insertText 1 イベントで投入する laundering。
+    // 改行を含まないため従来は「補完」扱いで isPureTyping=true を保てていた。
+    // metadata 照合 (bulkInsertEvents=1) は従来どおり一致し valid は保つ (advisory のみの変化)。
+    const oneLiner = 'const f=(n)=>n<2?n:f(n-1)+f(n-2);console.log(f(30));'.repeat(8); // 416 chars
+    const events = [
+      { type: 'contentChange', inputType: 'insertText', data: oneLiner, timestamp: 10 },
+    ] as StoredEvent[];
+    const proofData = {
+      metadata: {
+        totalEvents: 1, pasteEvents: 0, internalPasteEvents: 0, dropEvents: 0,
+        insertEvents: 1, deleteEvents: 0, bulkInsertEvents: 1, totalTypingTime: 10, averageTypingSpeed: 0,
+      },
+    } as ProofData;
+    expect(verifyProofMetadata(proofData, events)).toMatchObject({
+      valid: true,
+      isPureTyping: false,
       suspiciousBulkInsertEventIndexes: [0],
     });
   });

--- a/packages/shared/src/typingProof/__tests__/structuralEdit.test.ts
+++ b/packages/shared/src/typingProof/__tests__/structuralEdit.test.ts
@@ -5,6 +5,7 @@ import {
   isMultiLineBulkInsert,
   isFlaggedBulkInsert,
   collectInternalPasteContents,
+  MAX_BENIGN_SINGLE_LINE_INSERT_CHARS,
 } from '../structuralEdit.js';
 import type { StoredEvent, EditorAssistDeclaration } from '../../types.js';
 
@@ -31,6 +32,21 @@ describe('isBenignEditorInsert', () => {
 
   it('accepts a single-line completion that contains operators and spaces', () => {
     expect(isBenignEditorInsert(insert('result = a + b;', 'insertReplacementText'))).toBe(true);
+  });
+
+  it('accepts a single-line completion up to the length cap (#139)', () => {
+    const atCap = 'x'.repeat(MAX_BENIGN_SINGLE_LINE_INSERT_CHARS);
+    expect(isBenignEditorInsert(insert(atCap, 'insertReplacementText'))).toBe(true);
+  });
+
+  it('rejects a single-line insert longer than the cap (minified one-liner laundering, #139)', () => {
+    const oneLiner = 'const f=(n)=>n<2?n:f(n-1)+f(n-2);'.repeat(10); // 330 chars, no newline
+    expect(isBenignEditorInsert(insert(oneLiner, 'insertText'))).toBe(false);
+    expect(isBenignEditorInsert(insert('y'.repeat(MAX_BENIGN_SINGLE_LINE_INSERT_CHARS + 1), 'insertReplacementText'))).toBe(false);
+  });
+
+  it('keeps structural-only inserts benign regardless of length (they cannot carry code)', () => {
+    expect(isBenignEditorInsert(insert(' '.repeat(500), 'insertText'))).toBe(true);
   });
 
   it('accepts whitespace-only multi-line auto-indent', () => {

--- a/packages/shared/src/typingProof/structuralEdit.ts
+++ b/packages/shared/src/typingProof/structuralEdit.ts
@@ -13,7 +13,8 @@
  * TypedCode 自身はインライン AI 補完を無効化している前提だが、万一混入しても捕捉する。
  *
  * 区別の基準は **複数行かどうか** (ユーザ確認済み):
- *   - benign  = editor 内部の挿入/置換で「構造文字のみ」または「単一行」
+ *   - benign  = editor 内部の挿入/置換で「構造文字のみ」または「上限長以内の単一行」
+ *               (単一行にも長さ上限を置く (#139)。minify した 1 行プログラムの laundering 対策)
  *   - bulk    = 改行＋実コードを含む複数行の挿入 (AI/スニペットの一括投入。記録・検出対象)
  *
  * いずれも `valid` (暗号的合否) や `bulkInsertEvents` の申告メタデータ照合には影響しない。
@@ -65,15 +66,24 @@ export function getEditorAssistDeclaration(
 }
 
 /**
+ * 単一行 benign (補完) とみなす最大文字数 (#139)。現実の補完は識別子〜1 式程度で、これで
+ * 十分収まる。上限が無いと minify した 1 行のプログラム全体 (数千文字) を `insertText`
+ * 1 イベントで投入しても isPureTyping を保ててしまう (laundering 口)。
+ * 構造文字のみ (内容を運べない) の挿入には適用しない。
+ */
+export const MAX_BENIGN_SINGLE_LINE_INSERT_CHARS = 120;
+
+/**
  * 「1 キー入力 → 複数文字」の正規な editor 挿入か (括弧自動閉じ・type-over・auto-indent・
- * 単一行の補完)。構造文字のみ、または単一行 (改行を含まない) の editor 内部挿入。
+ * 単一行の補完)。構造文字のみ、または上限長以内の単一行 (改行を含まない) の editor 内部挿入。
+ * 上限を超える単一行挿入は補完として現実的でないため benign にしない (#139)。
  */
 export function isBenignEditorInsert(event: StoredEvent): boolean {
   if (!isEditorInternalInsert(event)) return false;
   const data = event.data;
   if (typeof data !== 'string' || data.length === 0) return false;
   if (STRUCTURAL_CHARS.test(data)) return true; // 括弧/クォート/空白のみ (内容を運べない)
-  return !/[\r\n]/.test(data); // 単一行 = 補完
+  return !/[\r\n]/.test(data) && data.length <= MAX_BENIGN_SINGLE_LINE_INSERT_CHARS; // 単一行 = 補完 (上限つき)
 }
 
 /**


### PR DESCRIPTION
## 概要

`isBenignEditorInsert` は改行を含まない挿入を**長さ無制限**で「補完」とみなしていた (#139)。このため minify した 1 行のプログラム全体 (数千文字) を `insertText` 1 イベントで投入しても `isPureTyping=true` を保てた (bulkInsertEvents にはカウントされるが著述性バッジは崩れない laundering 口)。

## 変更

- `MAX_BENIGN_SINGLE_LINE_INSERT_CHARS = 120` を導入 ([structuralEdit.ts](packages/shared/src/typingProof/structuralEdit.ts))。現実の補完 (識別子〜1 式) は収まる長さで、超過する単一行挿入は benign にしない
- 構造文字のみ (括弧/クォート/空白 = コード内容を運べない) は従来どおり長さ不問
- `isBenignEditorInsert` は verification / processSummary / pureTypingAnalyzer が共有する単一定義のため、変更は 1 箇所で全経路に反映

## 互換性

`isPureTyping` は **verifier 再計算の advisory** で、メタデータ完全一致照合 (`bulkInsertEvents` は `isSuspiciousBulkInsert` ベース) には載らない。よって**既存 proof の valid 判定は不変**。120 字超の単一行補完を含む過去の正規 proof は著述性表示のみ `external input present` 側に変わる (それがこの修正の意図 — 実際に一括投入だったのだから)。

## テスト

- `structuralEdit.test.ts`: 上限ちょうど benign / 超過 reject / 構造文字は長さ不問、の境界 3 ケース
- `verification.test.ts`: 416 字の minify 1 行投入で `isPureTyping=false` かつ metadata 照合は valid のまま (攻撃経路そのもの)
- `@typedcode/shared` 396 passed / `tsc --noEmit` clean

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)