### PR TITLE
fix(shared): replay と乖離した contentSnapshot を外部入力相当として advisory 検出する (#175)

### DIFF
--- a/packages/shared/src/__tests__/analysisOrchestrator.test.ts
+++ b/packages/shared/src/__tests__/analysisOrchestrator.test.ts
@@ -115,4 +115,28 @@ describe('pureTypingAnalyzer (placeholder)', () => {
     const report = await runAnalysis(makeInput({ isPureTyping: true }), [pureTypingAnalyzer]);
     expect(report.signals).toHaveLength(0);
   });
+
+  it('flags a divergent contentSnapshot as bulk evidence (#175)', async () => {
+    // 挿入イベント無しで replay 文書を丸ごと差し替える持ち込み口。bulk として数え、
+    // evidence の note で snapshot 由来だと分かるようにする。
+    const input = {
+      proof: {
+        proof: {
+          events: [
+            { sequence: 0, timestamp: 0, type: 'contentSnapshot', data: 'int ai() {\n  return 42;\n}\n' },
+          ],
+        },
+      },
+      verification: {
+        valid: true,
+        metadataValid: true,
+        chainValid: true,
+        isPureTyping: false,
+      },
+    } as unknown as AnalysisInput;
+    const report = await runAnalysis(input, [pureTypingAnalyzer]);
+    expect(report.signals).toHaveLength(1);
+    expect(report.signals[0]!.summaryParams).toMatchObject({ paste: 0, drop: 0, bulk: 1 });
+    expect(report.signals[0]!.evidence[0]?.note).toBe('divergent-content-snapshot');
+  });
 });

--- a/packages/shared/src/__tests__/processSummary.test.ts
+++ b/packages/shared/src/__tests__/processSummary.test.ts
@@ -240,6 +240,23 @@ describe('summarizeProcess — moments', () => {
     expect(s.externalInputCount).toBe(0);
   });
 
+  it('counts a contentSnapshot that diverges from the replayed document as external input (#175)', () => {
+    const s = summarizeProcess([
+      makeEvent({ type: 'contentChange', timestamp: 0, inputType: 'insertText', data: 'a', rangeOffset: 0, rangeLength: 0 }),
+      makeEvent({ type: 'contentSnapshot', timestamp: 100, data: 'int ai() {\n  return 42;\n}\n' }),
+    ]);
+    expect(s.externalInputCount).toBe(1);
+    expect(s.moments.find((x) => x.kind === 'external-input')?.fromEventIndex).toBe(1);
+  });
+
+  it('does not count the regular contentSnapshot that matches the replayed document (#175)', () => {
+    const s = summarizeProcess([
+      makeEvent({ type: 'contentChange', timestamp: 0, inputType: 'insertText', data: 'a', rangeOffset: 0, rangeLength: 0 }),
+      makeEvent({ type: 'contentSnapshot', timestamp: 100, data: 'a' }),
+    ]);
+    expect(s.externalInputCount).toBe(0);
+  });
+
   it('sorts moments by event index', () => {
     const gap = PROCESS_PAUSE_THRESHOLD_MS + 1_000;
     const s = summarizeProcess([

--- a/packages/shared/src/__tests__/verification.test.ts
+++ b/packages/shared/src/__tests__/verification.test.ts
@@ -334,4 +334,45 @@ describe('verification utilities', () => {
       isPureTyping: true,
     });
   });
+
+  it('breaks pure typing for a contentSnapshot that diverges from the replayed document (#175)', () => {
+    // 手製 proof が contentSnapshot 1 イベントで AI 解答全体を持ち込む laundering。
+    // 挿入イベントが無いので paste/drop/bulk のどのカウントにも載らず、従来は
+    // isPureTyping=true のまま通った。metadata 照合カウントは従来どおり (valid 不変)。
+    const events = [
+      { type: 'contentChange', inputType: 'insertText', data: 'a', rangeOffset: 0, rangeLength: 0, timestamp: 10 },
+      { type: 'contentSnapshot', inputType: null, data: 'int solve() {\n  return 42;\n}\n', timestamp: 20 },
+    ] as StoredEvent[];
+    const proofData = {
+      metadata: {
+        totalEvents: 2, pasteEvents: 0, internalPasteEvents: 0, dropEvents: 0,
+        insertEvents: 1, deleteEvents: 0, bulkInsertEvents: 0, totalTypingTime: 20, averageTypingSpeed: 0,
+      },
+    } as ProofData;
+    expect(verifyProofMetadata(proofData, events)).toMatchObject({
+      valid: true,
+      isPureTyping: false,
+      divergentContentSnapshotEventIndexes: [1],
+    });
+  });
+
+  it('keeps pure typing for the regular contentSnapshot that matches the replayed document (#175)', () => {
+    // editor が 100 イベント毎に出す正規 snapshot は取得時のエディタ内容 = replay 文書と
+    // 常に一致する no-op。既存 proof の isPureTyping を変えない (後方互換)。
+    const events = [
+      { type: 'contentChange', inputType: 'insertText', data: 'a', rangeOffset: 0, rangeLength: 0, timestamp: 10 },
+      { type: 'contentSnapshot', inputType: null, data: 'a', timestamp: 20 },
+    ] as StoredEvent[];
+    const proofData = {
+      metadata: {
+        totalEvents: 2, pasteEvents: 0, internalPasteEvents: 0, dropEvents: 0,
+        insertEvents: 1, deleteEvents: 0, bulkInsertEvents: 0, totalTypingTime: 20, averageTypingSpeed: 0,
+      },
+    } as ProofData;
+    expect(verifyProofMetadata(proofData, events)).toMatchObject({
+      valid: true,
+      isPureTyping: true,
+      divergentContentSnapshotEventIndexes: [],
+    });
+  });
 });

