### PR TITLE
test(verify): 検証層 (security boundary) にユニットテストを導入 (#135)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4469,7 +4469,8 @@
         "@types/diff": "^8.0.0",
         "@types/node": "^26.1.0",
         "typescript": "^6.0.2",
-        "vite": "^8.1.2"
+        "vite": "^8.1.2",
+        "vitest": "^4.1.9"
       }
     },
     "packages/verify-cli": {

--- a/packages/verify-cli/src/__tests__/analyzers.test.ts
+++ b/packages/verify-cli/src/__tests__/analyzers.test.ts
@@ -1,0 +1,55 @@
+/**
+ * loadExternalAnalyzers (#135 / ADR-0009 プラットフォーム方針) のテスト。
+ *
+ * `--analyzer <path>` は外部モジュールの動的 import + 契約バリデーションだけを担う
+ * (分析ロジックは外部側)。受理する export 形態・不正モジュールの拒否・重複 id の拒否は
+ * CLI の入口契約なのでここで固定する。
+ */
+
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { loadExternalAnalyzers } from '../analyzers.js';
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'analyzers');
+const fx = (name: string): string => join(FIXTURES, name);
+
+describe('loadExternalAnalyzers', () => {
+  it('loads a default-exported analyzer', async () => {
+    const analyzers = await loadExternalAnalyzers([fx('valid-default.mjs')]);
+    expect(analyzers.map((a) => a.id)).toEqual(['fixture-default']);
+  });
+
+  it('collects named "analyzer" and "analyzers" exports from one module', async () => {
+    const analyzers = await loadExternalAnalyzers([fx('valid-named.mjs')]);
+    expect(analyzers.map((a) => a.id)).toEqual([
+      'fixture-named-single',
+      'fixture-named-a',
+      'fixture-named-b',
+    ]);
+  });
+
+  it('accumulates analyzers across multiple modules in argument order', async () => {
+    const analyzers = await loadExternalAnalyzers([fx('valid-default.mjs'), fx('valid-named.mjs')]);
+    expect(analyzers).toHaveLength(4);
+    expect(analyzers[0]!.id).toBe('fixture-default');
+  });
+
+  it('rejects a module whose exports do not satisfy the Analyzer contract', async () => {
+    await expect(loadExternalAnalyzers([fx('invalid-shape.mjs')])).rejects.toThrow(
+      /no valid Analyzer export/
+    );
+  });
+
+  it('rejects a module that cannot be imported', async () => {
+    await expect(loadExternalAnalyzers([fx('does-not-exist.mjs')])).rejects.toThrow(
+      /Failed to load external analyzer/
+    );
+  });
+
+  it('rejects duplicate analyzer ids across modules', async () => {
+    await expect(
+      loadExternalAnalyzers([fx('valid-default.mjs'), fx('duplicate-of-default.mjs')])
+    ).rejects.toThrow(/Duplicate analyzer id "fixture-default"/);
+  });
+});

--- a/packages/verify-cli/src/__tests__/fixtures/analyzers/duplicate-of-default.mjs
+++ b/packages/verify-cli/src/__tests__/fixtures/analyzers/duplicate-of-default.mjs
@@ -1,0 +1,8 @@
+// テスト fixture: valid-default.mjs と同じ id (重複 id 拒否の検証用)
+export default {
+  id: 'fixture-default',
+  version: '2.0.0',
+  analyze() {
+    return [];
+  },
+};

--- a/packages/verify-cli/src/__tests__/fixtures/analyzers/invalid-shape.mjs
+++ b/packages/verify-cli/src/__tests__/fixtures/analyzers/invalid-shape.mjs
@@ -1,0 +1,2 @@
+// テスト fixture: Analyzer 契約 ({id, version, analyze}) を満たさない export
+export default { notAnAnalyzer: true };

--- a/packages/verify-cli/src/__tests__/fixtures/analyzers/valid-default.mjs
+++ b/packages/verify-cli/src/__tests__/fixtures/analyzers/valid-default.mjs
@@ -1,0 +1,8 @@
+// テスト fixture: default export の単一 Analyzer (ADR-0009 契約)
+export default {
+  id: 'fixture-default',
+  version: '1.0.0',
+  analyze() {
+    return [];
+  },
+};

--- a/packages/verify-cli/src/__tests__/fixtures/analyzers/valid-named.mjs
+++ b/packages/verify-cli/src/__tests__/fixtures/analyzers/valid-named.mjs
@@ -1,0 +1,25 @@
+// テスト fixture: named export (analyzer 単体 + analyzers 配列) の併存
+export const analyzer = {
+  id: 'fixture-named-single',
+  version: '1.0.0',
+  analyze() {
+    return [];
+  },
+};
+
+export const analyzers = [
+  {
+    id: 'fixture-named-a',
+    version: '1.0.0',
+    analyze() {
+      return [];
+    },
+  },
+  {
+    id: 'fixture-named-b',
+    version: '1.0.0',
+    analyze() {
+      return [];
+    },
+  },
+];

