### PR TITLE
fix(shared): 内部ペーストの許可をマーカー自己申告から replay 検証に変える (#138)

### DIFF
--- a/packages/shared/src/__tests__/verification.test.ts
+++ b/packages/shared/src/__tests__/verification.test.ts
@@ -270,4 +270,47 @@ describe('verification utilities', () => {
       )
     ).toMatchObject({ valid: true, isPureTyping: true, suspiciousBulkInsertEventIndexes: [] });
   });
+
+  it('does not launder an AI bulk insert through an internal-paste audit marker (#138)', () => {
+    // 手製 proof で「マーカー(data=AI コード) + insertParagraph(同一 data)」のペアを作る手口。
+    // マーカーは自己申告なので根拠にせず、内容がセッション内に実在した replay 証拠を要求する。
+    const ai = 'int solve() {\n  return 42;\n}\n';
+    const events = [
+      { type: 'contentChange', inputType: 'insertFromInternalPaste', data: ai, rangeOffset: null, rangeLength: 0, timestamp: 5 },
+      { type: 'contentChange', inputType: 'insertParagraph', data: ai, rangeOffset: 0, rangeLength: 0, timestamp: 10 },
+    ] as StoredEvent[];
+    const proofData = {
+      metadata: {
+        totalEvents: 2, pasteEvents: 0, internalPasteEvents: 1, dropEvents: 0,
+        insertEvents: 2, deleteEvents: 0, bulkInsertEvents: 0, totalTypingTime: 10, averageTypingSpeed: 0,
+      },
+    } as ProofData;
+    expect(verifyProofMetadata(proofData, events)).toMatchObject({
+      valid: true,
+      isPureTyping: false,
+    });
+  });
+
+  it('keeps a genuine internal paste of session-typed content as pure typing (#138)', () => {
+    // 実際にセッション内で 1 文字ずつ打った内容をコピーして貼り直す正規フロー。
+    // copyOperation がコピー時点の文書と突合され、複数行の実挿入が許可される。
+    const events = [
+      { type: 'contentChange', inputType: 'insertText', data: 'a', rangeOffset: 0, rangeLength: 0, timestamp: 1 },
+      { type: 'contentChange', inputType: 'insertText', data: '\n', rangeOffset: 1, rangeLength: 0, timestamp: 2 },
+      { type: 'contentChange', inputType: 'insertText', data: 'b', rangeOffset: 2, rangeLength: 0, timestamp: 3 },
+      { type: 'copyOperation', inputType: null, data: 'a\nb', rangeLength: 3, timestamp: 4 },
+      { type: 'contentChange', inputType: 'insertFromInternalPaste', data: 'a\nb', rangeOffset: null, rangeLength: 0, timestamp: 5 },
+      { type: 'contentChange', inputType: 'insertParagraph', data: 'a\nb', rangeOffset: 3, rangeLength: 0, timestamp: 6 },
+    ] as StoredEvent[];
+    const proofData = {
+      metadata: {
+        totalEvents: 6, pasteEvents: 0, internalPasteEvents: 1, dropEvents: 0,
+        insertEvents: 5, deleteEvents: 0, bulkInsertEvents: 0, totalTypingTime: 6, averageTypingSpeed: 0,
+      },
+    } as ProofData;
+    expect(verifyProofMetadata(proofData, events)).toMatchObject({
+      valid: true,
+      isPureTyping: true,
+    });
+  });
 });

--- a/packages/shared/src/analysis/analyzers/pureTypingAnalyzer.ts
+++ b/packages/shared/src/analysis/analyzers/pureTypingAnalyzer.ts
@@ -10,7 +10,7 @@
 
 import type { AnalysisInput, AnalysisSignal, Analyzer, EvidenceRef } from '../types.js';
 import { isProhibitedInputType } from '../../typingProof/InputTypeValidator.js';
-import { isBenignEditorInsert, isFlaggedBulkInsert, collectInternalPasteContents } from '../../typingProof/structuralEdit.js';
+import { isBenignEditorInsert, isFlaggedBulkInsert, SessionProvenanceLedger } from '../../typingProof/structuralEdit.js';
 
 const ID = 'example-pure-typing';
 
