### PR TITLE
fix(editor): IDB 保存の毎回フルスキャン解消と閉じタブのゴースト削除 (#144, #145)

### DIFF
--- a/packages/editor/src/ui/tabs/TabManager.ts
+++ b/packages/editor/src/ui/tabs/TabManager.ts
@@ -155,6 +155,14 @@ export class TabManager {
   private static readonly SAVE_DEBOUNCE_MS = 100;
   /** 現在の同期状態 */
   private currentSyncStatus: SyncStatus = 'synced';
+  /**
+   * IndexedDB へ保存済みのイベント数 (タブ毎、メモリ内配列先頭からの個数)。
+   * 保存のたびに全イベントを IDB から読み直して差分計算すると長セッションで保存が
+   * 線形に重くなる (#144) ため、初回だけ IDB と突合してカーソルを確定し、以降は
+   * カーソル以降のみを append する。重複は events store の unique index が弾くので
+   * カーソルが遅れていても二重保存にはならない。
+   */
+  private savedEventCursor: Map<string, number> = new Map();
 
   constructor(editor: monaco.editor.IStandaloneCodeEditor) {
     this.editor = editor;
@@ -466,6 +474,12 @@ export class TabManager {
     // タブを削除
     this.tabs.delete(tabId);
     this.tabOrder = this.tabOrder.filter(id => id !== tabId);
+    this.savedEventCursor.delete(tabId);
+
+    // IndexedDB の行とイベントも削除する (#145)。残すと復旧ダイアログに閉じたタブが
+    // ゴースト表示され、tabOrder フォールバック復元で復活もしうる。実行中の保存処理が
+    // このタブを書き戻さないよう、完了を待ってから消す (fire-and-forget)。
+    this.deleteTabFromIndexedDB(tabId);
 
     // タブが0になった場合
     if (this.tabs.size === 0) {
@@ -497,10 +511,26 @@ export class TabManager {
   }
 
   /**
+   * 閉じたタブの IndexedDB 行とイベントを削除する (#145)。
+   * 実行中の保存処理がタブを書き戻す競合を避けるため、完了を待ってから消す。
+   * 削除は best-effort (失敗しても UI は既に閉じている)。
+   */
+  private deleteTabFromIndexedDB(tabId: string): void {
+    if (!this.sessionService.isInitialized()) return;
+    const pendingSave = this.currentSavePromise ?? Promise.resolve();
+    void pendingSave
+      .catch(() => undefined)
+      .then(() => this.sessionService.deleteTab(tabId))
+      .catch((e) => console.warn('[TabManager] Failed to delete closed tab from IndexedDB:', e));
+  }
+
+  /**
    * すべてのタブを閉じる（テンプレートインポート用）
    * 通常のcloseTabと異なり、最後の1つも閉じる
    */
   async closeAllTabs(): Promise<void> {
+    const closedTabIds = Array.from(this.tabs.keys());
+
     // すべてのモデルと署名サービスを破棄
     for (const tab of this.tabs.values()) {
       tab.model.dispose();
@@ -512,9 +542,14 @@ export class TabManager {
     this.tabOrder = [];
     this.activeTabId = null;
     this.tabSwitches = [];
+    this.savedEventCursor.clear();
 
     // ストレージもクリア
     sessionStorage.removeItem(tabsKey());
+    // IndexedDB の行とイベントも削除 (#145: 残すと復旧ダイアログにゴースト表示される)
+    for (const tabId of closedTabIds) {
+      this.deleteTabFromIndexedDB(tabId);
+    }
   }
 
   /**
@@ -918,18 +953,32 @@ export class TabManager {
         }
       }
 
-      // 既存イベントのシーケンス番号をSetで取得（欠落検出用）
-      const existingEvents = await this.sessionService.getEvents(id);
-      const existingSequences = new Set(existingEvents.map(e => e.sequence));
-
-      // 未保存のイベントをIndexedDBに追加（存在しないシーケンス番号のみ）
+      // 未保存のイベントを IndexedDB に追加 (#144)。
+      // 初回のみ既存イベントを全読みして欠落込みで突合し、以降はカーソル以降だけを
+      // append する (保存は 100ms デバウンスで頻発するため、毎回の全読みは長セッションで
+      // 保存を線形に重くする)。
       let newEventsCount = 0;
-      for (const event of proofState.events) {
-        if (event && !existingSequences.has(event.sequence)) {
-          await this.sessionService.appendEvent(id, event);
-          newEventsCount++;
+      const cursor = this.savedEventCursor.get(id);
+      if (cursor === undefined) {
+        // 初回 (リロード復旧直後など): 既存シーケンスと突合して欠落も補修する (従来挙動)
+        const existingEvents = await this.sessionService.getEvents(id);
+        const existingSequences = new Set(existingEvents.map(e => e.sequence));
+        for (const event of proofState.events) {
+          if (event && !existingSequences.has(event.sequence)) {
+            await this.sessionService.appendEvent(id, event);
+            newEventsCount++;
+          }
+        }
+      } else {
+        for (let i = cursor; i < proofState.events.length; i++) {
+          const event = proofState.events[i];
+          if (event) {
+            await this.sessionService.appendEvent(id, event);
+            newEventsCount++;
+          }
         }
       }
+      this.savedEventCursor.set(id, proofState.events.length);
 
       if (newEventsCount > 0) {
         debugLog(`[TabManager] SAVE: Tab ${id}: saved ${newEventsCount} new events (total: ${proofState.events.length})`);


### PR DESCRIPTION
## 概要

編集ループの IndexedDB 永続化に関する 2 つの Medium (#144, #145) をまとめて修正。どちらも `TabManager` ↔ `SessionStorageService` の同じ配線の問題。

## #144: 保存毎のフルスキャン解消

`saveToIndexedDB` が保存のたびに `getEvents(id)` (tabId index 全読み + ソート) → Set 構築 → 差分 append をしていた。保存は打鍵中 100ms デバウンスで頻発するため、イベント数万の長セッション (試験 90 分で現実的) では保存が線形に重くなり、UI ジャンクと「クラッシュ時の未保存窓」拡大につながる。

- タブ毎の `savedEventCursor` (保存済みイベント数) を導入
- **初回のみ** IDB と突合して欠落込みで補修 (リロード復旧直後の従来挙動を維持)、以降はカーソル以降だけを append
- 途中失敗時はカーソルが進まず次回リトライ。重複は events store の **unique index + `appendEvent` の ConstraintError スキップ**が既に弾くため、カーソル遅延は二重保存にならない
- 保存は `currentSavePromise` の単一フライトで直列化済み (カーソル競合なし)

## #145: 閉じタブのゴースト削除

`closeTab` / `closeAllTabs` が IndexedDB のタブ行とイベントを削除しないため、復旧ダイアログ (`getSessionSummary` → `loadTabs`) に閉じたはずのタブが表示され、`loadFromIndexedDB` の tabOrder フォールバックでは**復活**もしえた。ストレージも肥大する。

- 全コード未使用だった `SessionStorageService.deleteTab` (行 + イベントの一括削除トランザクション) を配線
- 実行中の保存処理の完了を待ってから削除 (in-flight save がタブを書き戻す競合の回避)。削除は best-effort (fire-and-forget)
- `closeAllTabs` (テンプレートインポート経路) も同様に削除

## テスト

- `@typedcode/editor` 95 passed / `tsc --noEmit` clean
- TabManager は Monaco/IDB 依存でユニットテスト基盤が無いため新規テストなし。永続化ラウンドトリップは packages/e2e の既存 spec がカバー (編集→リロード復旧→export→verify-cli)

Closes #144
Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)