### PR TITLE
fix(shared/editor): exportProof をスナップショット一貫にし export 中の記録競合を解消 (#143)

### DIFF
--- a/packages/editor/src/export/ProofExporter.ts
+++ b/packages/editor/src/export/ProofExporter.ts
@@ -342,10 +342,17 @@ export class ProofExporter {
       // エクスポート前に明示的に同期を取る必要がある
       await this.tabManager?.flushToIndexedDB();
 
+      // #143: 直前の打鍵がまだ PoSW キューにあると「content には載っているのに
+      // チェーンに無い」export になり content replay で fail する。先に排出を待つ。
+      const drained = await activeTab.typingProof.waitForQueueDrain(5000);
+      if (!drained) {
+        console.warn('[ProofExporter] event queue did not drain within 5s; exporting the chain-consistent snapshot');
+      }
       const content = activeTab.model.getValue();
       // exportProof() は最終 checkpoint を作成して onCheckpointCreated フックを発火する。
-      // 戻り値の checkpoints は CheckpointManager 内部配列への参照なので、後段で
-      // waitForFlush している間に signature が attach される。
+      // 戻り値の checkpoints は要素オブジェクトを CheckpointManager と共有するので、後段で
+      // waitForFlush している間に signature が attach される (#143 でスナップショット外の
+      // checkpoint は同梱されなくなったが、要素共有は変わらない)。
       const proof = await activeTab.typingProof.exportProof(content);
 
       // Signed checkpoint の pending リクエストを最大 5 秒待機 (オンライン時のみ意味あり)
@@ -516,6 +523,13 @@ export class ProofExporter {
           total: allTabs.length,
         });
 
+        // #143: waitForProcessingComplete はアクティブタブしか待たない。タブ毎に
+        // キュー排出を待ってから content を確定する (排出しきれなくてもスナップショット
+        // 一貫性で proof 自体は整合するが、直前の打鍵が export に載らない)。
+        const drained = await tab.typingProof.waitForQueueDrain(5000);
+        if (!drained) {
+          console.warn(`[ProofExporter] tab ${tab.id}: event queue did not drain within 5s`);
+        }
         const content = tab.model.getValue();
         const proof = await tab.typingProof.exportProof(content);
 

--- a/packages/shared/src/__tests__/exportSnapshot.test.ts
+++ b/packages/shared/src/__tests__/exportSnapshot.test.ts
@@ -1,0 +1,105 @@
+/**
+ * exportProof のスナップショット一貫性 (#143) のテスト。
+ *
+ * export 中も記録は続きうる (スクショ/visibility の broadcast 等)。署名・メタデータ・
+ * checkpoint が別々の時点の events を見ると「同梱 events に無い eventIndex を指す
+ * checkpoint」や totalEvents 不一致の proof ができ、verifier で丸ごと invalid になる。
+ */
+
+import { describe, expect, it } from 'vitest';
+import { TypingProof, computeHash, verifyProofMetadata, verifyCheckpoints } from '../index.js';
+import type { FingerprintComponents } from '../types.js';
+
+const createMockFingerprintComponents = (): FingerprintComponents => ({
+  userAgent: 'Mozilla/5.0 (ExportSnapshot Test)',
+  language: 'en',
+  languages: ['en'],
+  platform: 'TestOS',
+  hardwareConcurrency: 4,
+  deviceMemory: 8,
+  screen: {
+    width: 1440,
+    height: 900,
+    availWidth: 1440,
+    availHeight: 860,
+    colorDepth: 24,
+    pixelDepth: 24,
+    devicePixelRatio: 2,
+  },
+  timezone: 'UTC',
+  timezoneOffset: 0,
+  canvas: 'mock-canvas',
+  webgl: { vendor: 'Mock', renderer: 'Mock' },
+  fonts: ['Arial'],
+  cookieEnabled: true,
+  doNotTrack: 'unspecified',
+  maxTouchPoints: 0,
+});
+
+async function buildProof(chars: string): Promise<{ proof: TypingProof; content: string }> {
+  const components = createMockFingerprintComponents();
+  const fingerprintHash = await computeHash(JSON.stringify(components, null, 0));
+  const proof = new TypingProof();
+  await proof.initialize(fingerprintHash, components);
+  let content = '';
+  for (const ch of chars) {
+    await proof.recordEvent({
+      type: 'contentChange',
+      inputType: 'insertText',
+      data: ch,
+      rangeOffset: content.length,
+      rangeLength: 0,
+    });
+    content += ch;
+  }
+  return { proof, content };
+}
+
+describe('exportProof snapshot consistency (#143)', () => {
+  it('never exports a checkpoint pointing beyond the exported events', async () => {
+    const { proof, content } = await buildProof('abc');
+    // export 中に別イベントの checkpoint が作られた状況を再現: 同梱 events (3 件) の
+    // 範囲外を指す checkpoint を注入する (checkpoints アクセサは内部配列を返す)。
+    proof.checkpoints.push({
+      eventIndex: 10,
+      hash: 'f'.repeat(64),
+      timestamp: 999,
+      contentHash: '',
+    });
+
+    const exported = await proof.exportProof(content);
+    const maxIndex = exported.proof.events.length - 1;
+    for (const cp of exported.checkpoints ?? []) {
+      expect(cp.eventIndex).toBeLessThanOrEqual(maxIndex);
+    }
+    // 同梱 events に対する checkpoint 検証が通る (範囲外 cp が残ると即 fail する層)
+    await expect(
+      verifyCheckpoints(exported.proof.events, exported.checkpoints)
+    ).resolves.toMatchObject({ valid: true });
+  });
+
+  it('creates the final checkpoint at the last exported event', async () => {
+    const { proof, content } = await buildProof('ab');
+    const exported = await proof.exportProof(content);
+    const last = exported.proof.events.length - 1;
+    expect((exported.checkpoints ?? []).some((cp) => cp.eventIndex === last)).toBe(true);
+  });
+
+  it('keeps signature totalEvents / finalHash and metadata consistent with the exported events', async () => {
+    const { proof, content } = await buildProof('abc');
+    const exported = await proof.exportProof(content);
+    expect(exported.proof.totalEvents).toBe(exported.proof.events.length);
+    expect(exported.proof.finalHash).toBe(
+      exported.proof.events[exported.proof.events.length - 1]!.hash
+    );
+    // メタデータ再カウント (verifyProofMetadata) が同梱 events と一致する
+    expect(
+      verifyProofMetadata(exported.typingProofData, exported.proof.events)
+    ).toMatchObject({ valid: true });
+  });
+
+  it('waitForQueueDrain resolves once all recorded events are on the chain', async () => {
+    const { proof } = await buildProof('a');
+    await expect(proof.waitForQueueDrain(1000)).resolves.toBe(true);
+  });
+});

--- a/packages/shared/src/typingProof/TypingProof.ts
+++ b/packages/shared/src/typingProof/TypingProof.ts
@@ -541,11 +541,17 @@ export class TypingProof {
 
   /**
    * 最終署名を生成
+   * @param events - 対象イベント (省略時は現時点の this.events)。#143: exportProof は
+   *   スナップショットを渡し、署名とメタデータと checkpoint が同じ配列を見るようにする
+   * @param finalHash - events 末尾のハッシュ (省略時は this.currentHash)
    */
-  async generateSignature(): Promise<SignatureData> {
+  async generateSignature(
+    events: readonly StoredEvent[] = this.events,
+    finalHash: string | null = this.currentHash
+  ): Promise<SignatureData> {
     const finalData = {
-      totalEvents: this.events.length,
-      finalHash: this.currentHash,
+      totalEvents: events.length,
+      finalHash,
       startTime: this.startTime,
       endTime: performance.now()
     };
@@ -554,7 +560,7 @@ export class TypingProof {
     const signature = await this.hashChainManager.computeHash(signatureData);
 
     // エクスポート用にメタデータのnullフィールドを省略
-    const compactEvents = this.events.map(event => this.compactEventForExport(event));
+    const compactEvents = events.map(event => this.compactEventForExport(event));
 
     return {
       ...finalData,
@@ -600,25 +606,42 @@ export class TypingProof {
   /**
    * 証明データをエクスポート
    * @param finalContent - 最終的なコード
+   *
+   * #143: export は原子的でない — export 中も broadcast (スクショ/visibility 等) の記録で
+   * `this.events` が伸びうる。署名・メタデータ・checkpoint が別々の時点の配列を見ると、
+   * 「totalEvents が同梱 events と食い違う」「同梱 events に無い eventIndex を指す checkpoint」
+   * を持つ proof ができ、verifier (verifyProofMetadata / verifyCheckpoints) で丸ごと invalid
+   * になる。冒頭で 1 度だけスナップショットし、以降すべて同じ配列に対して計算する。
+   * スナップショット後に記録されたイベントはこの export に含まれない (チェーンには残る)。
    */
   async exportProof(finalContent: string): Promise<ExportedProof> {
-    const signature = await this.generateSignature();
+    const events = this.events.slice();
+    const lastEventIndex = events.length - 1;
+    const finalHash = lastEventIndex >= 0 ? events[lastEventIndex]!.hash : this.currentHash;
 
-    // タイピング証明ハッシュを生成
-    const typingProof = await this.generateTypingProofHash(finalContent);
+    const signature = await this.generateSignature(events, finalHash);
+
+    // タイピング証明ハッシュを生成 (メタデータ再カウントも同じスナップショットから)
+    const typingProof = await this.generateTypingProofHash(finalContent, events, finalHash);
 
     // チェックポイントをクリーンアップして最終チェックポイントを作成
-    const lastEventIndex = this.events.length - 1;
     if (lastEventIndex >= 0) {
       // 正規のチェックポイント以外を削除
       this.checkpointManager.cleanupForExport();
 
-      // 最終イベントにチェックポイントを作成（まだ存在しない場合）
-      const lastCheckpoint = this.checkpointManager.getLastCheckpoint();
-      if (!lastCheckpoint || lastCheckpoint.eventIndex !== lastEventIndex) {
-        await this.checkpointManager.createCheckpoint(lastEventIndex, this.events);
+      // スナップショット最終イベントにチェックポイントを作成（まだ存在しない場合）
+      const hasFinalCheckpoint = this.checkpointManager
+        .getCheckpoints()
+        .some((cp) => cp.eventIndex === lastEventIndex);
+      if (!hasFinalCheckpoint) {
+        await this.checkpointManager.createCheckpoint(lastEventIndex, events);
       }
     }
+
+    // スナップショット外 (export 開始後に伸びた分) を指す checkpoint は同梱しない
+    const checkpoints = this.checkpointManager
+      .getCheckpoints()
+      .filter((cp) => cp.eventIndex <= lastEventIndex);
 
     const exported: ExportedProof = {
       version: PROOF_FORMAT_VERSION,
@@ -634,7 +657,7 @@ export class TypingProof {
         timestamp: new Date().toISOString(),
         isPureTyping: typingProof.compact.isPureTyping
       },
-      checkpoints: this.checkpointManager.getCheckpoints()
+      checkpoints
     };
 
     // 試験モード (ADR-0006): 束縛ブロックを焼き込む。grader はこのブロック + 公開 package
@@ -655,6 +678,26 @@ export class TypingProof {
     }
 
     return exported;
+  }
+
+  /**
+   * 記録キュー (pendingEvents / PoSW 計算待ち) が空になるまで待つ (#143)。
+   *
+   * exportProof はスナップショット一貫だが、直前の打鍵がまだキューにあると
+   * 「content (エディタ buffer) には載っているのにチェーンに無い」export になり、
+   * content replay (Layer 4) で fail する。exporter は**タブ毎に**これを待ってから
+   * model 内容を確定して exportProof を呼ぶこと (アクティブタブだけ待つのでは不足)。
+   *
+   * @returns 排出しきれば true、timeout なら false (呼び出し側は警告して続行してよい —
+   *   その場合もスナップショット一貫性により proof 自体は整合する)
+   */
+  async waitForQueueDrain(timeoutMs = 5000): Promise<boolean> {
+    const start = performance.now();
+    while (this.pendingEvents.length > 0 || this.queuedEventCount > 0) {
+      if (performance.now() - start > timeoutMs) return false;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    return true;
   }
 
   /**
@@ -737,15 +780,21 @@ export class TypingProof {
    * タイピング証明ハッシュを生成
    * @param finalContent - 最終的なコード
    */
-  async generateTypingProofHash(finalContent: string): Promise<TypingProofHashResult> {
+  async generateTypingProofHash(
+    finalContent: string,
+    events: readonly StoredEvent[] = this.events,
+    finalHash: string | null = this.currentHash
+  ): Promise<TypingProofHashResult> {
     const finalContentHash = await this.hashChainManager.computeHash(finalContent);
-    const stats = this.getTypingStatistics();
+    // #143: exportProof はスナップショットを渡す。this.events を直接見ると export 中の
+    // 追記でメタデータの再カウントが同梱 events と食い違い、verifyProofMetadata で fail する。
+    const stats = this.statisticsCalculator.getTypingStatistics(events as StoredEvent[], this.startTime);
 
     const proofData: ProofData = {
       finalContentHash,
       initialHashNonce: this.initialHashNonce ?? undefined,
-      initialEventChainHash: this.events[0]?.previousHash ?? this.currentHash,
-      finalEventChainHash: this.currentHash!,
+      initialEventChainHash: events[0]?.previousHash ?? finalHash,
+      finalEventChainHash: finalHash!,
       deviceId: this.fingerprint!,
       metadata: {
         totalEvents: stats.totalEvents,


### PR DESCRIPTION
## 概要

export は原子的でなく、`exportAllTabsAsZip` のループ + タブ毎最大 5 秒の `waitForFlush` の間もスクショ定期キャプチャ/visibility/fullscreen の broadcast 記録は止まらない (#143)。`exportProof` 内で署名スナップショット・メタデータ再カウント・最終 checkpoint 作成が**別々の時点の `this.events`** を見るため、export 中に events が伸びると:

- 同梱 events に無い eventIndex を指す checkpoint → `verifyCheckpoints` fail → **proof 全体 invalid** (レビュー時の事実確認で「主張より深刻」と確認済み)
- `totalEvents` / `finalHash` の食い違い → `verifyProofMetadata` / `verifyFinalChainHash` fail

## 変更

### shared ([TypingProof.ts](packages/shared/src/typingProof/TypingProof.ts))
- `exportProof` 冒頭で events を **1 度だけスナップショット**し、署名 (`generateSignature`)・メタデータ (`generateTypingProofHash`)・最終 checkpoint をすべて同じ配列に対して計算 (両メソッドは省略可能な events/finalHash 引数を追加 — 既定は従来どおり `this.events`)
- スナップショット外 (export 開始後に伸びた分) を指す checkpoint は同梱しない。checkpoint の**要素オブジェクトは CheckpointManager と共有のまま**なので、export 後の signed envelope attach (`waitForFlush` 中) は従来どおり反映される
- `waitForQueueDrain(timeoutMs)` を追加: pendingEvents / PoSW 計算キューの排出待ち

### editor ([ProofExporter.ts](packages/editor/src/export/ProofExporter.ts))
- 単一/全タブ両経路で、**タブ毎に** `waitForQueueDrain` を待ってから content を確定。従来の `waitForProcessingComplete` は**アクティブタブしか**待たないため、非アクティブタブの直前の打鍵が「content にあるのにチェーンに無い」まま export される窓があった (content replay fail = invalid)

排出しきれない場合 (worker throttling) も、スナップショット一貫性により proof 自体は整合する (直前の打鍵が export に載らないだけ)。

## テスト

- 新規 `exportSnapshot.test.ts` 4 ケース: 範囲外 checkpoint を注入しても同梱されない + `verifyCheckpoints` 通過 / 最終 checkpoint の存在 / totalEvents・finalHash・metadata 再カウントの同梱 events との一致 / drain の解決
- `@typedcode/shared` 396 passed / `@typedcode/editor` 95 passed / `tsc --noEmit` clean

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)