### PR TITLE
fix(editor): EventRecorder を Phase 5 より前に生成し起動時ワンショット信号の欠落を解消 (#132)

### DIFF
--- a/packages/e2e/tests/happy-path.spec.ts
+++ b/packages/e2e/tests/happy-path.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { EditorApp } from './helpers/app.js';
+import { EditorApp, readProofEvents } from './helpers/app.js';
 import { runVerifyCliWithAnalysis } from './helpers/verifyCli.js';
 
 /**
@@ -35,4 +35,20 @@ test('casual: 打鍵→export→CLI 検証が pass する', async ({ page }) => 
   // ② analysis レポート (advisory) も valid を返し、ペースト由来の指摘がない。
   expect(result.analysis.length).toBeGreaterThan(0);
   expect(result.analysis[0]!.valid).toBe(true);
+
+  // ③ 起動時ワンショット信号 (#132): environmentProbe (ADR-0007 Tier0 + ADR-0019 の
+  // editorAssist 宣言) と screenShareOptOut (casual は既定オプトアウト = ADR-0015) が
+  // チェーンに載っている。EventRecorder 生成 (Phase 4.9) より前に発火して無音ドロップ
+  // していた回帰の検出器。
+  const events = await readProofEvents(zipPath);
+  const probe = events.find((e) => e.type === 'environmentProbe');
+  expect(probe, 'environmentProbe recorded at startup').toBeDefined();
+  expect(
+    (probe!.data as { editorAssist?: unknown } | undefined)?.editorAssist,
+    'editorAssist declaration present in environmentProbe',
+  ).toBeTruthy();
+  expect(
+    events.some((e) => e.type === 'screenShareOptOut'),
+    'screenShareOptOut recorded at startup (casual defaults to opt-out)',
+  ).toBe(true);
 });

--- a/packages/editor/src/main.ts
+++ b/packages/editor/src/main.ts
@@ -1422,6 +1422,15 @@ async function initializeApp(): Promise<void> {
     });
   });
 
+  // Phase 4.9: EventRecorder の初期化 (#132)。
+  // 必ず Phase 5 (initializeTrackers) より前に生成する。Phase 5 の recordInitial 群
+  // (environmentProbe = ADR-0007 Tier0 / editorAssist = ADR-0019 / 初期 windowResize /
+  // networkStatusChange) と Phase 5.5 の screenShareOptOut は起動時ワンショットで、
+  // recorder 未生成だと optional chaining により**無音でドロップ**し、全 proof から
+  // 永久に欠落する (「捕捉は不可逆」原則への違反)。EventRecorder は tabManager が
+  // あれば生成できるので、ここまで前倒しして問題ない (logViewer は lazy getter)。
+  initializeEventRecorder();
+
   // Phase 5: トラッカーの初期化
   initializeTrackers({
     ctx,
@@ -1447,9 +1456,8 @@ async function initializeApp(): Promise<void> {
     ctx.trackers.screenshot.emitScreenShareOptOutEvent();
   }
 
-  // Phase 6: LogViewerとEventRecorderの初期化
+  // Phase 6: LogViewerの初期化 (EventRecorder は Phase 4.9 で生成済み #132)
   initializeLogViewer(ctx);
-  initializeEventRecorder();
 
   // フルスクリーン追跡 (ADR-0008/0014、能力 fullscreenTracking)。eventRecorder 準備後に配線する。
   // exam は警告バナー + 要求ボタン (fullscreenBanner=true、ボタンが開始ジェスチャ)。

--- a/packages/editor/src/tracking/__tests__/EnvironmentTracker.test.ts
+++ b/packages/editor/src/tracking/__tests__/EnvironmentTracker.test.ts
@@ -1,0 +1,90 @@
+/**
+ * EnvironmentTracker (ADR-0007 Tier0 / ADR-0019) の recordInitial テスト。
+ *
+ * #132: 起動時ワンショットの environmentProbe が EventRecorder 未生成のタイミングで
+ * 発火して無音ドロップし、全 proof から欠落していた。main.ts 側の順序修正 (Phase 4.9)
+ * と併せて、tracker 自体が callback へ確実に 1 発出すことをここで固定する
+ * (チェーンに載る end-to-end は e2e happy-path が assert する)。
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EnvironmentTracker, type EnvironmentTrackerEvent } from '../EnvironmentTracker.js';
+import type { EditorAssistDeclaration } from '@typedcode/shared';
+
+function assist(): EditorAssistDeclaration {
+  return {
+    schema: 'editor-assist/1',
+    quickSuggestions: null,
+    suggestOnTriggerCharacters: null,
+    wordBasedSuggestions: null,
+    snippetSuggestions: null,
+    inlineSuggest: null,
+    tabCompletion: null,
+    acceptSuggestionOnEnter: null,
+    parameterHints: null,
+    autoClosingBrackets: 'languageDefined',
+    autoClosingQuotes: 'languageDefined',
+    autoSurround: 'languageDefined',
+    formatOnType: null,
+    formatOnPaste: null,
+  };
+}
+
+describe('EnvironmentTracker.recordInitial', () => {
+  beforeEach(() => {
+    // node 環境に window は無いので capture が読む範囲だけ偽装する
+    vi.stubGlobal('window', { __playwright: {}, cdc_asdjflasutopfhvcZLmcfl_: {} });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('emits exactly one environmentProbe event to the callback', () => {
+    const tracker = new EnvironmentTracker();
+    const events: EnvironmentTrackerEvent[] = [];
+    tracker.setCallback((e) => events.push(e));
+
+    tracker.recordInitial();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('environmentProbe');
+  });
+
+  it('captures automation globals (playwright hint and cdc_* prefix)', () => {
+    const tracker = new EnvironmentTracker();
+    const events: EnvironmentTrackerEvent[] = [];
+    tracker.setCallback((e) => events.push(e));
+
+    tracker.recordInitial();
+
+    const globals = events[0]!.data.automationGlobals;
+    expect(globals).toContain('__playwright');
+    expect(globals.some((g) => g.startsWith('cdc_'))).toBe(true);
+  });
+
+  it('includes the editor-assist declaration from the provider (ADR-0019)', () => {
+    const tracker = new EnvironmentTracker();
+    const decl = assist();
+    tracker.setAssistDeclarationProvider(() => decl);
+    const events: EnvironmentTrackerEvent[] = [];
+    tracker.setCallback((e) => events.push(e));
+
+    tracker.recordInitial();
+
+    expect(events[0]!.data.editorAssist).toBe(decl);
+  });
+
+  it('records editorAssist: null when the provider throws (graceful absence)', () => {
+    const tracker = new EnvironmentTracker();
+    tracker.setAssistDeclarationProvider(() => {
+      throw new Error('resolution failed');
+    });
+    const events: EnvironmentTrackerEvent[] = [];
+    tracker.setCallback((e) => events.push(e));
+
+    tracker.recordInitial();
+
+    expect(events[0]!.data.editorAssist).toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要

起動時ワンショット信号 — `environmentProbe` (ADR-0007 Tier0: webdriver/自動化グローバル + ADR-0019: editorAssist 宣言)・初期 `windowResize`/`networkStatusChange` (Phase 5)・`screenShareOptOut` (Phase 5.5、事実確認パスで判明した追加被害) — が、`EventRecorder` 生成 (旧 Phase 6) より前に発火するため `ctx.eventRecorder?.` の optional chaining で**無音ドロップ**し、**全モード・全セッションの proof から欠落**していた (#132)。「捕捉は不可逆」原則への重い違反で、`automationAnalyzer` の入力も常に欠落。

## 変更

- `initializeEventRecorder()` を **Phase 4.9** (initializeTrackers より前) へ移動。EventRecorder は tabManager さえあれば生成できる (logViewer は lazy getter なので Phase 6 のままで問題ない)
- ドロップの理由と順序制約をコメントで固定

## テスト (3 層)

1. **unit**: `EnvironmentTracker.recordInitial` 4 ケース (1 発発火 / `__playwright`・`cdc_*` の捕捉 / editorAssist 宣言の同梱 / provider 例外時の graceful null)
2. **e2e**: happy-path に「export した proof に `environmentProbe` (editorAssist 込み) と `screenShareOptOut` (casual は既定オプトアウト = ADR-0015) が載る」assertion を追加
3. **実機の負のコントロール**: main.ts の修正だけ外して e2e を実行 → **fail** (欠落を再現)、修正を当てる → **pass** (34s)。バグの実在と修正の因果を暗号的成果物で確認済み

- `@typedcode/editor` 99 passed / `tsc --noEmit` (editor, e2e) clean

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)