--- a/packages/shared/src/analysis/analyzers/pureTypingAnalyzer.ts
+++ b/packages/shared/src/analysis/analyzers/pureTypingAnalyzer.ts
@@ -11,6 +11,7 @@
 import type { AnalysisInput, AnalysisSignal, Analyzer, EvidenceRef } from '../types.js';
 import { isProhibitedInputType } from '../../typingProof/InputTypeValidator.js';
 import { isBenignEditorInsert, isFlaggedBulkInsert, SessionProvenanceLedger } from '../../typingProof/structuralEdit.js';
+import { isDivergentContentSnapshot } from '../../typingProof/replay.js';
 
 const ID = 'example-pure-typing';
 
@@ -23,6 +24,7 @@ export const pureTypingAnalyzer: Analyzer = {
     // 外部入力の event index を証拠として集める。
     // - paste/drop 等の禁止 InputType (正規な editor 補完は除く)
     // - AI/スニペットによる複数行の一括投入 (replaceContent/insertText は禁止型でないので明示的に拾う)
+    // - replay 文書と乖離した contentSnapshot (#175: 挿入イベント無しの全文差し替え。bulk に含める)
     const evidence: EvidenceRef[] = [];
     let pasteCount = 0;
     let dropCount = 0;
@@ -32,9 +34,13 @@ export const pureTypingAnalyzer: Analyzer = {
     for (let i = 0; i < events.length; i++) {
       const event = events[i];
       if (!event) continue;
+      const divergentSnapshot = isDivergentContentSnapshot(event, ledger.currentContent);
       const sessionDerived = ledger.checkAndApply(event);
       const inputType = event.inputType;
-      if (isFlaggedBulkInsert(event, sessionDerived)) {
+      if (divergentSnapshot) {
+        bulkCount++;
+        evidence.push({ fromEventIndex: i, note: 'divergent-content-snapshot' });
+      } else if (isFlaggedBulkInsert(event, sessionDerived)) {
         // 複数行のコード一括投入 (Copilot/Cursor が Tab で全体投入する類)。最も注視すべき痕跡。
         bulkCount++;
         evidence.push({ fromEventIndex: i, note: `multiline-bulk:${inputType ?? 'insert'}` });

--- a/packages/shared/src/processSummary.ts
+++ b/packages/shared/src/processSummary.ts
@@ -16,6 +16,7 @@ import type { StoredEvent } from './types/proof.js';
 import type { CodeExecutionEventData, FocusChangeData, ReflectionNoteData } from './types/events.js';
 import { isProhibitedInputType } from './typingProof/InputTypeValidator.js';
 import { isBenignEditorInsert, isFlaggedBulkInsert, SessionProvenanceLedger } from './typingProof/structuralEdit.js';
+import { isDivergentContentSnapshot } from './typingProof/replay.js';
 
 /** 編集の停止 (考え中) とみなす contentChange 間ギャップの下限。 */
 export const PROCESS_PAUSE_THRESHOLD_MS = 10_000;
@@ -149,6 +150,7 @@ export function summarizeProcess(events: readonly StoredEvent[]): ProcessSummary
   for (let i = 0; i < events.length; i++) {
     const event = events[i]!;
     // 逐次判定 (イベント適用前の状態に対して)。全イベントを記録順に通す必要がある。
+    const divergentSnapshot = isDivergentContentSnapshot(event, ledger.currentContent);
     const sessionDerived = ledger.checkAndApply(event);
 
     switch (event.type) {
@@ -274,9 +276,11 @@ export function summarizeProcess(events: readonly StoredEvent[]): ProcessSummary
     // 外部入力 = ペースト/ドロップ等の禁止 InputType (正規な editor 補完は除く)、または
     // AI/スニペットによる複数行の一括投入 (replaceContent/insertText は禁止型ではないので
     // 明示的に拾う)。後者は「コード全体を Tab で一気に入れる」類を記録・検出するため。
+    // replay と乖離した contentSnapshot (#175: 挿入イベント無しの全文差し替え) も同扱い。
     if (
       (event.inputType && isProhibitedInputType(event.inputType) && !isBenignEditorInsert(event)) ||
-      isFlaggedBulkInsert(event, sessionDerived)
+      isFlaggedBulkInsert(event, sessionDerived) ||
+      divergentSnapshot
     ) {
       externalInputCount++;
       if (externalMoments.length < PROCESS_MAX_EXTERNAL_INPUT_MOMENTS) {

--- a/packages/shared/src/types/verification.ts
+++ b/packages/shared/src/types/verification.ts
@@ -52,6 +52,12 @@ export interface ProofMetadataVerificationResult {
   isPureTyping: boolean;
   recomputedMetadata: ProofMetadata;
   suspiciousBulkInsertEventIndexes: number[];
+  /**
+   * replay 文書と乖離した contentSnapshot の event index (#175)。挿入イベント無しで
+   * 文書を丸ごと差し替える持ち込み口。1 つでもあれば isPureTyping=false (advisory のみ、
+   * valid には影響しない)。editor の正規 snapshot は replay と常に一致するため載らない。
+   */
+  divergentContentSnapshotEventIndexes: number[];
 }
 
 /** タイピング証明ハッシュ検証結果 */

--- a/packages/shared/src/typingProof/__tests__/structuralEdit.test.ts
+++ b/packages/shared/src/typingProof/__tests__/structuralEdit.test.ts
@@ -169,6 +169,21 @@ describe('SessionProvenanceLedger (#138: 内部ペーストの内容はセッシ
     expect(results[1]).toBe(false);
     expect(results[2]).toBe(false);
   });
+
+  it('does not absorb a divergent contentSnapshot, so smuggled content is never session-derived (#175)', () => {
+    // 乖離 snapshot で AI 解答を持ち込み、その部分文字列を「内部ペースト」として挿入する迂回路。
+    const ai = 'int ai() {\n  return 42;\n}\n';
+    const snapshot = { type: 'contentSnapshot', inputType: null, data: ai } as unknown as StoredEvent;
+    const insertion = { type: 'contentChange', inputType: 'insertParagraph', data: ai, rangeOffset: 0, rangeLength: 0 } as unknown as StoredEvent;
+    const results = run([snapshot, insertion]);
+    expect(results[1]).toBe(false);
+  });
+
+  it('treats a matching contentSnapshot as a provenance no-op (the regular 100-event snapshot)', () => {
+    const snapshot = { type: 'contentSnapshot', inputType: null, data: code } as unknown as StoredEvent;
+    const results = run([typed(code, 0), snapshot, typed(code, code.length)]);
+    expect(results[2]).toBe(true); // snapshot を挟んでも文書由来の再挿入は引き続き許可
+  });
 });
 
 describe('getEditorAssistDeclaration', () => {

--- a/packages/shared/src/typingProof/replay.ts
+++ b/packages/shared/src/typingProof/replay.ts
@@ -18,6 +18,26 @@ export function isTemplateInjectionData(data: unknown): data is { content: strin
   );
 }
 
+/**
+ * contentSnapshot が replay 文書と乖離しているか (#175)。
+ *
+ * editor の正規 snapshot (100 イベント毎、`ProofStatusDisplay.checkSnapshot`) は取得時の
+ * エディタ内容そのものなので、忠実な replay とは常に完全一致する (= replay 上 no-op)。
+ * 乖離する snapshot は replay 文書を挿入イベント無しで丸ごと差し替えられる唯一の口であり、
+ * 手製 proof が AI 解答全体を 1 イベントで持ち込む laundering に使える。
+ * 判定は advisory のみ (isPureTyping / 分析シグナル / processSummary)。`valid` には影響させない。
+ */
+export function isDivergentContentSnapshot(
+  event: StoredEvent,
+  replayContentBeforeApply: string
+): boolean {
+  return (
+    event.type === 'contentSnapshot' &&
+    typeof event.data === 'string' &&
+    event.data !== replayContentBeforeApply
+  );
+}
+
 /** Monaco の range (1-origin 行/列) を文書内 offset へ変換する。範囲外なら null。 */
 export function offsetFromRange(content: string, event: StoredEvent): number | null {
   if (typeof event.rangeOffset === 'number') {

--- a/packages/shared/src/typingProof/structuralEdit.ts
+++ b/packages/shared/src/typingProof/structuralEdit.ts
@@ -22,7 +22,7 @@
  */
 
 import type { StoredEvent, EditorAssistDeclaration } from '../types.js';
-import { applyReplayEventTolerant } from './replay.js';
+import { applyReplayEventTolerant, isDivergentContentSnapshot } from './replay.js';
 
 /** 構造文字: 括弧・クォート・空白。これらだけなら「内容 (コード)」を運べない。 */
 const STRUCTURAL_CHARS = /^[()\[\]{}<>"'`\s]+$/;
@@ -165,6 +165,14 @@ export class SessionProvenanceLedger {
   private verifiedCopies = new Set<string>();
 
   /**
+   * 適用済みイベントまでの replay 文書 (読み取り専用)。
+   * 呼び出し側が `checkAndApply` の**前**に snapshot 乖離判定 (#175) へ渡すために公開する。
+   */
+  get currentContent(): string {
+    return this.content;
+  }
+
+  /**
    * イベントを 1 つ進める。返り値は「このイベントの data がセッション由来か」
    * (適用前の文書 or 検証済みコピーに対する判定)。events の記録順に全イベントを通すこと。
    */
@@ -179,6 +187,13 @@ export class SessionProvenanceLedger {
       // コピー内容が当時の文書に実在したときだけ「セッション由来」と認める。
       if (sessionDerived && data !== null) this.verifiedCopies.add(data);
       return sessionDerived;
+    }
+
+    // #175: 乖離した contentSnapshot は台帳に取り込まない。取り込むと持ち込んだ内容の
+    // 部分文字列が以後「セッション由来」と誤認され、内部ペースト検証の迂回路になる。
+    // 正規 snapshot は replay と常に一致する no-op なので、この分岐は正直な proof に影響しない。
+    if (isDivergentContentSnapshot(event, this.content)) {
+      return false;
     }
 
     this.content = applyReplayEventTolerant(this.content, event);

--- a/packages/shared/src/verification.ts
+++ b/packages/shared/src/verification.ts
@@ -24,7 +24,7 @@ export {
 import { deterministicStringify, computeHash } from './utils/hashUtils.js';
 import { computeExamChainRoot } from './exam/examPackage.js';
 import { isBenignEditorInsert, isFlaggedBulkInsert, isSuspiciousBulkInsert, SessionProvenanceLedger } from './typingProof/structuralEdit.js';
-import { isTemplateInjectionData, offsetFromRange } from './typingProof/replay.js';
+import { isDivergentContentSnapshot, isTemplateInjectionData, offsetFromRange } from './typingProof/replay.js';
 import { POSW_ITERATIONS, EXAM_ROOT_BINDING_V2 } from './version.js';
 import {
   verifyProofSignedCheckpoints,
@@ -383,6 +383,11 @@ function recomputeProofMetadata(events: StoredEvent[]): ProofMetadataVerificatio
   // bulkInsertEvents の申告メタデータ照合 (verifyProofMetadata) は従来どおり suspicious のみ
   // 数えるので、既存 proof との後方互換と整合性チェックは保たれる。
   let nonBenignBulkInsertCount = 0;
+  // #175: replay 文書と乖離した contentSnapshot。挿入イベント無しで文書を丸ごと差し替え
+  // られる唯一の口なので、外部入力相当として isPureTyping を崩す (正規 snapshot は常に
+  // 一致する no-op なので既存 proof に影響しない)。claimed metadata との照合カウントには
+  // 含めない (後方互換)。
+  const divergentContentSnapshotEventIndexes: number[] = [];
   // #138: 内部ペーストの許可はマーカー (自己申告) でなく、replay で検証したセッション内在性。
   const ledger = new SessionProvenanceLedger();
 
@@ -396,6 +401,9 @@ function recomputeProofMetadata(events: StoredEvent[]): ProofMetadataVerificatio
     if (event.type === 'contentChange' && event.data) insertEvents++;
     if (event.inputType?.startsWith('delete')) deleteEvents++;
 
+    if (isDivergentContentSnapshot(event, ledger.currentContent)) {
+      divergentContentSnapshotEventIndexes.push(i);
+    }
     const sessionDerived = ledger.checkAndApply(event);
     const suspicious = isSuspiciousBulkInsert(event);
     if (suspicious) suspiciousBulkInsertEventIndexes.push(i);
@@ -426,9 +434,14 @@ function recomputeProofMetadata(events: StoredEvent[]): ProofMetadataVerificatio
 
   return {
     valid: true,
-    isPureTyping: pasteEvents === 0 && dropEvents === 0 && nonBenignBulkInsertCount === 0,
+    isPureTyping:
+      pasteEvents === 0 &&
+      dropEvents === 0 &&
+      nonBenignBulkInsertCount === 0 &&
+      divergentContentSnapshotEventIndexes.length === 0,
     recomputedMetadata,
     suspiciousBulkInsertEventIndexes,
+    divergentContentSnapshotEventIndexes,
   };
 }
 


### PR DESCRIPTION
## 概要

Issue #175: `contentSnapshot` は replay 文書を丸ごと置換できるのに、どの申告カウントにも `isPureTyping` にも反映されず、手製 proof が AI 解答全体を 1 イベントで持ち込める laundering 口だった。

## 重要な事実修正

Issue 備考の「現行 editor は contentSnapshot を emit しない」は**誤り**。`ProofStatusDisplay.checkSnapshot` → `main.ts` 経由で **100 イベント毎に emit している**。よって受理の非推奨化 (案 b) は取れず、乖離検出 (案 a+c) を採用した。

## 設計: 「replay 文書との乖離」を判別軸にする

editor の正規 snapshot は取得時のエディタ内容そのものなので、忠実な replay とは**常に完全一致する (= replay 上 no-op)**。乖離する snapshot だけが持ち込み口。

- `isDivergentContentSnapshot` を `typingProof/replay.ts` に新設 (適用規則と同居させドリフト防止)
- `recomputeProofMetadata`: 乖離 snapshot の index を収集し `isPureTyping` を崩す。**claimed metadata 照合には含めない** (既存 proof と後方互換)。`valid` 不変 (ADR-0023: advisory 層のみ)
- `SessionProvenanceLedger`: 乖離 snapshot を台帳に取り込まない → 持ち込み内容の部分文字列が「セッション由来」と誤認される内部ペースト検証の迂回路 (PR #173 の限界) を塞ぐ
- `pureTypingAnalyzer`: bulk として数え evidence note `divergent-content-snapshot`。既存の summaryKey を流用し i18n 追加なし (#150 と競合させない)
- `processSummary`: external-input の見どころとして数える

## テスト

- verifyProofMetadata: 乖離 snapshot → `isPureTyping=false` + index 報告 / 一致 snapshot → 影響なし (後方互換)
- ledger: 乖離 snapshot 経由の持ち込み内容は session-derived にならない / 一致 snapshot は no-op
- analyzer / processSummary の検出経路

`@typedcode/shared` 439 passed、typecheck 全パッケージ green。

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)