--- a/packages/verify/CLAUDE.md
+++ b/packages/verify/CLAUDE.md
@@ -67,7 +67,7 @@ File Selection (drag&drop / FSA API)
 - worker が検証後に shared の `runAnalysis` を実行し `VerificationResultData.analysis` で返す。**advisory であって判定ではない** — `valid` / TrustCalculator / タブ status には一切反映しない (ここを破ると ADR-0009 の直交性が壊れる)
 - 表示は `AnalysisReportCard` (`#card-analysis`)。severity (`info`/`notice`/`review`)・score/confidence・summary に加え **evidence (event index) をボタンで出す**
 - evidence クリックは `document` に `verify:seek-to-event` CustomEvent を dispatch し、`ChartController` が `SeekbarController.seekTo(eventIndex + 1)` で当該イベント適用後の状態へジャンプする (「シグナルを見る → 現場を検分」の 1 クリック化)
-- 分析ロジックは shared に置く。verify 側に分析器を書かない (verify はテスト未整備のため)
+- 分析ロジックは shared に置く。verify 側に分析器を書かない (テストの厚みが shared 側にあるため。verify のユニットテストは #135 で導入済みだが純関数中心)
 
 ## 三層保証バッジ (ADR-0020)
 

--- a/packages/verify/package.json
+++ b/packages/verify/package.json
@@ -6,7 +6,9 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "@typedcode/shared": "*",
@@ -21,6 +23,7 @@
     "@types/diff": "^8.0.0",
     "@types/node": "^26.1.0",
     "typescript": "^6.0.2",
-    "vite": "^8.1.2"
+    "vite": "^8.1.2",
+    "vitest": "^4.1.9"
   }
 }

--- a/packages/verify/src/services/__tests__/TrustCalculator.test.ts
+++ b/packages/verify/src/services/__tests__/TrustCalculator.test.ts
@@ -1,0 +1,129 @@
+/**
+ * TrustCalculator (#135) のテスト。
+ *
+ * 信頼バッジは verify (web) の security boundary の要 — 「タブは緑なのにバッジは failed」
+ * 型の回帰 (#146) が着地する場所なので、error / warning / verified の軸を仕様として固定する。
+ * VerificationController.handleComplete の status 判定はこれと同じ軸を見る (verify/CLAUDE.md)。
+ */
+
+import { describe, expect, it } from 'vitest';
+import { TrustCalculator } from '../TrustCalculator.js';
+import type { ScreenshotVerificationSummary, VerificationResultData } from '../../types.js';
+
+/** 健全な anchored proof の検証結果 (テストごとに上書きして崩す)。 */
+function healthyResult(): VerificationResultData {
+  return {
+    metadataValid: true,
+    chainValid: true,
+    isPureTyping: true,
+    rootAnchored: true,
+    signedCheckpointAnchored: true,
+    signedCheckpointValid: true,
+  } as unknown as VerificationResultData;
+}
+
+function noScreenshots(): ScreenshotVerificationSummary {
+  return { total: 0, verified: 0, missing: 0, tampered: 0 };
+}
+
+function calc(
+  result: VerificationResultData | null,
+  screenshots: ScreenshotVerificationSummary = noScreenshots(),
+  options?: { hasScreenShareOptOut?: boolean }
+) {
+  return TrustCalculator.calculate(result, undefined, screenshots, undefined, options);
+}
+
+describe('TrustCalculator.calculate — level determination', () => {
+  it('reports verified when no issue is raised', () => {
+    expect(calc(healthyResult()).level).toBe('verified');
+  });
+
+  it('fails when metadata verification failed', () => {
+    const r = calc({ ...healthyResult(), metadataValid: false });
+    expect(r.level).toBe('failed');
+    expect(r.issues.some((i) => i.component === 'metadata' && i.severity === 'error')).toBe(true);
+  });
+
+  it('fails when the hash chain is broken', () => {
+    expect(calc({ ...healthyResult(), chainValid: false }).level).toBe('failed');
+  });
+
+  it('fails when any screenshot is tampered', () => {
+    const r = calc(healthyResult(), { total: 3, verified: 2, missing: 0, tampered: 1 });
+    expect(r.level).toBe('failed');
+    expect(r.issues.some((i) => i.component === 'screenshots' && i.severity === 'error')).toBe(true);
+  });
+
+  it('downgrades to partial (not failed) when screenshots are only missing', () => {
+    const r = calc(healthyResult(), { total: 3, verified: 2, missing: 1, tampered: 0 });
+    expect(r.level).toBe('partial');
+  });
+
+  it('fails when signed checkpoints exist but are invalid', () => {
+    const r = calc({
+      ...healthyResult(),
+      signedCheckpointAnchored: true,
+      signedCheckpointValid: false,
+    });
+    expect(r.level).toBe('failed');
+    expect(r.issues.some((i) => i.component === 'anchoring' && i.severity === 'error')).toBe(true);
+  });
+
+  it('warns (partial) when no signed checkpoint anchors the proof', () => {
+    const r = calc({ ...healthyResult(), signedCheckpointAnchored: false });
+    expect(r.level).toBe('partial');
+  });
+
+  it('warns when the chain root is not server-anchored for a non-exam proof', () => {
+    const r = calc({ ...healthyResult(), rootAnchored: false });
+    expect(r.level).toBe('partial');
+    expect(r.issues.some((i) => i.component === 'anchoring' && i.severity === 'warning')).toBe(true);
+  });
+
+  it('does not warn about root anchoring for an exam proof (own T0 binding)', () => {
+    const r = calc({
+      ...healthyResult(),
+      rootAnchored: false,
+      exam: { present: true, packageProvided: true, binding: { valid: true } },
+    } as unknown as VerificationResultData);
+    expect(r.issues.filter((i) => i.component === 'anchoring')).toHaveLength(0);
+  });
+
+  it('warns on non-pure typing', () => {
+    const r = calc({ ...healthyResult(), isPureTyping: false });
+    expect(r.level).toBe('partial');
+    expect(r.issues.some((i) => i.component === 'typing')).toBe(true);
+  });
+
+  it('warns on screen-share opt-out', () => {
+    const r = calc(healthyResult(), noScreenshots(), { hasScreenShareOptOut: true });
+    expect(r.level).toBe('partial');
+  });
+
+  it('fails when a provided exam package fails binding verification', () => {
+    const r = calc({
+      ...healthyResult(),
+      exam: { present: true, packageProvided: true, binding: { valid: false } },
+    } as unknown as VerificationResultData);
+    expect(r.level).toBe('failed');
+    expect(r.issues.some((i) => i.component === 'exam' && i.severity === 'error')).toBe(true);
+  });
+
+  it('warns (unverified authenticity) for an exam proof without the package', () => {
+    const r = calc({
+      ...healthyResult(),
+      exam: { present: true, packageProvided: false },
+    } as unknown as VerificationResultData);
+    expect(r.level).toBe('partial');
+    expect(r.issues.some((i) => i.component === 'exam' && i.severity === 'warning')).toBe(true);
+  });
+
+  it('error always dominates warnings in the final level', () => {
+    const r = calc(
+      { ...healthyResult(), chainValid: false, isPureTyping: false, rootAnchored: false },
+      { total: 1, verified: 0, missing: 1, tampered: 0 }
+    );
+    expect(r.level).toBe('failed');
+  });
+});

