### PR TITLE
fix(editor): firstSeenAt が既知値と食い違う envelope を破棄して再送する (#151)

### DIFF
--- a/packages/editor/src/services/SignedCheckpointService.ts
+++ b/packages/editor/src/services/SignedCheckpointService.ts
@@ -94,6 +94,15 @@ export class SignedCheckpointService {
   private lastCheckpointIndex = -1;
   /** 直近に署名要求した eventIndex (totalEventsSincePrevious 計算用) */
   private lastEventIndex = -1;
+  /**
+   * このセッション(タブ)で確定した firstSeenAt (#151)。
+   * KV は結果整合で他コロへの伝播に最大 ~60s かかるため、cp 周期 (~10s) 内のコロ切替で
+   * サーバが existing=null と誤認し**別の firstSeenAt** で署名して返すことがある。
+   * verifier は全 envelope の firstSeenAt 完全一致を要求するので、不一致 envelope を
+   * attach すると正直な proof が丸ごと fail する。既知値と食い違う envelope は破棄して
+   * バックオフ再送する (伝播後のリトライは正しい firstSeenAt で署名される)。
+   */
+  private knownFirstSeenAt: string | null = null;
   /** online/offline リスナのデタッチ用 */
   private onlineListener: (() => void) | null = null;
   /**
@@ -161,6 +170,7 @@ export class SignedCheckpointService {
       this.previousSignedCheckpointHash = await hashSignedCheckpointPayload(last.payload);
       this.lastCheckpointIndex = last.payload.checkpointIndex;
       this.lastEventIndex = last.payload.eventIndex;
+      this.knownFirstSeenAt = last.payload.firstSeenAt;
     }
 
     // 未署名 checkpoint を queue に再投入
@@ -307,6 +317,15 @@ export class SignedCheckpointService {
         return this.handleFailure(eventIndex, entry, 'response missing envelope');
       }
       const envelope = body.envelope;
+      // #151: 既知の firstSeenAt と食い違う envelope は KV 伝播遅延の疑い。attach すると
+      // verifier の完全一致要求で proof 丸ごと fail するため、破棄して再送に回す。
+      if (this.knownFirstSeenAt !== null && envelope.payload.firstSeenAt !== this.knownFirstSeenAt) {
+        return this.handleFailure(
+          eventIndex,
+          entry,
+          `firstSeenAt mismatch (expected ${this.knownFirstSeenAt}, got ${envelope.payload.firstSeenAt}) — KV propagation lag suspected (#151), discarding envelope`
+        );
+      }
       const attached = this.attachSignature(eventIndex, envelope);
       if (!attached) {
         // checkpoint が cleanup 済み等で見つからない場合は queue から外すだけ
@@ -318,6 +337,7 @@ export class SignedCheckpointService {
       this.previousSignedCheckpointHash = await hashSignedCheckpointPayload(envelope.payload);
       this.lastCheckpointIndex = envelope.payload.checkpointIndex;
       this.lastEventIndex = envelope.payload.eventIndex;
+      if (this.knownFirstSeenAt === null) this.knownFirstSeenAt = envelope.payload.firstSeenAt;
       this.queue.delete(eventIndex);
       return true;
     } catch (err) {

--- a/packages/editor/src/services/__tests__/signedCheckpointFirstSeenAt.test.ts
+++ b/packages/editor/src/services/__tests__/signedCheckpointFirstSeenAt.test.ts
@@ -1,0 +1,139 @@
+/**
+ * SignedCheckpointService の firstSeenAt 突合 (#151) のテスト。
+ *
+ * KV は結果整合で他コロへの伝播に最大 ~60s かかるため、コロ切替に当たったリクエストは
+ * サーバが existing=null と誤認し別の firstSeenAt で署名して返すことがある。verifier は
+ * 全 envelope の firstSeenAt 完全一致を要求するので、その envelope を attach すると
+ * 正直な proof が丸ごと fail する。クライアントは不一致 envelope を破棄して再送する。
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { SignedCheckpointService } from '../SignedCheckpointService.js';
+import type { CheckpointData, SignedCheckpointEnvelope } from '@typedcode/shared';
+
+const SESSION = 'session-1';
+const TAB = 'tab-1';
+
+function makeEnvelope(params: {
+  checkpointIndex: number;
+  eventIndex: number;
+  firstSeenAt: string;
+}): SignedCheckpointEnvelope {
+  return {
+    payload: {
+      version: 1,
+      sessionId: SESSION,
+      tabId: TAB,
+      checkpointIndex: params.checkpointIndex,
+      eventIndex: params.eventIndex,
+      initialEventChainHash: 'a'.repeat(64),
+      chainHash: 'b'.repeat(64),
+      contentHash: 'c'.repeat(64),
+      previousSignedCheckpointHash: null,
+      totalEventsSincePrevious: 1,
+      clientTimestamp: '2026-07-02T00:00:00.000Z',
+      serverTimestamp: '2026-07-02T00:00:01.000Z',
+      firstSeenAt: params.firstSeenAt,
+      poswIterations: 1,
+    },
+    signature: 'sig',
+    keyId: 'test-key',
+    algorithm: 'ECDSA-P256',
+  } as unknown as SignedCheckpointEnvelope;
+}
+
+function makeCheckpoint(eventIndex: number): CheckpointData {
+  return {
+    eventIndex,
+    hash: 'b'.repeat(64),
+    timestamp: eventIndex * 1000,
+    contentHash: 'c'.repeat(64),
+  };
+}
+
+function createService(responses: SignedCheckpointEnvelope[]) {
+  const fetchCalls: number[] = [];
+  const attached: Array<{ eventIndex: number; firstSeenAt: string }> = [];
+  const fetchImpl = vi.fn(async () => {
+    const envelope = responses[fetchCalls.length];
+    fetchCalls.push(fetchCalls.length);
+    return {
+      ok: true,
+      json: async () => ({ envelope }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+
+  const service = new SignedCheckpointService({
+    apiUrl: 'http://localhost:9999',
+    sessionId: SESSION,
+    tabId: TAB,
+    getInitialEventChainHash: () => 'a'.repeat(64),
+    attachSignature: (eventIndex, envelope) => {
+      attached.push({ eventIndex, firstSeenAt: envelope.payload.firstSeenAt });
+      return true;
+    },
+    isOnline: () => true,
+    fetchImpl,
+    backoffSchedule: [10],
+    maxAttemptsPerCheckpoint: 5,
+  });
+
+  return { service, attached, fetchImpl };
+}
+
+describe('SignedCheckpointService firstSeenAt consistency (#151)', () => {
+  it('discards an envelope whose firstSeenAt diverges from the established one and retries until it matches', async () => {
+    const t0 = '2026-07-02T00:00:00.000Z';
+    const t1 = '2026-07-02T00:00:09.000Z'; // 別コロが existing=null と誤認して打った別の firstSeenAt
+    const { service, attached } = createService([
+      makeEnvelope({ checkpointIndex: 0, eventIndex: 0, firstSeenAt: t0 }),
+      makeEnvelope({ checkpointIndex: 1, eventIndex: 5, firstSeenAt: t1 }), // 破棄されるべき
+      makeEnvelope({ checkpointIndex: 1, eventIndex: 5, firstSeenAt: t0 }), // 伝播後のリトライ
+    ]);
+
+    service.handleNewCheckpoint(makeCheckpoint(0));
+    await vi.waitFor(() => expect(attached).toHaveLength(1));
+
+    service.handleNewCheckpoint(makeCheckpoint(5));
+    await vi.waitFor(() => expect(attached).toHaveLength(2), { timeout: 2000 });
+
+    // 不一致 envelope (t1) は attach されず、最終的に t0 の envelope だけが載る
+    expect(attached.map((a) => a.firstSeenAt)).toEqual([t0, t0]);
+    expect(service.pendingCount()).toBe(0);
+    service.dispose();
+  });
+
+  it('adopts the first envelope firstSeenAt as the session baseline', async () => {
+    const t0 = '2026-07-02T01:00:00.000Z';
+    const { service, attached } = createService([
+      makeEnvelope({ checkpointIndex: 0, eventIndex: 0, firstSeenAt: t0 }),
+      makeEnvelope({ checkpointIndex: 1, eventIndex: 3, firstSeenAt: t0 }),
+    ]);
+
+    service.handleNewCheckpoint(makeCheckpoint(0));
+    service.handleNewCheckpoint(makeCheckpoint(3));
+    await vi.waitFor(() => expect(attached).toHaveLength(2), { timeout: 2000 });
+    expect(attached.map((a) => a.firstSeenAt)).toEqual([t0, t0]);
+    service.dispose();
+  });
+
+  it('seeds the baseline from restored signed checkpoints', async () => {
+    const t0 = '2026-07-02T02:00:00.000Z';
+    const tOther = '2026-07-02T02:00:30.000Z';
+    const { service, attached } = createService([
+      makeEnvelope({ checkpointIndex: 1, eventIndex: 9, firstSeenAt: tOther }), // 破棄されるべき
+      makeEnvelope({ checkpointIndex: 1, eventIndex: 9, firstSeenAt: t0 }),
+    ]);
+
+    // 復元: 署名済み cp (firstSeenAt=t0) + 未署名 cp
+    const signedCp: CheckpointData = {
+      ...makeCheckpoint(0),
+      signature: makeEnvelope({ checkpointIndex: 0, eventIndex: 0, firstSeenAt: t0 }),
+    };
+    await service.restore([signedCp, makeCheckpoint(9)]);
+
+    await vi.waitFor(() => expect(attached).toHaveLength(1), { timeout: 2000 });
+    expect(attached[0]!.firstSeenAt).toBe(t0);
+    service.dispose();
+  });
+});

--- a/packages/workers/CLAUDE.md
+++ b/packages/workers/CLAUDE.md
@@ -108,6 +108,8 @@ CORS は `ALLOWED_ORIGINS` (env var, カンマ区切り) による**許可リス
 |---|---|---|
 | `CHECKPOINT_SESSIONS` | `firstSeenAt`, `lastCheckpointIndex`, `lastServerTimestamp`, `signedCount`, `lastEnvelope` (冪等用) | 7 日 |
 
+**firstSeenAt の分裂 (#151)**: KV は結果整合で他コロへの伝播に最大 ~60 秒かかる。cp 周期 (~10s) 内にコロ切替 (モバイル網等) が起きると、切替先では `existing=null` と誤認して**別の `firstSeenAt`** で署名しうる。verifier は全 envelope の firstSeenAt 完全一致を要求するため、そのまま proof に載ると正直な提出が丸ごと fail する。**緩和はクライアント側** — editor の `SignedCheckpointService` が既知の firstSeenAt と食い違う envelope を破棄してバックオフ再送する (伝播後のリトライは正しい値で署名される)。恒久対策 (Durable Object での per-session 逐次化) は W5 の ADR 課題。
+
 ## 観測性・シークレット宣言・型 (運用)
 
 `wrangler.{staging,production}.toml` に以下を宣言している (dev の `wrangler.toml` は skip-worktree なので対象外):


### PR DESCRIPTION
## 概要

KV は結果整合で他コロへの伝播に最大 ~60 秒。cp 周期 (~10s) 内のコロ切替 (モバイル網切替等) で、切替先コロが `existing=null` と誤認し**別の `firstSeenAt`** で署名した envelope を返しうる (#151)。verifier は全 envelope の firstSeenAt 完全一致を要求するため、そのまま proof に載ると**正直な提出が丸ごと fail** する。

## 変更 (Issue の「軽量な緩和」案)

- `SignedCheckpointService` に `knownFirstSeenAt` を導入 — 初回成功 envelope、または restore 時の署名済み checkpoint から確定
- 受領 envelope の firstSeenAt が既知値と不一致なら **attach せず破棄**し、既存の指数バックオフで再送 (バックオフ合計 ~4 分 > KV 伝播 ~60s なので、伝播後のリトライは正しい firstSeenAt で署名される)
- [workers/CLAUDE.md](packages/workers/CLAUDE.md) の KV セクションに失敗モードと緩和を明記

恒久対策 (Durable Object での per-session 逐次化 — ADR-0003 が却下した複雑性との再トレードオフ) は W5 の ADR 課題として残しています。

## テスト

- 新規 `signedCheckpointFirstSeenAt.test.ts` 3 ケース (fetch 注入で KV 伝播遅延を再現): 不一致 envelope の破棄 → リトライで正値 attach / 初回 envelope による baseline 確定 / restore 済み署名 cp からの baseline 引き継ぎ
- `@typedcode/editor` 98 passed / `tsc --noEmit` clean

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)