@@ -28,12 +28,13 @@ export const pureTypingAnalyzer: Analyzer = {
     let dropCount = 0;
     let bulkCount = 0;
     const events = input.proof.proof?.events ?? [];
-    const internalPasteContents = collectInternalPasteContents(events);
+    const ledger = new SessionProvenanceLedger();
     for (let i = 0; i < events.length; i++) {
       const event = events[i];
       if (!event) continue;
+      const sessionDerived = ledger.checkAndApply(event);
       const inputType = event.inputType;
-      if (isFlaggedBulkInsert(event, internalPasteContents)) {
+      if (isFlaggedBulkInsert(event, sessionDerived)) {
         // 複数行のコード一括投入 (Copilot/Cursor が Tab で全体投入する類)。最も注視すべき痕跡。
         bulkCount++;
         evidence.push({ fromEventIndex: i, note: `multiline-bulk:${inputType ?? 'insert'}` });

--- a/packages/shared/src/processSummary.ts
+++ b/packages/shared/src/processSummary.ts
@@ -15,7 +15,7 @@
 import type { StoredEvent } from './types/proof.js';
 import type { CodeExecutionEventData, FocusChangeData, ReflectionNoteData } from './types/events.js';
 import { isProhibitedInputType } from './typingProof/InputTypeValidator.js';
-import { isBenignEditorInsert, isFlaggedBulkInsert, collectInternalPasteContents } from './typingProof/structuralEdit.js';
+import { isBenignEditorInsert, isFlaggedBulkInsert, SessionProvenanceLedger } from './typingProof/structuralEdit.js';
 
 /** 編集の停止 (考え中) とみなす contentChange 間ギャップの下限。 */
 export const PROCESS_PAUSE_THRESHOLD_MS = 10_000;
@@ -80,8 +80,8 @@ export interface ProcessSummary {
  */
 export function summarizeProcess(events: readonly StoredEvent[]): ProcessSummary {
   const moments: ProcessKeyMoment[] = [];
-  // 内部ペースト (自分のコード) の実挿入を AI 一括投入と取り違えないための許可リスト。
-  const internalPasteContents = collectInternalPasteContents(events);
+  // 内部ペースト (自分のコード) の実挿入を AI 一括投入と取り違えないための逐次台帳 (#138)。
+  const ledger = new SessionProvenanceLedger();
 
   let contentChangeCount = 0;
   let insertedChars = 0;
@@ -148,6 +148,8 @@ export function summarizeProcess(events: readonly StoredEvent[]): ProcessSummary
 
   for (let i = 0; i < events.length; i++) {
     const event = events[i]!;
+    // 逐次判定 (イベント適用前の状態に対して)。全イベントを記録順に通す必要がある。
+    const sessionDerived = ledger.checkAndApply(event);
 
     switch (event.type) {
       case 'contentChange': {
@@ -274,7 +276,7 @@ export function summarizeProcess(events: readonly StoredEvent[]): ProcessSummary
     // 明示的に拾う)。後者は「コード全体を Tab で一気に入れる」類を記録・検出するため。
     if (
       (event.inputType && isProhibitedInputType(event.inputType) && !isBenignEditorInsert(event)) ||
-      isFlaggedBulkInsert(event, internalPasteContents)
+      isFlaggedBulkInsert(event, sessionDerived)
     ) {
       externalInputCount++;
       if (externalMoments.length < PROCESS_MAX_EXTERNAL_INPUT_MOMENTS) {

--- a/packages/shared/src/typingProof/__tests__/structuralEdit.test.ts
+++ b/packages/shared/src/typingProof/__tests__/structuralEdit.test.ts
@@ -4,7 +4,7 @@ import {
   isBenignEditorInsert,
   isMultiLineBulkInsert,
   isFlaggedBulkInsert,
-  collectInternalPasteContents,
+  SessionProvenanceLedger,
 } from '../structuralEdit.js';
 import type { StoredEvent, EditorAssistDeclaration } from '../../types.js';
 
@@ -91,23 +91,65 @@ describe('isMultiLineBulkInsert', () => {
 describe('isFlaggedBulkInsert (内部ペースト除外)', () => {
   const code = 'int helper = 7;\r\n';
 
-  it('flags an AI/external multi-line block when no internal-paste audit matches', () => {
-    expect(isFlaggedBulkInsert(insert(code, 'insertParagraph'), new Set())).toBe(true);
+  it('flags an AI/external multi-line block that is not session-derived', () => {
+    expect(isFlaggedBulkInsert(insert(code, 'insertParagraph'), false)).toBe(true);
   });
 
-  it('does NOT flag a multi-line insert whose content matches an internal-paste audit', () => {
-    const internal = new Set([code]);
-    expect(isFlaggedBulkInsert(insert(code, 'insertParagraph'), internal)).toBe(false);
+  it('does NOT flag a multi-line insert verified as session-derived', () => {
+    expect(isFlaggedBulkInsert(insert(code, 'insertParagraph'), true)).toBe(false);
+  });
+});
+
+describe('SessionProvenanceLedger (#138: 内部ペーストの内容はセッション由来を replay で検証する)', () => {
+  const code = 'int helper = 7;\n';
+
+  function typed(data: string, rangeOffset: number, rangeLength = 0): StoredEvent {
+    return { type: 'contentChange', inputType: 'insertText', data, rangeOffset, rangeLength } as unknown as StoredEvent;
+  }
+  function copyOp(data: string): StoredEvent {
+    return { type: 'copyOperation', inputType: null, data } as unknown as StoredEvent;
+  }
+  function run(events: StoredEvent[]): boolean[] {
+    const ledger = new SessionProvenanceLedger();
+    return events.map((e) => ledger.checkAndApply(e));
+  }
+
+  it('accepts a re-insertion of content present in the document before the event', () => {
+    const results = run([typed(code, 0), typed(code, code.length)]);
+    expect(results[1]).toBe(true);
   });
 
-  it('collectInternalPasteContents gathers insertFromInternalPaste data', () => {
-    const events = [
-      insert('a', 'insertText'),
-      insert(code, 'insertFromInternalPaste'),
-    ];
-    const set = collectInternalPasteContents(events as never);
-    expect(set.has(code)).toBe(true);
-    expect(set.size).toBe(1);
+  it('accepts content matching a verified copyOperation even after the original was deleted', () => {
+    const deleteAll = { type: 'contentChange', inputType: 'deleteContentBackward', data: '', rangeOffset: 0, rangeLength: code.length } as unknown as StoredEvent;
+    const results = run([typed(code, 0), copyOp(code), deleteAll, typed(code, 0)]);
+    expect(results[1]).toBe(true); // copy 時点で文書に実在 → 検証済みコピー
+    expect(results[3]).toBe(true); // 削除後でもコピー由来として許可 (editor の copiedContent と同じ)
+  });
+
+  it('rejects content that never existed in the session (marker laundering, #138)', () => {
+    const ai = 'int ai() {\n  return 42;\n}\n';
+    const marker = { type: 'contentChange', inputType: 'insertFromInternalPaste', data: ai, rangeOffset: null, rangeLength: 0 } as unknown as StoredEvent;
+    const insertion = { type: 'contentChange', inputType: 'insertParagraph', data: ai, rangeOffset: 9, rangeLength: 0 } as unknown as StoredEvent;
+    const results = run([typed('unrelated', 0), marker, insertion]);
+    expect(results[1]).toBe(false); // マーカー (自己申告) は根拠にならない
+    expect(results[2]).toBe(false); // 実挿入もセッション由来と認めない
+  });
+
+  it('rejects an insertion whose only evidence is the insertion itself (insertion-then-marker reordering)', () => {
+    // 事前パスの許可リスト方式だと「実挿入 → マーカー」の並べ替えで挿入後の文書を根拠に
+    // 自己検証できた。逐次判定 (適用前の状態) はこれを塞ぐ。
+    const ai = 'int ai() {\n  return 42;\n}\n';
+    const insertion = { type: 'contentChange', inputType: 'insertParagraph', data: ai, rangeOffset: 0, rangeLength: 0 } as unknown as StoredEvent;
+    const marker = { type: 'contentChange', inputType: 'insertFromInternalPaste', data: ai, rangeOffset: null, rangeLength: 0 } as unknown as StoredEvent;
+    const results = run([insertion, marker]);
+    expect(results[0]).toBe(false);
+  });
+
+  it('does not trust a fabricated copyOperation whose content was not in the document', () => {
+    const ai = 'int ai() {\n  return 42;\n}\n';
+    const results = run([typed('unrelated', 0), copyOp(ai), typed(ai, 9)]);
+    expect(results[1]).toBe(false);
+    expect(results[2]).toBe(false);
   });
 });
 

--- a/packages/shared/src/typingProof/replay.ts
+++ b/packages/shared/src/typingProof/replay.ts
@@ -1,0 +1,75 @@
+/**
+ * content replay の共有プリミティブ。
+ *
+ * 厳密な検証 (`verification.ts` の `verifyContentReplay` — 不正イベントで fail) と、
+ * advisory な分類 (`structuralEdit.ts` の内部ペースト検証 — 不正イベントは黙って無視) の
+ * 両方が同じ適用規則を使うためにここへ置く。適用規則が 2 実装に分かれると
+ * 「replay は通るのに分類だけずれる」ドリフトが起きる (#140 と同型の問題)。
+ */
+
+import type { StoredEvent } from '../types.js';
+
+export function isTemplateInjectionData(data: unknown): data is { content: string } {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'content' in data &&
+    typeof (data as { content: unknown }).content === 'string'
+  );
+}
+
+/** Monaco の range (1-origin 行/列) を文書内 offset へ変換する。範囲外なら null。 */
+export function offsetFromRange(content: string, event: StoredEvent): number | null {
+  if (typeof event.rangeOffset === 'number') {
+    return event.rangeOffset;
+  }
+
+  const range = event.range;
+  if (!range) return null;
+
+  const lines = content.split('\n');
+  const lineIndex = range.startLineNumber - 1;
+  if (lineIndex < 0 || lineIndex >= lines.length) return null;
+
+  const columnIndex = range.startColumn - 1;
+  const line = lines[lineIndex] ?? '';
+  if (columnIndex < 0 || columnIndex > line.length) return null;
+
+  let offset = columnIndex;
+  for (let i = 0; i < lineIndex; i++) {
+    offset += (lines[i]?.length ?? 0) + 1;
+  }
+  return offset;
+}
+
+/**
+ * 1 イベントを replay 文書へ **best-effort** で適用する (分類用途)。
+ * 適用できないイベント (範囲外・型不正) は黙って無視して元の content を返す —
+ * 厳密な整合性は `verifyContentReplay` が別途 fail させるので、ここでは落とさない。
+ * `insertFromInternalPaste` の監査マーカー (rangeOffset==null) は文書に触れない。
+ */
+export function applyReplayEventTolerant(content: string, event: StoredEvent): string {
+  if (event.type === 'templateInjection') {
+    return isTemplateInjectionData(event.data) ? event.data.content : content;
+  }
+
+  if (event.type === 'contentSnapshot') {
+    return typeof event.data === 'string' ? event.data : content;
+  }
+
+  if (event.type !== 'contentChange') return content;
+
+  if (event.inputType === 'insertFromInternalPaste' && event.rangeOffset == null) {
+    return content;
+  }
+
+  if (typeof event.data !== 'string') return content;
+
+  const offset = offsetFromRange(content, event);
+  const rangeLength = event.rangeLength ?? 0;
+  if (offset === null || rangeLength < 0 || offset < 0 || offset + rangeLength > content.length) {
+    return content;
+  }
+
+  return content.slice(0, offset) + event.data + content.slice(offset + rangeLength);
+}

--- a/packages/shared/src/typingProof/structuralEdit.ts
+++ b/packages/shared/src/typingProof/structuralEdit.ts
@@ -21,6 +21,7 @@
  */
 
 import type { StoredEvent, EditorAssistDeclaration } from '../types.js';
+import { applyReplayEventTolerant } from './replay.js';
 
 /** 構造文字: 括弧・クォート・空白。これらだけなら「内容 (コード)」を運べない。 */
 const STRUCTURAL_CHARS = /^[()\[\]{}<>"'`\s]+$/;
@@ -88,31 +89,61 @@ export function isMultiLineBulkInsert(event: StoredEvent): boolean {
 }
 
 /**
- * events から内部ペースト (自分のコードのコピペ = 許可) の挿入内容を集める。
- * 内部ペーストは `insertFromInternalPaste` の監査マーカー (rangeOffset==null) を伴い、
- * 実際の挿入は別途 contentChange (複数行なら insertParagraph) として記録される。後者を
- * AI 一括投入と取り違えないよう、監査マーカーと同一内容を許可リスト化する。
+ * セッション内在性 (session provenance) の逐次台帳 (#138)。
+ *
+ * 内部ペースト (自分のコードのコピペ = 許可) の実挿入を AI 一括投入と区別するために使う。
+ * 従来は `insertFromInternalPaste` の監査マーカーの data を**無条件に**許可リスト化していた
+ * ため、手製 proof で「マーカー(data=AI コード) + insertParagraph(同一 data)」のペアを
+ * 作るだけで isPureTyping を保てる laundering 口だった (#138)。マーカーは自己申告であり、
+ * 判定の入力にしない (ADR-0020)。
+ *
+ * 代わりに、editor 側 `SessionContentRegistry` の判定 (コピー登録 or 現文書の部分文字列)
+ * を verifier 側で replay により再現する。events を記録順に 1 度ずつ `checkAndApply` へ
+ * 通すと、イベント適用**前**の状態に対して「このイベントの内容はセッション由来か」を返す:
+ *   (a) それ以前の `copyOperation` の data と完全一致し、かつその data がコピー時点の
+ *       replay 文書の部分文字列だった (捏造 copyOperation ごと持ち込む偽装も塞ぐ)。
+ *       コピー済み内容は編集で消えても有効 (editor の copiedContent と同じ)
+ *   (b) 適用前の replay 文書の部分文字列である
+ * 「適用前」が重要 — 事前パスの許可リスト方式だと「実挿入 → マーカー」と並べ替えるだけで
+ * 挿入後の文書を根拠に自己検証できてしまう。
+ *
+ * 限界: 別タブからのコピペは正規でもこの proof (= 1 タブ) 内では検証できず、bulk 扱いに
+ * なる (advisory の isPureTyping が崩れるだけで valid は不変)。タブ横断の突合は ZIP 全体を
+ * 見る呼び出し側の将来課題。
  */
-export function collectInternalPasteContents(events: readonly StoredEvent[]): Set<string> {
-  const out = new Set<string>();
-  for (const event of events) {
-    if (event?.inputType === 'insertFromInternalPaste' && typeof event.data === 'string') {
-      out.add(event.data);
+export class SessionProvenanceLedger {
+  private content = '';
+  private verifiedCopies = new Set<string>();
+
+  /**
+   * イベントを 1 つ進める。返り値は「このイベントの data がセッション由来か」
+   * (適用前の文書 or 検証済みコピーに対する判定)。events の記録順に全イベントを通すこと。
+   */
+  checkAndApply(event: StoredEvent): boolean {
+    const data = typeof event.data === 'string' ? event.data : null;
+    const sessionDerived =
+      data !== null &&
+      data.length > 0 &&
+      (this.verifiedCopies.has(data) || this.content.includes(data));
+
+    if (event.type === 'copyOperation') {
+      // コピー内容が当時の文書に実在したときだけ「セッション由来」と認める。
+      if (sessionDerived && data !== null) this.verifiedCopies.add(data);
+      return sessionDerived;
     }
+
+    this.content = applyReplayEventTolerant(this.content, event);
+    return sessionDerived;
   }
-  return out;
 }
 
 /**
  * 複数行 bulk 挿入のうち「記録・検出すべきもの」か (内部ペーストの実挿入は除外する)。
- * `internalPasteContents` は collectInternalPasteContents の結果を渡す。
+ * `sessionDerived` は `SessionProvenanceLedger.checkAndApply` が当該イベントに返した値
+ * (#138: マーカー由来の許可リストではなく、replay で検証したセッション内在性)。
  */
-export function isFlaggedBulkInsert(
-  event: StoredEvent,
-  internalPasteContents: ReadonlySet<string>,
-): boolean {
+export function isFlaggedBulkInsert(event: StoredEvent, sessionDerived: boolean): boolean {
   if (!isMultiLineBulkInsert(event)) return false;
   // 内部ペースト (自分のコード) の実挿入は許可。AI/外部の一括投入だけ残す。
-  if (typeof event.data === 'string' && internalPasteContents.has(event.data)) return false;
-  return true;
+  return !sessionDerived;
 }

--- a/packages/shared/src/verification.ts
+++ b/packages/shared/src/verification.ts
@@ -23,7 +23,8 @@ export {
 
 import { deterministicStringify, computeHash } from './utils/hashUtils.js';
 import { computeExamChainRoot } from './exam/examPackage.js';
-import { isBenignEditorInsert, isFlaggedBulkInsert, collectInternalPasteContents } from './typingProof/structuralEdit.js';
+import { isBenignEditorInsert, isFlaggedBulkInsert, SessionProvenanceLedger } from './typingProof/structuralEdit.js';
+import { isTemplateInjectionData, offsetFromRange } from './typingProof/replay.js';
 import { POSW_ITERATIONS, EXAM_ROOT_BINDING_V2 } from './version.js';
 import {
   verifyProofSignedCheckpoints,
@@ -253,33 +254,6 @@ export async function verifyInitialHashRoot(
   return { valid: true, computedInitialHash, expectedInitialHash, rootAnchored };
 }
 
-function isTemplateInjectionData(data: unknown): data is { content: string } {
-  return typeof data === 'object' && data !== null && typeof (data as { content?: unknown }).content === 'string';
-}
-
-function offsetFromRange(content: string, event: StoredEvent): number | null {
-  if (typeof event.rangeOffset === 'number') {
-    return event.rangeOffset;
-  }
-
-  const range = event.range;
-  if (!range) return null;
-
-  const lines = content.split('\n');
-  const lineIndex = range.startLineNumber - 1;
-  if (lineIndex < 0 || lineIndex >= lines.length) return null;
-
-  const columnIndex = range.startColumn - 1;
-  const line = lines[lineIndex] ?? '';
-  if (columnIndex < 0 || columnIndex > line.length) return null;
-
-  let offset = columnIndex;
-  for (let i = 0; i < lineIndex; i++) {
-    offset += (lines[i]?.length ?? 0) + 1;
-  }
-  return offset;
-}
-
 function firstMismatchIndex(left: string, right: string): number {
   const length = Math.min(left.length, right.length);
   for (let i = 0; i < length; i++) {
@@ -421,13 +395,16 @@ function recomputeProofMetadata(events: StoredEvent[]): ProofMetadataVerificatio
   const suspiciousBulkInsertEventIndexes: number[] = [];
   // isPureTyping を崩す「正規でない bulk 挿入」の数。2 種を拾う:
   //  (a) 従来の suspicious bulk (insertReplacementText/replaceContent/insertText>1/大内部ペースト)
-  //      のうち、括弧自動閉じ・単一行補完などの benign を除いたもの。
+  //      のうち、括弧自動閉じ・単一行補完などの benign と、検証済み内部ペースト (自分の
+  //      コードのコピペ = 許可。#138 の replay 検証に合格したもの) を除いたもの。
   //  (b) 複数行の実コード一括投入 (AI/snippet)。Monaco は insertParagraph で記録するため
-  //      (a) の suspicious 判定には載らないので別途拾う。空白のみの auto-indent は除外。
+  //      (a) の suspicious 判定には載らないので別途拾う。空白のみの auto-indent と
+  //      検証済み内部ペーストの実挿入は除外。
   // bulkInsertEvents の申告メタデータ照合 (verifyProofMetadata) は従来どおり suspicious のみ
   // 数えるので、既存 proof との後方互換と整合性チェックは保たれる。
   let nonBenignBulkInsertCount = 0;
-  const internalPasteContents = collectInternalPasteContents(events);
+  // #138: 内部ペーストの許可はマーカー (自己申告) でなく、replay で検証したセッション内在性。
+  const ledger = new SessionProvenanceLedger();
 
   for (let i = 0; i < events.length; i++) {
     const event = events[i];
@@ -439,9 +416,13 @@ function recomputeProofMetadata(events: StoredEvent[]): ProofMetadataVerificatio
     if (event.type === 'contentChange' && event.data) insertEvents++;
     if (event.inputType?.startsWith('delete')) deleteEvents++;
 
+    const sessionDerived = ledger.checkAndApply(event);
     const suspicious = isSuspiciousBulkInsert(event);
     if (suspicious) suspiciousBulkInsertEventIndexes.push(i);
-    if ((suspicious && !isBenignEditorInsert(event)) || isFlaggedBulkInsert(event, internalPasteContents)) {
+    if (
+      (suspicious && !isBenignEditorInsert(event) && !sessionDerived) ||
+      isFlaggedBulkInsert(event, sessionDerived)
+    ) {
       nonBenignBulkInsertCount++;
     }
   }


### PR DESCRIPTION
## 概要

`collectInternalPasteContents` が `insertFromInternalPaste` 監査マーカーの data を**無条件に**許可リスト化していたため、手製 proof で「マーカー(data=AI コード) + `insertParagraph`(同一 data)」のペアを作るだけで、数百行の AI コードが `isPureTyping=true` (著述性バッジ維持) のまま通る laundering 口だった (#138)。

## 変更

### SessionProvenanceLedger (新設)
マーカー (自己申告) を判定の入力にせず (ADR-0020)、editor 側 `SessionContentRegistry` の判定を verifier 側で replay により再現する。events を記録順に逐次処理し、**イベント適用前の状態**に対して内容のセッション由来を判定:
- (a) それ以前の `copyOperation` と完全一致、かつその内容がコピー時点の replay 文書に実在した (捏造 copyOperation ごと持ち込む偽装も塞ぐ)。コピー済み内容は編集で消えても有効 (editor の `copiedContent` と同じ)
- (b) 適用前の replay 文書の部分文字列

**「適用前」の逐次判定が本質**: 事前パスの許可リスト方式だと「実挿入 → マーカー」と並べ替えるだけで挿入後の文書を根拠に自己検証できてしまう (実装中に発見し、テストで固定)。

### 付随する構造変更
- replay 適用規則 (`offsetFromRange` 等) を [typingProof/replay.ts](packages/shared/src/typingProof/replay.ts) に抽出し `verifyContentReplay` と共有 (適用規則の二重実装ドリフト防止、#140 と同型)
- 消費側 3 箇所 (`recomputeProofMetadata` / `summarizeProcess` / `pureTypingAnalyzer`) を ledger に移行。`isFlaggedBulkInsert` は `sessionDerived: boolean` を取る形に変更
- `recomputeProofMetadata` の suspicious 経路も検証済みセッション由来を除外条件に追加 (#139 の単一行上限とマージされても正規の内部ペーストを誤検知しない)

## 互換性

- `isPureTyping` は verifier 再計算の advisory。メタデータ完全一致照合 (`bulkInsertEvents`) は不変のため**既存 proof の valid は不変**
- **既知の限界 (コメントに明記)**: 別タブからの正規コピペは proof (= 1 タブ) 内では検証できず bulk 扱いになる (advisory のみの変化)。タブ横断突合は ZIP 全体を見る層の将来課題

## テスト

- `SessionProvenanceLedger` 単体 5 ケース (再挿入 / 削除後のコピー由来 / laundering 拒否 / **並べ替え攻撃拒否** / 捏造 copyOperation 拒否)
- `verifyProofMetadata` end-to-end 2 ケース (laundering ペアで `isPureTyping=false` / 正規の内部ペーストフローは pure 維持)
- `@typedcode/shared` 398 passed / `tsc --noEmit` (shared, verify, verify-cli) clean

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)