--- a/packages/verify/vitest.config.ts
+++ b/packages/verify/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // TrustCalculator 等の純関数を対象にする (DOM 非依存)。UI コンポーネントのテストを
+    // 足すときは happy-dom を導入して environmentMatchGlobs で分けること。
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    globals: true,
+  },
+});


### PR DESCRIPTION
## 概要

verify (Web) はテスト 0 件・test スクリプトなし、verify-cli は #148 で入った args.test.ts のみだった (#135)。検証層は本プロジェクトの security boundary であり、誤表示・exit code 誤りが信頼を直撃する。Issue の優先順 (1)(2)(4) を実装。

## 変更

### verify (web) — vitest 新規導入
- `vitest` devDep + `vitest.config.ts` (node 環境・純関数対象) + `test`/`test:run` スクリプト。CI の test job は `--workspaces --if-present` (#156) なので**設定追加だけで自動組み込み**
- **TrustCalculator 14 ケース**: error/warning/verified の軸を実行可能な仕様として固定 — スクショ改竄 = failed / 欠損 = partial、署名 cp が anchored だが invalid = failed、exam proof は root アンカー警告の対象外、exam package 未提供 = 真正性未確認の warning、error は warning に常に優先、等。`VerificationController.handleComplete` が同じ軸を見る (#146) ため、両者の乖離回帰の防波堤になる

### verify-cli
- **loadExternalAnalyzers 6 ケース** (ADR-0009 プラットフォーム方針の入口契約): default / named `analyzer` / named `analyzers` 配列の受理と併存、契約不適合モジュールの拒否、読込失敗の明示エラー、モジュール横断の重複 id 拒否。fixture は実 ES モジュールとしてコミット (動的 import の実挙動でテスト)

## スコープ外 (followup)

- ResultPanel のエスケープ回帰テスト (happy-dom 導入が必要)
- cli.ts の exit code マトリクス統合テスト — e2e 12 spec が敵対ケース込みで既にカバー

## テスト

- `@typedcode/verify` 14 passed (新規) / `@typedcode/verify-cli` 15 passed (args 9 + analyzers 6) / `tsc --noEmit` clean

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)