### PR TITLE
fix(verify): スクショ検証を shared に一元化し CLI 検証と status 軸合流 (#146, #147)

### DIFF
--- a/packages/shared/src/__tests__/screenshotVerification.test.ts
+++ b/packages/shared/src/__tests__/screenshotVerification.test.ts
@@ -1,0 +1,166 @@
+/**
+ * スクリーンショット検証 (#146/#147) のテスト。
+ * verify (web) と verify-cli が共有する単一実装 — ここが壊れると
+ * 「Web では改ざん FAILED / CLI では PROVEN + exit 0」型の乖離事故に直結する。
+ */
+
+import { describe, expect, it } from 'vitest';
+import JSZip from 'jszip';
+import {
+  sha256HexOfBytes,
+  collectChainImageHashes,
+  checkScreenshotImage,
+  summarizeScreenshotArtifacts,
+  extractScreenshotArtifactsFromZip,
+} from '../index.js';
+import type { StoredEvent } from '../types.js';
+
+const enc = new TextEncoder();
+
+async function hashOf(text: string): Promise<string> {
+  return sha256HexOfBytes(enc.encode(text));
+}
+
+describe('sha256HexOfBytes', () => {
+  it('computes the SHA-256 of raw bytes as lowercase hex', async () => {
+    // 既知ベクトル: SHA-256("abc")
+    expect(await hashOf('abc')).toBe(
+      'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
+    );
+  });
+});
+
+describe('collectChainImageHashes', () => {
+  it('collects imageHash values from screenshotCapture events across proofs', () => {
+    const eventsA = [
+      { type: 'screenshotCapture', data: { imageHash: 'aa' } },
+      { type: 'contentChange', data: 'x' },
+    ] as unknown as StoredEvent[];
+    const eventsB = [{ type: 'screenshotCapture', data: { imageHash: 'bb' } }] as unknown as StoredEvent[];
+    expect(collectChainImageHashes([eventsA, eventsB])).toEqual(new Set(['aa', 'bb']));
+  });
+
+  it('ignores screenshotCapture events without a usable imageHash', () => {
+    const events = [
+      { type: 'screenshotCapture', data: {} },
+      { type: 'screenshotCapture', data: null },
+      { type: 'screenshotCapture', data: { imageHash: '' } },
+    ] as unknown as StoredEvent[];
+    expect(collectChainImageHashes([events]).size).toBe(0);
+  });
+});
+
+describe('checkScreenshotImage', () => {
+  it('verifies an image whose bytes match the manifest hash and the chain', async () => {
+    const bytes = enc.encode('image-1');
+    const hash = await sha256HexOfBytes(bytes);
+    const check = await checkScreenshotImage(bytes, hash, new Set([hash]));
+    expect(check).toEqual({ verified: true, tampered: false });
+  });
+
+  it('flags a hash mismatch as tampered', async () => {
+    const check = await checkScreenshotImage(enc.encode('swapped'), 'f'.repeat(64), new Set(['f'.repeat(64)]));
+    expect(check.tampered).toBe(true);
+    expect(check.verified).toBe(false);
+  });
+
+  it('flags a manifest+image pair swap: hash self-consistent but not backed by the chain', async () => {
+    const bytes = enc.encode('attacker image');
+    const hash = await sha256HexOfBytes(bytes);
+    const check = await checkScreenshotImage(bytes, hash, new Set(['0'.repeat(64)]));
+    expect(check).toEqual({ verified: true, tampered: true });
+  });
+
+  it('does not require chain backing when the chain set is empty (old proofs)', async () => {
+    const bytes = enc.encode('legacy');
+    const hash = await sha256HexOfBytes(bytes);
+    expect((await checkScreenshotImage(bytes, hash, new Set())).tampered).toBe(false);
+    expect((await checkScreenshotImage(bytes, hash, undefined)).tampered).toBe(false);
+  });
+});
+
+describe('summarizeScreenshotArtifacts', () => {
+  it('counts verified / missing / tampered / chainOnly in one pass', async () => {
+    const okBytes = enc.encode('ok');
+    const okHash = await sha256HexOfBytes(okBytes);
+    const swappedHash = await sha256HexOfBytes(enc.encode('original'));
+    const strippedHash = '1'.repeat(64);
+
+    const images = new Map<string, Uint8Array>([
+      ['ok.webp', okBytes],
+      ['swapped.webp', enc.encode('not the original')],
+    ]);
+    const summary = await summarizeScreenshotArtifacts({
+      entries: [
+        { filename: 'ok.webp', imageHash: okHash },
+        { filename: 'swapped.webp', imageHash: swappedHash },
+        { filename: 'gone.webp', imageHash: '2'.repeat(64) },
+      ],
+      getImageBytes: async (name) => images.get(name) ?? null,
+      chainImageHashes: new Set([okHash, swappedHash, '2'.repeat(64), strippedHash]),
+    });
+
+    expect(summary).toEqual({ total: 3, verified: 1, missing: 1, tampered: 1, chainOnly: 1 });
+  });
+
+  it('reports stripped screenshots as chainOnly when the manifest is empty or absent', async () => {
+    const summary = await summarizeScreenshotArtifacts({
+      entries: [],
+      getImageBytes: async () => null,
+      chainImageHashes: new Set(['a'.repeat(64), 'b'.repeat(64)]),
+    });
+    expect(summary.total).toBe(0);
+    expect(summary.chainOnly).toBe(2);
+  });
+});
+
+describe('extractScreenshotArtifactsFromZip', () => {
+  async function buildZip(files: Record<string, string | Uint8Array>): Promise<ArrayBuffer> {
+    const zip = new JSZip();
+    for (const [path, content] of Object.entries(files)) {
+      zip.file(path, content);
+    }
+    return zip.generateAsync({ type: 'arraybuffer' });
+  }
+
+  it('returns manifest entries and image bytes without judging them', async () => {
+    const buffer = await buildZip({
+      'screenshots/manifest.json': JSON.stringify({
+        version: '1.0',
+        screenshots: [
+          { filename: 'a.webp', imageHash: 'a'.repeat(64) },
+          { filename: 'gone.webp', imageHash: 'b'.repeat(64) },
+        ],
+      }),
+      'screenshots/a.webp': enc.encode('img'),
+    });
+    const artifacts = await extractScreenshotArtifactsFromZip(buffer);
+    expect(artifacts).not.toBeNull();
+    expect(artifacts!.entries).toEqual([
+      { filename: 'a.webp', imageHash: 'a'.repeat(64) },
+      { filename: 'gone.webp', imageHash: 'b'.repeat(64) },
+    ]);
+    expect(artifacts!.images.has('a.webp')).toBe(true);
+    expect(artifacts!.images.has('gone.webp')).toBe(false);
+  });
+
+  it('supports the legacy array-form manifest', async () => {
+    const buffer = await buildZip({
+      'screenshots/manifest.json': JSON.stringify([{ filename: 'x.webp', imageHash: 'c'.repeat(64) }]),
+    });
+    const artifacts = await extractScreenshotArtifactsFromZip(buffer);
+    expect(artifacts!.entries).toHaveLength(1);
+  });
+
+  it('returns null when there is no screenshots/manifest.json at all', async () => {
+    const buffer = await buildZip({ 'main_proof.json': '{}' });
+    expect(await extractScreenshotArtifactsFromZip(buffer)).toBeNull();
+  });
+
+  it('returns empty entries (not null) for a corrupt manifest so chain-only stripping still surfaces', async () => {
+    const buffer = await buildZip({ 'screenshots/manifest.json': '{not json' });
+    const artifacts = await extractScreenshotArtifactsFromZip(buffer);
+    expect(artifacts).not.toBeNull();
+    expect(artifacts!.entries).toEqual([]);
+  });
+});

--- a/packages/shared/src/fileProcessing/index.ts
+++ b/packages/shared/src/fileProcessing/index.ts
@@ -29,5 +29,6 @@ export {
   parseZipBuffer,
   extractFirstProofFromZip,
   extractAllProofsFromZip,
+  extractScreenshotArtifactsFromZip,
   assertZipWithinBudget,
 } from './parser.js';

--- a/packages/shared/src/fileProcessing/parser.ts
+++ b/packages/shared/src/fileProcessing/parser.ts
@@ -298,6 +298,56 @@ async function loadScreenshotsFromZip(
 }
 
 /**
+ * ZIP から `screenshots/manifest.json` の entry 群と画像バイト列を取り出す (#147)。
+ *
+ * ここでは**検証しない** — 判定 (ハッシュ突合・チェーン裏付け) は
+ * `screenshotVerification.ts` の `summarizeScreenshotArtifacts` に委譲する。
+ * - manifest 自体が無い → null (スクショ無しセッション / 旧 export / JSON 単体)
+ * - manifest が壊れている / 形式不正 → `entries: []` (チェーンに記録があれば
+ *   chainOnly として浮くように、「無かった」と同一視しない)
+ */
+export async function extractScreenshotArtifactsFromZip(buffer: ArrayBuffer): Promise<{
+  entries: Array<{ filename: string; imageHash: string }>;
+  images: Map<string, ArrayBuffer>;
+} | null> {
+  const zip = await JSZip.loadAsync(buffer);
+  assertZipWithinBudget(zip);
+
+  const manifestFile = zip.file('screenshots/manifest.json');
+  if (!manifestFile) return null;
+
+  let rawEntries: unknown = [];
+  try {
+    const parsed: unknown = JSON.parse(await manifestFile.async('string'));
+    rawEntries = Array.isArray(parsed)
+      ? parsed
+      : ((parsed as { screenshots?: unknown } | null)?.screenshots ?? []);
+  } catch {
+    rawEntries = [];
+  }
+
+  const entries: Array<{ filename: string; imageHash: string }> = [];
+  if (Array.isArray(rawEntries)) {
+    for (const e of rawEntries) {
+      const filename = (e as { filename?: unknown } | null)?.filename;
+      const imageHash = (e as { imageHash?: unknown } | null)?.imageHash;
+      if (typeof filename === 'string' && typeof imageHash === 'string') {
+        entries.push({ filename, imageHash });
+      }
+    }
+  }
+
+  const images = new Map<string, ArrayBuffer>();
+  for (const entry of entries) {
+    const file = zip.file(`screenshots/${entry.filename}`);
+    if (!file) continue;
+    images.set(entry.filename, await file.async('arraybuffer'));
+  }
+
+  return { entries, images };
+}
+
+/**
  * Extract first proof file from ZIP buffer
  * Simplified function for CLI use
  * @param buffer - ZIP file as ArrayBuffer

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -219,8 +219,21 @@ export {
   parseZipBuffer,
   extractFirstProofFromZip,
   extractAllProofsFromZip,
+  extractScreenshotArtifactsFromZip,
   assertZipWithinBudget,
 } from './fileProcessing/index.js';
+
+// スクリーンショット検証 (#146/#147): verify (web) / verify-cli が同じ結論を出すための単一実装
+export {
+  sha256HexOfBytes,
+  collectChainImageHashes,
+  isChainBackedImageHash,
+  checkScreenshotImage,
+  summarizeScreenshotArtifacts,
+  type ScreenshotManifestEntryLike,
+  type ScreenshotImageCheck,
+  type ScreenshotVerificationSummary,
+} from './screenshotVerification.js';
 
 // UI共通コンポーネント
 export {

--- a/packages/shared/src/screenshotVerification.ts
+++ b/packages/shared/src/screenshotVerification.ts
@@ -1,0 +1,139 @@
+/**
+ * スクリーンショット検証の単一実装 (#146/#147)。
+ *
+ * 真正な記録は改ざん不能なチェーンに焼かれた `screenshotCapture.imageHash` だけであり、
+ * `screenshots/manifest.json` と画像ファイルは未署名 = セットで差し替え可能。判定ポリシー:
+ *
+ * - verified: 画像バイト列の SHA-256 が manifest entry の `imageHash` と一致
+ * - tampered: ハッシュ不一致、**または** `imageHash` がチェーン集合に無い
+ *             (集合が空/未提供 = 旧 proof や screenshotCapture の無い proof は対象外)
+ * - missing:  manifest entry の画像が ZIP/フォルダに無い、または読めない
+ * - chainOnly: チェーンには記録があるのに manifest 側に対応 entry が無い imageHash 数
+ *              (スクショの剥ぎ取り疑い。manifest ごと消しても検出できる唯一の軸)
+ *
+ * verify (web) と verify-cli の両方がここへ委譲する。片方だけ再実装すると
+ * 「Web では改ざん FAILED / CLI では PROVEN + exit 0」型の乖離事故になる (#147)。
+ */
+
+import type { StoredEvent } from './types.js';
+import { arrayBufferToHex } from './utils/hashUtils.js';
+
+/** manifest entry のうち検証に必要な最小形。 */
+export interface ScreenshotManifestEntryLike {
+  filename: string;
+  imageHash: string;
+}
+
+/** 1 画像の検証結果。 */
+export interface ScreenshotImageCheck {
+  /** 画像バイト列の SHA-256 が manifest の imageHash と一致したか。 */
+  verified: boolean;
+  /** 改ざん疑い (ハッシュ不一致 or チェーン非裏付け)。 */
+  tampered: boolean;
+}
+
+/** manifest + 画像群 + チェーン集合から導く全体サマリ。 */
+export interface ScreenshotVerificationSummary {
+  /** manifest entry 数。 */
+  total: number;
+  verified: number;
+  missing: number;
+  tampered: number;
+  /** チェーンに記録があるのに manifest に対応 entry が無い imageHash 数。 */
+  chainOnly: number;
+}
+
+/** 画像バイト列の SHA-256 (hex)。Node ≥24 / ブラウザ両対応 (WebCrypto)。 */
+export async function sha256HexOfBytes(bytes: ArrayBuffer | Uint8Array): Promise<string> {
+  const buffer = await crypto.subtle.digest('SHA-256', bytes as BufferSource);
+  return arrayBufferToHex(buffer);
+}
+
+/**
+ * proof (複数可) の `screenshotCapture` イベントから imageHash を収集する。
+ * チェーンは検証済み・改ざん不能なので、これがスクショの真正なハッシュ集合になる。
+ */
+export function collectChainImageHashes(
+  eventsList: ReadonlyArray<readonly StoredEvent[]>
+): Set<string> {
+  const hashes = new Set<string>();
+  for (const events of eventsList) {
+    for (const e of events) {
+      if (e?.type === 'screenshotCapture') {
+        const h = (e.data as { imageHash?: string } | null | undefined)?.imageHash;
+        if (typeof h === 'string' && h.length > 0) hashes.add(h);
+      }
+    }
+  }
+  return hashes;
+}
+
+/**
+ * entry の imageHash が検証済みチェーンに記録されているか。集合が未提供 or 空 (旧 proof /
+ * screenshotCapture イベントを持たない proof 等) なら対象外とみなし true (false-positive 回避)。
+ */
+export function isChainBackedImageHash(
+  imageHash: string,
+  chainImageHashes?: ReadonlySet<string>
+): boolean {
+  if (!chainImageHashes || chainImageHashes.size === 0) return true;
+  return chainImageHashes.has(imageHash);
+}
+
+/**
+ * 1 画像の検証。verify (web) の ScreenshotService と verify-cli が共に使う判定の実体。
+ */
+export async function checkScreenshotImage(
+  bytes: ArrayBuffer | Uint8Array,
+  expectedImageHash: string,
+  chainImageHashes?: ReadonlySet<string>
+): Promise<ScreenshotImageCheck> {
+  let verified = false;
+  try {
+    verified = (await sha256HexOfBytes(bytes)) === expectedImageHash;
+  } catch {
+    verified = false;
+  }
+  const tampered = !verified || !isChainBackedImageHash(expectedImageHash, chainImageHashes);
+  return { verified, tampered };
+}
+
+/**
+ * manifest 全 entry + 画像取得コールバックからサマリを導く (verify-cli の入口)。
+ * `getImageBytes` が null を返した entry は missing。manifest 自体が無い場合は
+ * `entries: []` で呼ぶと chainOnly (剥ぎ取り疑い) だけが残る。
+ */
+export async function summarizeScreenshotArtifacts(params: {
+  entries: readonly ScreenshotManifestEntryLike[];
+  getImageBytes: (filename: string) => Promise<ArrayBuffer | Uint8Array | null>;
+  chainImageHashes?: ReadonlySet<string>;
+}): Promise<ScreenshotVerificationSummary> {
+  const { entries, getImageBytes, chainImageHashes } = params;
+  let verified = 0;
+  let missing = 0;
+  let tampered = 0;
+
+  for (const entry of entries) {
+    let bytes: ArrayBuffer | Uint8Array | null = null;
+    try {
+      bytes = await getImageBytes(entry.filename);
+    } catch {
+      bytes = null;
+    }
+    if (bytes === null) {
+      missing++;
+      continue;
+    }
+    const check = await checkScreenshotImage(bytes, entry.imageHash, chainImageHashes);
+    if (check.tampered) tampered++;
+    else if (check.verified) verified++;
+  }
+
+  const manifestHashes = new Set(entries.map((e) => e.imageHash));
+  let chainOnly = 0;
+  for (const h of chainImageHashes ?? []) {
+    if (!manifestHashes.has(h)) chainOnly++;
+  }
+
+  return { total: entries.length, verified, missing, tampered, chainOnly };
+}

--- a/packages/verify-cli/CLAUDE.md
+++ b/packages/verify-cli/CLAUDE.md
@@ -43,6 +43,13 @@ src/
 - package 指定で束縛失敗は **exit 1**。exam 束縛のみ失敗時は出力ヘッダに束縛理由を出す (chain の成功メッセージを誤表示しない)
 - ロジックは全て shared (`verifyExamBinding` / `parseExamPackageManifest`) に委譲。CLI は薄いラッパに留める
 
+## スクリーンショット検証 (#147)
+
+- ZIP 入力のとき、`screenshots/manifest.json` の entry と画像バイト列を突合し、さらにチェーンの `screenshotCapture.imageHash` (改ざん不能な唯一の真正記録) との裏付けを検査する。判定は **shared の `summarizeScreenshotArtifacts` / `checkScreenshotImage`** (verify web と同一実装) — CLI 側で再実装しない
+- **改ざん (tampered) は exit 1** (web の error 軸 / integrity failed と同じ結論)。欠損・chainOnly (チェーンに記録があるのに manifest に無い = 剥ぎ取り疑い) は warning のみで exit 非干渉
+- JSON 単体入力は画像が無いので未検査 — 出力に `Screenshots: not checked` を明示する (overclaim 防止)
+- サマリは ZIP 単位で一度だけ計算し全 proof に共有する (スクショはセッション単位で proof 横断)。`deriveAssurance` へは `screenshotsTampered` として渡る
+
 ## アンカー密度 gate (ADR-0016)
 
 - `--require-anchor-density` (任意・boolean): 署名 cp が「主張したイベント数 / 経過時間」に対して**疎**な proof を **exit 1** にする (採点向け opt-in)。既定は warning のみで `Anchoring` 行の下に `! Anchoring is sparse …` を出す

--- a/packages/verify-cli/src/cli.ts
+++ b/packages/verify-cli/src/cli.ts
@@ -8,7 +8,7 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import { resolve, extname } from 'node:path';
 import { verifyProof, type ProofFile } from './verify.js';
-import { extractAllProofs } from './zip.js';
+import { extractAllProofs, extractScreenshotArtifacts } from './zip.js';
 import { loadExternalAnalyzers } from './analyzers.js';
 import { formatResult, printError, printUsage } from './output.js';
 import { Spinner } from './progress.js';
@@ -16,10 +16,13 @@ import {
   parseExamPackageManifest,
   defaultAnalyzers,
   buildAnalysisBundle,
+  collectChainImageHashes,
+  summarizeScreenshotArtifacts,
   type VerificationMode,
   type ExamPackageManifest,
   type Analyzer,
   type AnalysisBundle,
+  type ScreenshotVerificationSummary,
 } from '@typedcode/shared';
 
 import { findFlagError, flagValue, flagValues, nonFlagArgs } from './args.js';
@@ -145,6 +148,22 @@ async function main(): Promise<void> {
       examPackageManifest = parsed;
     }
 
+    // スクリーンショット検証 (#147): ZIP 入力のとき一度だけ計算して全 proof に渡す
+    // (スクショはセッション単位で proof 横断)。真正記録は各チェーンの screenshotCapture.imageHash。
+    // JSON 単体入力は画像が無いので未検査 (undefined) — 出力で明示する (overclaim 防止)。
+    let screenshotSummary: ScreenshotVerificationSummary | undefined;
+    if (ext === '.zip') {
+      const chainImageHashes = collectChainImageHashes(proofs.map((p) => p.proof.proof.events));
+      const artifacts = await extractScreenshotArtifacts(filePath);
+      // スクショ無しセッション (manifest もチェーン記録も無し) は全ゼロの summary になり
+      // 出力上は沈黙する。undefined は「検査できない」(JSON 単体入力) の意味に限定する。
+      screenshotSummary = await summarizeScreenshotArtifacts({
+        entries: artifacts?.entries ?? [],
+        getImageBytes: async (filename) => artifacts?.images.get(filename) ?? null,
+        chainImageHashes,
+      });
+    }
+
     spinner.stop();
 
     // 全 proof を検証。1 件でも fail なら exit 1 (CI が部分合格を成功と誤読しないように)。
@@ -154,7 +173,7 @@ async function main(): Promise<void> {
     const bundleDump: Array<{ filename: string } & AnalysisBundle> = [];
     for (const { filename, proof } of proofs) {
       if (multi) console.log(`\n=== ${filename} ===`);
-      const result = await verifyProof(proof, { mode, examPackageManifest, submittedAtMs, requireAnchorDensity, requireRootAnchor, analyzers });
+      const result = await verifyProof(proof, { mode, examPackageManifest, submittedAtMs, requireAnchorDensity, requireRootAnchor, analyzers, screenshotSummary });
       console.log(formatResult(result));
       summary.push({ filename, valid: result.valid });
       analysisDump.push({ filename, valid: result.valid, analysis: result.analysis });

--- a/packages/verify-cli/src/output.ts
+++ b/packages/verify-cli/src/output.ts
@@ -25,6 +25,7 @@ import type {
   AssuranceResult,
   ProcessSummary,
   ProcessKeyMoment,
+  ScreenshotVerificationSummary,
 } from '@typedcode/shared';
 import type { CLIExamResult } from './verify.js';
 
@@ -54,6 +55,8 @@ export interface VerificationOutput {
   processSummary?: ProcessSummary;
   /** 試験モードの束縛検証 (ADR-0006)。exam proof でないときは undefined。 */
   exam?: CLIExamResult;
+  /** スクリーンショット検証 (#147)。undefined = 未検査 (JSON 単体入力)。 */
+  screenshots?: ScreenshotVerificationSummary;
 }
 
 function passFail(ok: boolean): string {
@@ -298,6 +301,26 @@ export function formatResult(result: VerificationOutput): string {
     } else {
       lines.push(`Anchoring:   ${c('red', 'FAILED')} ${sc.reason ?? ''}`);
     }
+  }
+
+  // スクリーンショット検証 (#147): Web と同一の shared 実装で突合した結果。
+  // 未検査 (JSON 単体入力) は明示して overclaim を防ぐ。
+  const ss = result.screenshots;
+  if (ss) {
+    if (ss.tampered > 0) {
+      lines.push(`Screenshots: ${c('red', 'FAILED')} (${ss.tampered}/${ss.total} tampered — hash mismatch or not backed by the chain)`);
+    } else if (ss.total > 0 || ss.chainOnly > 0) {
+      const ok = ss.missing === 0 && ss.chainOnly === 0;
+      lines.push(`Screenshots: ${ok ? c('green', 'VERIFIED') : c('yellow', 'PARTIAL')} (${ss.verified}/${ss.total} verified)`);
+    }
+    if (ss.missing > 0) {
+      lines.push(c('yellow', `  ! ${ss.missing} image(s) listed in the manifest are missing from the ZIP`));
+    }
+    if (ss.chainOnly > 0) {
+      lines.push(c('yellow', `  ! ${ss.chainOnly} screenshot hash(es) recorded in the chain have no manifest entry (screenshots may have been stripped)`));
+    }
+  } else {
+    lines.push(c('dim', 'Screenshots: not checked (provide the export ZIP to verify screenshots)'));
   }
 
   // 試験モード (ADR-0006): exam ブロックがあれば束縛検証セクションを出す。

--- a/packages/verify-cli/src/verify.ts
+++ b/packages/verify-cli/src/verify.ts
@@ -21,6 +21,7 @@ import {
   type ProcessSummary,
   type ExamPackageManifest,
   type ExamBindingVerificationResult,
+  type ScreenshotVerificationSummary,
 } from '@typedcode/shared';
 import { ProgressBar } from './progress.js';
 
@@ -68,6 +69,11 @@ export interface CLIVerificationResult {
   processSummary: ProcessSummary;
   /** 試験モードの束縛検証 (ADR-0006)。exam proof でないときは undefined。 */
   exam?: CLIExamResult;
+  /**
+   * スクリーンショット検証 (#147)。ZIP 入力で計算されたときのみ。undefined = 未検査
+   * (JSON 単体入力など)。判定は shared の summarizeScreenshotArtifacts (verify web と同一実装)。
+   */
+  screenshots?: ScreenshotVerificationSummary;
 }
 
 export interface VerifyProofOptions {
@@ -86,6 +92,12 @@ export interface VerifyProofOptions {
    * advisory のまま — valid / exit code には一切影響しない (直交性維持)。
    */
   analyzers?: readonly Analyzer[];
+  /**
+   * ZIP 全体のスクリーンショット検証サマリ (#147)。呼び出し側 (cli.ts) が ZIP から
+   * 一度だけ計算して全 proof に渡す (スクショはセッション単位で proof 横断のため)。
+   * tampered > 0 は verify (web) の error 軸と同じく valid を落とす。未指定 = 未検査。
+   */
+  screenshotSummary?: ScreenshotVerificationSummary;
 }
 
 export async function verifyProof(
@@ -153,6 +165,10 @@ export async function verifyProof(
   // package が渡されたとき、束縛失敗は全体を fail にする (proof 自己整合とは別軸の真正性)。
   const examValid = exam?.binding ? exam.binding.valid : true;
 
+  // #147: スクショ改ざんは verify (web) の error 軸 (TrustCalculator/integrity failed) と同じく
+  // 全体 fail = exit 1 に合流させる。欠損/chainOnly は warning (web と同じ) で exit 非干渉。
+  const screenshotsValid = (options.screenshotSummary?.tampered ?? 0) === 0;
+
   // 三層保証語彙 (ADR-0020): 実証拠のみから導出 (自己申告 mode は使わない)。
   const assurance = deriveAssurance({
     metadataValid: result.metadataValid,
@@ -175,10 +191,12 @@ export async function verifyProof(
       : undefined,
     isPureTyping: result.isPureTyping,
     analysis: summarizeAnalysisForAssurance(analysis),
+    // #147: ZIP 入力で検査したときのみ渡す (undefined = 未検査は integrity に影響しない)。
+    screenshotsTampered: options.screenshotSummary?.tampered,
   });
 
   return {
-    valid: result.valid && examValid,
+    valid: result.valid && examValid && screenshotsValid,
     metadataValid: result.metadataValid,
     chainValid: result.chainValid,
     isPureTyping: result.isPureTyping,
@@ -198,5 +216,6 @@ export async function verifyProof(
     assurance,
     processSummary: summarizeProcess(events),
     exam,
+    screenshots: options.screenshotSummary,
   };
 }

--- a/packages/verify-cli/src/zip.ts
+++ b/packages/verify-cli/src/zip.ts
@@ -8,16 +8,16 @@ import { readFile } from 'node:fs/promises';
 import {
   extractFirstProofFromZip,
   extractAllProofsFromZip,
+  extractScreenshotArtifactsFromZip,
   type ProofFile,
 } from '@typedcode/shared';
 
+function toArrayBuffer(buffer: Buffer): ArrayBuffer {
+  return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength) as ArrayBuffer;
+}
+
 export async function extractProofFromZip(filePath: string): Promise<ProofFile> {
-  const buffer = await readFile(filePath);
-  // Convert Buffer to ArrayBuffer
-  const arrayBuffer = buffer.buffer.slice(
-    buffer.byteOffset,
-    buffer.byteOffset + buffer.byteLength
-  );
+  const arrayBuffer = toArrayBuffer(await readFile(filePath));
   const proof = await extractFirstProofFromZip(arrayBuffer);
   return proof as ProofFile;
 }
@@ -29,11 +29,19 @@ export async function extractProofFromZip(filePath: string): Promise<ProofFile> 
 export async function extractAllProofs(
   filePath: string
 ): Promise<Array<{ filename: string; proof: ProofFile }>> {
-  const buffer = await readFile(filePath);
-  const arrayBuffer = buffer.buffer.slice(
-    buffer.byteOffset,
-    buffer.byteOffset + buffer.byteLength
-  );
+  const arrayBuffer = toArrayBuffer(await readFile(filePath));
   const proofs = await extractAllProofsFromZip(arrayBuffer);
   return proofs.map((p) => ({ filename: p.filename, proof: p.proof as ProofFile }));
+}
+
+/**
+ * ZIP から screenshots/manifest.json の entry 群と画像バイト列を取り出す (#147)。
+ * 判定はしない (shared の summarizeScreenshotArtifacts に委譲)。manifest 無しは null。
+ */
+export async function extractScreenshotArtifacts(filePath: string): Promise<{
+  entries: Array<{ filename: string; imageHash: string }>;
+  images: Map<string, ArrayBuffer>;
+} | null> {
+  const arrayBuffer = toArrayBuffer(await readFile(filePath));
+  return extractScreenshotArtifactsFromZip(arrayBuffer);
 }

--- a/packages/verify/CLAUDE.md
+++ b/packages/verify/CLAUDE.md
@@ -52,7 +52,9 @@ File Selection (drag&drop / FSA API)
 - **error**: metadata 不正、ハッシュチェーン不正、スクショ改竄、署名 cp が anchored だが invalid、exam 束縛失敗 (package 提供時)
 - **warning**: 未アンカー (署名 cp なし)、post-hoc 一括署名疑い、**アンカー密度が疎 (ADR-0016, `signedCheckpointDensity.sparse`)**、**root 未サーバアンカー (ADR-0017, `!rootAnchored` かつ非 exam)**、非ピュアタイピング (ペースト/バルク挿入)、ソース不一致、attestation 検証失敗、`screenShareOptOut`、exam だが問題パッケージ未読込、スクショ欠損
 
-`VerificationController.handleComplete` のタブ status 判定と **同じ軸** を見るので、両者を揃えて変更すること (タブが緑なのに信頼バッジが警告、のような不整合を避ける)。`component` を増やしたら `ResultPanel.getComponentLabel` にラベルも追加する。
+`VerificationController.handleComplete` のタブ status 判定と **同じ軸** を見るので、両者を揃えて変更すること (タブが緑なのに信頼バッジが警告、のような不整合を避ける)。`component` を増やしたら `ResultPanel.getComponentLabel` にラベルも追加する。#146 で handleComplete にスクショ改竄 (error)・スクショ欠損・`screenShareOptOut` (warning) を合流済み。attestation 失敗は `humanAttestationResult` の書き込み元が現状無い (dead) ため status 軸に入れていない。
+
+スクショの per-image 判定 (ハッシュ突合 + チェーン裏付け) の実体は **shared の `checkScreenshotImage`** (#147)。verify 側で再実装しない — verify-cli と結論が食い違うため。
 
 ## よくある罠
 

--- a/packages/verify/src/services/ScreenshotService.ts
+++ b/packages/verify/src/services/ScreenshotService.ts
@@ -5,6 +5,7 @@
  */
 
 import type JSZip from 'jszip';
+import { checkScreenshotImage } from '@typedcode/shared';
 import type {
   VerifyScreenshot,
   ScreenshotManifest,
@@ -51,8 +52,10 @@ export class ScreenshotService {
 
           // ハッシュ検証: 画像とハッシュが一致しても、そのハッシュがチェーンに無ければ
           // manifest+画像が揃って差し替えられた疑い (manifest は未署名・チェーンは改ざん不能)。
-          const verified = await this.verifyImageHash(blob, entry.imageHash);
-          const tampered = !verified || !this.isChainBacked(entry.imageHash, chainImageHashes);
+          // 判定は shared の単一実装 (#147: verify-cli と結論を揃える)。
+          const { verified, tampered } = await checkScreenshotImage(
+            await blob.arrayBuffer(), entry.imageHash, chainImageHashes
+          );
           console.log(`[ScreenshotService] Image ${entry.filename}: verified=${verified}, tampered=${tampered}`);
 
           // ユニークIDとしてマニフェストのindexを使用（eventSequenceは重複の可能性あり）
@@ -133,9 +136,10 @@ export class ScreenshotService {
         const file = await fileHandle.getFile();
         const blob = new Blob([await file.arrayBuffer()], { type: file.type });
 
-        // ハッシュ検証 (チェーン突合は loadFromZip と同じ。集合未提供時は従来どおり画像照合のみ)
-        const verified = await this.verifyImageHash(blob, entry.imageHash);
-        const tampered = !verified || !this.isChainBacked(entry.imageHash, chainImageHashes);
+        // ハッシュ検証 (チェーン突合は loadFromZip と同じ。判定は shared の単一実装 #147)
+        const { verified, tampered } = await checkScreenshotImage(
+          await blob.arrayBuffer(), entry.imageHash, chainImageHashes
+        );
         console.log(`[ScreenshotService] Image ${entry.filename}: verified=${verified}, tampered=${tampered}`);
 
         const screenshot: VerifyScreenshot = {
@@ -228,31 +232,6 @@ export class ScreenshotService {
       if (screenshot.imageBlob && !screenshot.imageUrl) {
         screenshot.imageUrl = URL.createObjectURL(screenshot.imageBlob);
       }
-    }
-  }
-
-  /**
-   * entry の imageHash が検証済みチェーンに記録されているか。集合が未提供 or 空 (旧 proof /
-   * screenshotCapture イベントを持たない proof 等) なら対象外とみなし true を返す (false-positive 回避)。
-   */
-  private isChainBacked(imageHash: string, chainImageHashes?: ReadonlySet<string>): boolean {
-    if (!chainImageHashes || chainImageHashes.size === 0) return true;
-    return chainImageHashes.has(imageHash);
-  }
-
-  /**
-   * 画像ハッシュを検証
-   */
-  async verifyImageHash(blob: Blob, expectedHash: string): Promise<boolean> {
-    try {
-      const buffer = await blob.arrayBuffer();
-      const hashBuffer = await crypto.subtle.digest('SHA-256', buffer);
-      const hashArray = Array.from(new Uint8Array(hashBuffer));
-      const hash = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
-      return hash === expectedHash;
-    } catch (error) {
-      console.error('Hash verification failed:', error);
-      return false;
     }
   }
 

--- a/packages/verify/src/services/ZipFileProcessor.ts
+++ b/packages/verify/src/services/ZipFileProcessor.ts
@@ -5,7 +5,7 @@
  */
 
 import JSZip from 'jszip';
-import { assertZipWithinBudget } from '@typedcode/shared';
+import { assertZipWithinBudget, collectChainImageHashes } from '@typedcode/shared';
 import type { ProofFile, ScreenshotManifest, VerifyScreenshot } from '../types.js';
 import type { ParsedFileData, FileProcessResult, FileProcessCallbacks } from './FileProcessor.js';
 import { ScreenshotService } from './ScreenshotService.js';
@@ -303,21 +303,12 @@ export class ZipFileProcessor {
   /**
    * 全 proof の screenshotCapture イベントから imageHash を収集する。チェーンは検証済み・
    * 改ざん不能なので、これが screenshot の真正なハッシュ集合になる (manifest は未署名なので
-   * 画像とセットで差し替え可能)。
+   * 画像とセットで差し替え可能)。実体は shared (#147: verify-cli と同一実装)。
    */
   private collectChainScreenshotHashes(files: ParsedFileData[]): Set<string> {
-    const hashes = new Set<string>();
-    for (const f of files) {
-      const events = f.proofData?.proof?.events;
-      if (!events) continue;
-      for (const e of events) {
-        if (e.type === 'screenshotCapture') {
-          const h = (e.data as { imageHash?: string } | null | undefined)?.imageHash;
-          if (typeof h === 'string' && h.length > 0) hashes.add(h);
-        }
-      }
-    }
-    return hashes;
+    return collectChainImageHashes(
+      files.map((f) => f.proofData?.proof?.events).filter((e): e is NonNullable<typeof e> => !!e)
+    );
   }
 
   /**

--- a/packages/verify/src/ui/controllers/VerificationController.ts
+++ b/packages/verify/src/ui/controllers/VerificationController.ts
@@ -68,10 +68,25 @@ export class VerificationController {
     const currentTabState = this.deps.tabManager.getTab(id);
     const hasSourceMismatch = !!currentTabState?.associatedSourceMismatch;
 
+    // スクリーンショット検証 (#146): enqueue 時に tabState へ保持済みの per-image 判定を集計。
+    // TrustCalculator (改竄 = error) / deriveAssurance (integrity failed) と同じ軸を見る —
+    // ここだけ見ないとサイドバー/タブの緑と開いた結果バッジが食い違い、緑の流し見で
+    // 改竄提出が素通りする (verify/CLAUDE.md「両者を揃えて変更すること」)。
+    const screenshots = currentTabState?.screenshots ?? [];
+    const screenshotsTampered = screenshots.filter((s) => s.tampered).length;
+    const screenshotsMissing = screenshots.filter((s) => s.missing).length;
+    // 画面共有オプトアウト (TrustCalculator と同じく warning 軸)
+    const events = currentTabState?.proofData?.proof?.events ?? [];
+    const hasScreenShareOptOut = events.some(
+      (e: { type: string }) => e.type === 'screenShareOptOut'
+    );
+
     // ステータス判定: エラー > 警告 > 成功。
-    // - error: チェーン/メタデータ破綻、署名 cp があるのに無効、package 提供下で exam 束縛失敗 (spec §6.4)
+    // - error: チェーン/メタデータ破綻、署名 cp があるのに無効、package 提供下で exam 束縛失敗 (spec §6.4)、
+    //          スクショ改竄 (#146)
     // - warning: 非ピュアタイピング / ソース不一致 / 時刻アンカー無し (偽造不能要素が無い) /
-    //            post-hoc 一括署名疑い / anchoring 密度が疎 (ADR-0016) / exam だが問題パッケージ未検証 (真正性未確認)
+    //            post-hoc 一括署名疑い / anchoring 密度が疎 (ADR-0016) / exam だが問題パッケージ未検証 (真正性未確認) /
+    //            スクショ欠損 / 画面共有オプトアウト (#146)
     const examBindingFailed =
       !!result.exam?.packageProvided && result.exam.binding?.valid === false;
     const anchoredButInvalid =
@@ -81,7 +96,13 @@ export class VerificationController {
     // ADR-0017: root 未アンカー (serverNonce トークン無し) は警告。exam は独自束縛のため対象外。
     const rootNotAnchored = !result.rootAnchored && !result.exam?.present;
     let status: FileStatus;
-    if (!result.metadataValid || !result.chainValid || examBindingFailed || anchoredButInvalid) {
+    if (
+      !result.metadataValid ||
+      !result.chainValid ||
+      examBindingFailed ||
+      anchoredButInvalid ||
+      screenshotsTampered > 0
+    ) {
       status = 'error';
     } else if (
       !result.isPureTyping ||
@@ -90,7 +111,9 @@ export class VerificationController {
       result.signedCheckpointTemporal?.postHocSuspected ||
       result.signedCheckpointDensity?.sparse ||
       rootNotAnchored ||
-      examPresentButUnverified
+      examPresentButUnverified ||
+      screenshotsMissing > 0 ||
+      hasScreenShareOptOut
     ) {
       status = 'warning';
     } else {


### PR DESCRIPTION
## 概要

スクリーンショット検証に関する W4 の 2 件をまとめて修正。

## #147: CLI がスクショを一切検証しない

スクショ差し替え ZIP が **Web では integrity FAILED / 信頼バッジ failed** になるのに、**CLI では Integrity: PROVEN + exit 0** で通っていた。

- **shared [screenshotVerification.ts](packages/shared/src/screenshotVerification.ts) を新設** — 判定ポリシーの単一実装:
  - verified = 画像バイト列の SHA-256 が manifest の imageHash に一致
  - tampered = ハッシュ不一致 **or** チェーン (`screenshotCapture.imageHash` = 改ざん不能な唯一の真正記録) に裏付けが無い
  - chainOnly = チェーンに記録があるのに manifest に entry が無い (**スクショ剥ぎ取り疑い** — manifest ごと消しても検出できる新しい軸)
- shared parser に `extractScreenshotArtifactsFromZip` (抽出のみ・判定なし)。壊れた manifest は「無かった」と同一視せず `entries: []` (chainOnly が浮くように)
- **verify-cli**: ZIP 単位でサマリを一度計算し全 proof に共有 (スクショはセッション単位)。**改ざんは exit 1** (web の error 軸と同じ結論)。欠損/chainOnly は warning で exit 非干渉。JSON 単体入力は `Screenshots: not checked` を明示。`deriveAssurance` に `screenshotsTampered` を配線 (Integrity 表示も web と一致)
- **verify (web)**: `ScreenshotService.verifyImageHash`/`isChainBacked` と `ZipFileProcessor.collectChainScreenshotHashes` の再実装を削除し shared へ委譲

## #146: サイドバー/タブ status が TrustCalculator/assurance と乖離

`handleComplete` の status 判定がスクショ改竄・欠損・`screenShareOptOut` を見ないため、スクショ差し替え ZIP でサイドバーは緑 ✓ のまま (開くと検証失敗バッジ) — 緑の流し見の採点フローで素通りする。

- スクショ改竄 → **error**、スクショ欠損 / `screenShareOptOut` → **warning** を status 軸に合流 (TrustCalculator と同軸に)
- attestation 失敗は `humanAttestationResult` の書き込み元が現存しない (dead field) ため status 軸に入れず、CLAUDE.md に明記

## テスト

- 新規 `screenshotVerification.test.ts` 13 ケース (既知ベクトル / manifest+画像ペア差し替え / 旧 proof の chain 集合なし / 剥ぎ取り chainOnly / 壊れ manifest / legacy 配列形式)
- `@typedcode/shared` 405 passed / editor 95 / workers 43 / `tsc --noEmit` (shared, verify, verify-cli) clean
- verify (web) / verify-cli の CLAUDE.md に一元化の不変条件を追記

Closes #146
Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)