### PR TITLE
test(editor): Argon2id 封印テストの timeout を既定 5000ms から引き上げる

### DIFF
--- a/packages/editor/src/authoring/__tests__/authorityKey.test.ts
+++ b/packages/editor/src/authoring/__tests__/authorityKey.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { verifyExamPackageSignature, type ExamAuthorityKey } from '@typedcode/shared';
 import { generateAuthorityKey, suggestKeyId } from '../authorityKey.js';
 import { createExamPackage, importAuthoritySigner } from '../examPackageAuthoring.js';
+
+// end-to-end ケースは Argon2id 封印 (createExamPackage) を実際に回すため CI ランナーで
+// vitest 既定 5000ms に迫る。examPackageAuthoring.test.ts と同じ理由で余裕を持たせる。
+vi.setConfig({ testTimeout: 60_000 });
 
 describe('suggestKeyId', () => {
   it('formats as exam-YYYYMM-xxxxxx from the given date and random hex', () => {

--- a/packages/editor/src/authoring/__tests__/examPackageAuthoring.test.ts
+++ b/packages/editor/src/authoring/__tests__/examPackageAuthoring.test.ts
@@ -1,4 +1,9 @@
-import { beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+// Argon2id (メモリハード KDF) を実際に回す封印/復号テストは 1 件あたり 2.5〜5 秒超かかり、
+// CI ランナーでは vitest 既定の 5000ms を恒常的に跨いでしまう (editor テストの CI 組込み
+// #155 で顕在化)。KDF の遅さは仕様 (総当たり耐性) なので、このファイルだけ余裕を持たせる。
+vi.setConfig({ testTimeout: 60_000 });
 import {
   canonicalizeStartToken,
   computeExamPackageHash,


### PR DESCRIPTION
## 概要

PR #170 の test job が 2 回連続で fail した原因。`examPackageAuthoring.test.ts` の封印/復号テストは Argon2id (メモリハード KDF) を実際に回すため 1 件 2.5〜5 秒超かかり、GitHub Actions ランナーでは vitest 既定の 5000ms timeout を恒常的にわずかに超える (実測 5029〜5187ms)。editor テストの CI 組込み (#155 / PR #167) で顕在化した。

## 変更

- `examPackageAuthoring.test.ts` / `authorityKey.test.ts` (Argon2id を回す 2 ファイルのみ) に `vi.setConfig({ testTimeout: 60_000 })` を設定
- グローバル (vitest.config.ts) は触らない — 他のテストの genuine hang は従来どおり 5000ms で検出される

KDF の遅さは総当たり耐性のための仕様 (ADR-0006) なので、テストを速くする方向 (パラメータ緩和) は取らない。

## テスト

- `@typedcode/editor`: 95 passed (ローカル)

🤖 Generated with [Claude Code](https://claude.com/claude-code)