### PR TITLE
fix(verify): ハードコード日本語を t() 化し en ロケールの混在を解消 (#150)

### DIFF
--- a/packages/verify/src/charts/ChartUtils.ts
+++ b/packages/verify/src/charts/ChartUtils.ts
@@ -4,6 +4,8 @@
  * キャンバス初期化や共通の描画関数を提供します。
  */
 
+import { t } from '../i18n/index.js';
+
 // ============================================================================
 // 型定義
 // ============================================================================
@@ -55,7 +57,7 @@ export class ChartUtils {
    * 時間を短いフォーマットに（秒.ms）
    */
   static formatTimeShort(ms: number): string {
-    return `${(ms / 1000).toFixed(2)}秒`;
+    return t('charts.secondsShort', { seconds: (ms / 1000).toFixed(2) });
   }
 
   /**

--- a/packages/verify/src/charts/IntegratedChart.ts
+++ b/packages/verify/src/charts/IntegratedChart.ts
@@ -25,6 +25,7 @@ import type { StoredEvent, KeystrokeDynamicsData, InputType, EventType } from '@
 import type { VerifyScreenshot, IntegratedChartCache } from '../types.js';
 import type { ChartEventVisibility } from '../types/chartVisibility.js';
 import { DEFAULT_CHART_EVENT_VISIBILITY, isEventTypeVisible } from '../types/chartVisibility.js';
+import { t } from '../i18n/index.js';
 
 // Chart.js登録
 Chart.register(
@@ -512,7 +513,7 @@ export class IntegratedChart {
     if (this.isVisible('contentChange')) {
       datasets.push({
         type: 'line',
-        label: 'タイピング速度 (CPS)',
+        label: t('charts.datasets.typingSpeed'),
         data: this.cache.typingSpeedData,
         borderColor: '#667eea',
         backgroundColor: 'rgba(102, 126, 234, 0.1)',
@@ -557,7 +558,7 @@ export class IntegratedChart {
     if (this.isVisible('externalInput') && this.cache.externalInputMarkers.length > 0) {
       datasets.push({
         type: 'scatter',
-        label: '外部入力',
+        label: t('charts.events.externalInput'),
         data: this.cache.externalInputMarkers.map((m) => ({
           x: m.timestamp,
           y: 0,
@@ -575,7 +576,7 @@ export class IntegratedChart {
     if (this.isVisible('contentChange') && this.cache.internalPasteMarkers.length > 0) {
       datasets.push({
         type: 'scatter',
-        label: '内部ペースト',
+        label: t('charts.datasets.internalPaste'),
         data: this.cache.internalPasteMarkers.map((m) => ({
           x: m.timestamp,
           y: 0.35, // 外部入力マーカーより上、他のイベントより下に配置
@@ -595,7 +596,7 @@ export class IntegratedChart {
     if (this.isVisible('humanAttestation') && this.cache.humanAttestationEvents.length > 0) {
       datasets.push({
         type: 'scatter',
-        label: '人間検証',
+        label: t('charts.datasets.humanAttestation'),
         data: this.cache.humanAttestationEvents.map((m) => ({
           x: m.timestamp,
           y: 0.9, // 上部に配置
@@ -630,7 +631,7 @@ export class IntegratedChart {
       if (periodicScreenshots.length > 0) {
         datasets.push({
           type: 'scatter',
-          label: '定期撮影',
+          label: t('charts.datasets.periodicCapture'),
           data: periodicScreenshots.map((s) => ({
             x: s.timestamp,
             y: 0.6, // 上部に配置
@@ -669,7 +670,7 @@ export class IntegratedChart {
       if (focusLostScreenshots.length > 0) {
         datasets.push({
           type: 'scatter',
-          label: 'フォーカス喪失撮影',
+          label: t('charts.datasets.focusLostCapture'),
           data: focusLostScreenshots.map((s) => ({
             x: s.timestamp,
             y: 0.3, // 定期撮影より下に配置
@@ -708,7 +709,7 @@ export class IntegratedChart {
       if (manualScreenshots.length > 0) {
         datasets.push({
           type: 'scatter',
-          label: '手動撮影',
+          label: t('charts.datasets.manualCapture'),
           data: manualScreenshots.map((s) => ({
             x: s.timestamp,
             y: 0.9, // 最上部
@@ -750,7 +751,7 @@ export class IntegratedChart {
       if (this.isVisible('termsAccepted') && termsEvents.length > 0) {
         datasets.push({
           type: 'scatter',
-          label: '利用規約同意',
+          label: t('charts.events.termsAccepted'),
           data: termsEvents.map((m) => ({
             x: m.timestamp,
             y: 0.75,
@@ -771,7 +772,7 @@ export class IntegratedChart {
       if (this.isVisible('preExportAttestation') && preExportEvents.length > 0) {
         datasets.push({
           type: 'scatter',
-          label: 'エクスポート認証',
+          label: t('charts.datasets.preExportAttestation'),
           data: preExportEvents.map((m) => ({
             x: m.timestamp,
             y: 0.85,
@@ -795,7 +796,7 @@ export class IntegratedChart {
       if (this.isVisible('editorInitialized') && initEvents.length > 0) {
         datasets.push({
           type: 'scatter',
-          label: 'エディタ初期化',
+          label: t('charts.events.editorInitialized'),
           data: initEvents.map((m) => ({
             x: m.timestamp,
             y: 0.1,
@@ -816,7 +817,7 @@ export class IntegratedChart {
       if (this.isVisible('networkStatusChange') && networkEvents.length > 0) {
         datasets.push({
           type: 'scatter',
-          label: 'ネットワーク変更',
+          label: t('charts.datasets.networkStatusChange'),
           data: networkEvents.map((m) => ({
             x: m.timestamp,
             y: 0.15,
@@ -840,7 +841,7 @@ export class IntegratedChart {
       if (this.isVisible('codeExecution') && codeEvents.length > 0) {
         datasets.push({
           type: 'scatter',
-          label: 'コード実行',
+          label: t('charts.events.codeExecution'),
           data: codeEvents.map((m) => ({
             x: m.timestamp,
             y: 0.5,
@@ -861,7 +862,7 @@ export class IntegratedChart {
       if (this.isVisible('terminalInput') && terminalEvents.length > 0) {
         datasets.push({
           type: 'scatter',
-          label: 'ターミナル入力',
+          label: t('charts.events.terminalInput'),
           data: terminalEvents.map((m) => ({
             x: m.timestamp,
             y: 0.45,
@@ -885,7 +886,7 @@ export class IntegratedChart {
       if (this.isVisible('screenShareStart') && shareStartEvents.length > 0) {
         datasets.push({
           type: 'scatter',
-          label: '画面共有開始',
+          label: t('charts.events.screenShareStart'),
           data: shareStartEvents.map((m) => ({
             x: m.timestamp,
             y: 0.55,
@@ -906,7 +907,7 @@ export class IntegratedChart {
       if (this.isVisible('screenShareStop') && shareStopEvents.length > 0) {
         datasets.push({
           type: 'scatter',
-          label: '画面共有終了',
+          label: t('charts.events.screenShareStop'),
           data: shareStopEvents.map((m) => ({
             x: m.timestamp,
             y: 0.55,
@@ -927,7 +928,7 @@ export class IntegratedChart {
       if (this.isVisible('templateInjection') && templateEvents.length > 0) {
         datasets.push({
           type: 'scatter',
-          label: 'テンプレート挿入',
+          label: t('charts.events.templateInjection'),
           data: templateEvents.map((m) => ({
             x: m.timestamp,
             y: 0.4,
@@ -948,7 +949,7 @@ export class IntegratedChart {
     if (this.isVisible('windowResize') && this.cache.windowResizeEvents && this.cache.windowResizeEvents.length > 0) {
       datasets.push({
         type: 'scatter',
-        label: 'ウィンドウリサイズ',
+        label: t('charts.events.windowResize'),
         data: this.cache.windowResizeEvents.map((m) => ({
           x: m.timestamp,
           y: 0.2,
@@ -968,7 +969,7 @@ export class IntegratedChart {
     if (this.isVisible('contentSnapshot') && this.cache.contentSnapshotEvents && this.cache.contentSnapshotEvents.length > 0) {
       datasets.push({
         type: 'scatter',
-        label: 'スナップショット',
+        label: t('charts.datasets.contentSnapshot'),
         data: this.cache.contentSnapshotEvents.map((m) => ({
           x: m.timestamp,
           y: 0.25,
@@ -1001,7 +1002,7 @@ export class IntegratedChart {
       scales: {
         x: {
           type: 'linear',
-          title: { display: true, text: '時刻' },
+          title: { display: true, text: t('charts.axisTime') },
           ticks: {
             callback: (value) => this.formatAxisTime(value as number),
             maxTicksLimit: 10,
@@ -1219,29 +1220,28 @@ export class IntegratedChart {
     if (this.isScreenshotDataset(label)) {
       const data = context.raw as ScreenshotPointData;
       const typeMap: Record<string, string> = {
-        periodic: '定期',
-        focusLost: 'フォーカス喪失',
-        manual: '手動',
+        periodic: t('screenshot.typePeriodic'),
+        focusLost: t('screenshot.typeFocusLost'),
+        manual: t('screenshot.typeManual'),
       };
-      const captureType = typeMap[data.screenshot.captureType] ?? data.screenshot.captureType;
+      const type = typeMap[data.screenshot.captureType] ?? data.screenshot.captureType;
       const time = this.formatAxisTime(data.screenshot.timestamp);
 
       if (data.screenshot.missing) {
-        return `❌ ${captureType} - ${time} [画像欠損]`;
+        return t('charts.tooltips.screenshotMissing', { type, time });
       } else if (!data.screenshot.verified) {
-        return `⚠️ ${captureType} - ${time} [改ざんの可能性]`;
+        return t('charts.tooltips.screenshotTampered', { type, time });
       } else {
-        return `📷 ${captureType} - ${time} [検証済み]`;
+        return t('charts.tooltips.screenshotVerified', { type, time });
       }
     }
 
-    if (label === '人間検証') {
+    if (label === t('charts.datasets.humanAttestation')) {
       const data = context.raw as { x: number; y: number };
-      const time = this.formatAxisTime(data.x);
-      return `⭐ 人間検証 (Turnstile) - ${time}`;
+      return t('charts.tooltips.humanAttestation', { time: this.formatAxisTime(data.x) });
     }
 
-    if (label === 'タイピング速度 (CPS)') {
+    if (label === t('charts.datasets.typingSpeed')) {
       const data = context.raw as { x: number; y: number };
       return `${data.y.toFixed(1)} CPS`;
     }
@@ -1251,86 +1251,34 @@ export class IntegratedChart {
       return `${label}: ${data.y.toFixed(0)}ms (${data.key})`;
     }
 
-    if (label === '外部入力') {
-      return '⚠️ 外部ペースト/ドロップ';
+    if (label === t('charts.events.externalInput')) {
+      return t('charts.tooltips.externalInput');
     }
 
-    if (label === '内部ペースト') {
+    if (label === t('charts.datasets.internalPaste')) {
       const data = context.raw as { x: number; y: number };
-      const time = this.formatAxisTime(data.x);
-      return `✅ 内部ペースト（許可） - ${time}`;
+      return t('charts.tooltips.internalPaste', { time: this.formatAxisTime(data.x) });
     }
 
-    // Auth events
-    if (label === '利用規約同意') {
+    // Auth / system / execution / capture / window / content events は
+    // dataset label → tooltip キーの対応表で解決する
+    const eventTooltips: Array<[string, string]> = [
+      [t('charts.events.termsAccepted'), 'charts.tooltips.termsAccepted'],
+      [t('charts.datasets.preExportAttestation'), 'charts.tooltips.preExportAttestation'],
+      [t('charts.events.editorInitialized'), 'charts.tooltips.editorInitialized'],
+      [t('charts.datasets.networkStatusChange'), 'charts.tooltips.networkStatusChange'],
+      [t('charts.events.codeExecution'), 'charts.tooltips.codeExecution'],
+      [t('charts.events.terminalInput'), 'charts.tooltips.terminalInput'],
+      [t('charts.events.screenShareStart'), 'charts.tooltips.screenShareStart'],
+      [t('charts.events.screenShareStop'), 'charts.tooltips.screenShareStop'],
+      [t('charts.events.templateInjection'), 'charts.tooltips.templateInjection'],
+      [t('charts.events.windowResize'), 'charts.tooltips.windowResize'],
+      [t('charts.datasets.contentSnapshot'), 'charts.tooltips.contentSnapshot'],
+    ];
+    const match = eventTooltips.find(([datasetLabel]) => datasetLabel === label);
+    if (match) {
       const data = context.raw as { x: number; y: number };
-      const time = this.formatAxisTime(data.x);
-      return `📜 利用規約同意 - ${time}`;
-    }
-
-    if (label === 'エクスポート前検証') {
-      const data = context.raw as { x: number; y: number };
-      const time = this.formatAxisTime(data.x);
-      return `🔐 エクスポート前検証 (Turnstile) - ${time}`;
-    }
-
-    // System events
-    if (label === 'エディタ初期化') {
-      const data = context.raw as { x: number; y: number };
-      const time = this.formatAxisTime(data.x);
-      return `🚀 エディタ初期化 - ${time}`;
-    }
-
-    if (label === 'ネットワーク変更') {
-      const data = context.raw as { x: number; y: number };
-      const time = this.formatAxisTime(data.x);
-      return `🌐 ネットワーク状態変更 - ${time}`;
-    }
-
-    // Execution events
-    if (label === 'コード実行') {
-      const data = context.raw as { x: number; y: number };
-      const time = this.formatAxisTime(data.x);
-      return `▶️ コード実行 - ${time}`;
-    }
-
-    if (label === 'ターミナル入力') {
-      const data = context.raw as { x: number; y: number };
-      const time = this.formatAxisTime(data.x);
-      return `💻 ターミナル入力 - ${time}`;
-    }
-
-    // Capture events
-    if (label === '画面共有開始') {
-      const data = context.raw as { x: number; y: number };
-      const time = this.formatAxisTime(data.x);
-      return `🎬 画面共有開始 - ${time}`;
-    }
-
-    if (label === '画面共有終了') {
-      const data = context.raw as { x: number; y: number };
-      const time = this.formatAxisTime(data.x);
-      return `🛑 画面共有終了 - ${time}`;
-    }
-
-    if (label === 'テンプレート挿入') {
-      const data = context.raw as { x: number; y: number };
-      const time = this.formatAxisTime(data.x);
-      return `📝 テンプレート挿入 - ${time}`;
-    }
-
-    // Window events
-    if (label === 'ウィンドウリサイズ') {
-      const data = context.raw as { x: number; y: number };
-      const time = this.formatAxisTime(data.x);
-      return `📐 ウィンドウリサイズ - ${time}`;
-    }
-
-    // Content events
-    if (label === 'コンテンツスナップショット') {
-      const data = context.raw as { x: number; y: number };
-      const time = this.formatAxisTime(data.x);
-      return `📋 コンテンツスナップショット - ${time}`;
+      return t(match[1], { time: this.formatAxisTime(data.x) });
     }
 
     return label;
@@ -1342,9 +1290,13 @@ export class IntegratedChart {
   private isScreenshotDataset(label: string | undefined): boolean {
     if (!label) return false;
     // 新しいラベル形式（定期撮影、フォーカス喪失撮影、手動撮影）
-    return label === '定期撮影' || label === 'フォーカス喪失撮影' || label === '手動撮影' ||
-           // 後方互換のための旧ラベル
-           label.startsWith('スクリーンショット');
+    return (
+      label === t('charts.datasets.periodicCapture') ||
+      label === t('charts.datasets.focusLostCapture') ||
+      label === t('charts.datasets.manualCapture') ||
+      // 後方互換のための旧ラベル
+      label.startsWith('スクリーンショット')
+    );
   }
 
   /**

--- a/packages/verify/src/charts/ScreenshotOverlay.ts
+++ b/packages/verify/src/charts/ScreenshotOverlay.ts
@@ -7,6 +7,7 @@
 
 import type { VerifyScreenshot } from '../types.js';
 import type { ScreenshotService } from '../services/ScreenshotService.js';
+import { t } from '../i18n/index.js';
 
 /**
  * スクリーンショットプレビューオーバーレイ
@@ -85,9 +86,9 @@ export class ScreenshotOverlay {
 
     // 情報を更新
     const typeMap: Record<string, string> = {
-      periodic: '定期',
-      focusLost: 'フォーカス喪失',
-      manual: '手動',
+      periodic: t('screenshot.typePeriodic'),
+      focusLost: t('screenshot.typeFocusLost'),
+      manual: t('screenshot.typeManual'),
     };
 
     this.typeEl.textContent = typeMap[screenshot.captureType] ?? screenshot.captureType;

--- a/packages/verify/src/i18n/translations/en.ts
+++ b/packages/verify/src/i18n/translations/en.ts
@@ -4,6 +4,7 @@ export const en: VerifyTranslationKeys = {
   common: {
     cancel: 'Cancel',
     close: 'Close',
+    delete: 'Delete',
     ready: 'Ready',
     verifying: 'Verifying',
     files: 'files',
@@ -29,6 +30,7 @@ export const en: VerifyTranslationKeys = {
   activityBar: {
     menu: 'Menu',
     openFile: 'Open File',
+    openFolder: 'Open Folder',
     explorer: 'Explorer',
     settings: 'Settings',
     themeToggle: 'Toggle Theme',
@@ -41,6 +43,9 @@ export const en: VerifyTranslationKeys = {
     addFile: 'Add File',
     addFolder: 'Add Folder',
     emptyMessage: 'Files will appear here\nwhen loaded',
+    removeFile: 'Remove',
+    removeFolder: 'Remove Folder',
+    removeConfirm: 'Remove "${filename}" from the list?',
   },
 
   welcome: {
@@ -62,10 +67,33 @@ export const en: VerifyTranslationKeys = {
     samplingDesc: 'Partial verification of checkpoint segments',
     completeStep: 'Complete',
     completeDesc: 'Displaying verification results',
+    statusRunning: 'Processing...',
+    statusDone: 'Done',
+    statusError: 'Error',
+    statusSkipped: 'Skipped',
+    statusFallback: 'Fallback',
+    statusNoCheckpoints: 'No checkpoints',
+    chainDetail: '${current} / ${total} events',
+    samplingDetail: '${current} events verified / ${total} events',
+    samplingDetailWithTotal:
+      '${current} events verified / ${total} events (${totalEvents} total)',
   },
 
   result: {
     statusVerifying: 'Verifying...',
+    statusSuccess: 'Verification Successful',
+    statusWarning: 'Warnings Found',
+    statusFailed: 'Verification Failed',
+    typingPure: 'Pure',
+    typingExternal: 'External input',
+    timesCount: '${count}',
+    externalInputYes: 'Detected',
+    externalInputNo: 'None',
+    eventsUnit: '${count}',
+    screenshotsMissing: '✗ ${missing}/${total} missing',
+    screenshotsMissingAndTampered: '✗ ${missing} missing, ${tampered} possibly tampered',
+    imageLoadFailed: 'Failed to load image',
+    sourceMismatchBanner: 'Source file does not match proof content',
     typing: 'Typing',
     pasteCount: 'External Paste',
     internalPasteCount: 'Internal Paste',
@@ -212,9 +240,28 @@ export const en: VerifyTranslationKeys = {
     valid: 'Valid',
     invalid: 'Invalid',
     none: 'None',
+    validCount: '${valid}/${total} valid',
     verifiedLegacy: 'Verified (legacy)',
     exportTimeAuth: 'Authenticated at export',
     noAttestation: 'No human attestation',
+  },
+
+  screenshot: {
+    typePeriodic: 'Periodic capture',
+    typeFocusLost: 'Focus lost',
+    typeManual: 'Manual',
+  },
+
+  lightbox: {
+    close: 'Close (Esc)',
+    prev: 'Previous (←)',
+    next: 'Next (→)',
+    type: 'Type',
+    time: 'Time',
+    resolution: 'Resolution',
+    hashVerification: 'Hash Verification',
+    verified: '✓ Verified',
+    unverified: 'Unverified',
   },
 
   statusBar: {
@@ -231,6 +278,38 @@ export const en: VerifyTranslationKeys = {
     flight: 'Flight',
     mouse: 'Mouse',
     eventFilter: 'Event Filter',
+    axisTime: 'Time',
+    secondsShort: '${seconds}s',
+    datasets: {
+      typingSpeed: 'Typing Speed (CPS)',
+      internalPaste: 'Internal Paste',
+      periodicCapture: 'Periodic Capture',
+      focusLostCapture: 'Focus-Lost Capture',
+      manualCapture: 'Manual Capture',
+      humanAttestation: 'Human Attestation',
+      preExportAttestation: 'Export Attestation',
+      networkStatusChange: 'Network Change',
+      contentSnapshot: 'Snapshot',
+    },
+    tooltips: {
+      screenshotMissing: '❌ ${type} - ${time} [image missing]',
+      screenshotTampered: '⚠️ ${type} - ${time} [possibly tampered]',
+      screenshotVerified: '📷 ${type} - ${time} [verified]',
+      humanAttestation: '⭐ Human attestation (Turnstile) - ${time}',
+      externalInput: '⚠️ External paste/drop',
+      internalPaste: '✅ Internal paste (allowed) - ${time}',
+      termsAccepted: '📜 Terms accepted - ${time}',
+      preExportAttestation: '🔐 Pre-export attestation (Turnstile) - ${time}',
+      editorInitialized: '🚀 Editor initialized - ${time}',
+      networkStatusChange: '🌐 Network status change - ${time}',
+      codeExecution: '▶️ Code execution - ${time}',
+      terminalInput: '💻 Terminal input - ${time}',
+      screenShareStart: '🎬 Screen share started - ${time}',
+      screenShareStop: '🛑 Screen share stopped - ${time}',
+      templateInjection: '📝 Template injected - ${time}',
+      windowResize: '📐 Window resized - ${time}',
+      contentSnapshot: '📋 Content snapshot - ${time}',
+    },
     categories: {
       content: 'Content',
       cursor: 'Cursor',
@@ -272,6 +351,40 @@ export const en: VerifyTranslationKeys = {
 
   trust: {
     screenShareOptOut: 'Recorded without screen sharing',
+    summaryVerified: 'Verification successful',
+    summaryPartial: 'Warnings (${count})',
+    summaryFailed: 'Verification failed (${count} errors)',
+    issueMetadataInvalid: 'Metadata verification failed',
+    issueChainInvalid: 'Hash chain verification failed',
+    issueScreenshotsTampered: '${count} screenshots possibly tampered',
+    issueScreenshotsMissing: '${count} screenshots missing',
+    issueAttestationBoth: 'Human attestation verification failed',
+    issueAttestationCreate: 'Human attestation at creation is invalid',
+    issueAttestationExport: 'Human attestation at export is invalid',
+    issueSourceMismatch:
+      '${filename}: source file differs from proof content (+${additions}/-${deletions} lines)',
+    issueAnchoringInvalid: 'Signed checkpoints are invalid',
+    issueAnchoringMissing: 'No temporal anchor (signed checkpoints)',
+    issueAnchoringPostHoc:
+      'Post-hoc batch signing suspected (server span is far shorter than the claimed session)',
+    issueAnchoringSparse:
+      'Anchor density is sparse (signed checkpoints are too few / too late for the claimed session)',
+    issueRootNotAnchored:
+      'Chain root is not server-anchored (start time unfixed; offline forgery possible)',
+    issueNotPureTyping: 'Not pure typing (paste / bulk insertion detected)',
+    issueExamBindingFailed: 'Exam binding (signature / content hash) verification failed',
+    issueExamUnverified: 'Problem package not loaded; authenticity unverified',
+    components: {
+      metadata: 'Metadata',
+      chain: 'Hash Chain',
+      posw: 'PoSW',
+      attestation: 'Human Attestation',
+      screenshots: 'Screenshots',
+      source: 'Source File',
+      anchoring: 'Temporal Anchoring',
+      exam: 'Exam Binding',
+      typing: 'Typing',
+    },
   },
 
   process: {
@@ -421,6 +534,13 @@ export const en: VerifyTranslationKeys = {
     browserNotSupportedDesc:
       'Please use file selection or drag and drop instead',
     examInvalidPackage: 'Invalid problem package (.tcexam)',
+    jsonParseError: 'JSON parse error: ${filename}',
+    fileLoadFailed: 'Failed to read file: ${message}',
+    zipEmpty: 'No files found in the ZIP.',
+    zipLoadFailed: 'Failed to read ZIP file: ${message}',
+    unsupportedFormat:
+      'Unsupported format: metadata is missing (v3.0.0 or later required)',
+    noEvents: 'No events found in proof data',
   },
 
   messages: {

--- a/packages/verify/src/i18n/translations/ja.ts
+++ b/packages/verify/src/i18n/translations/ja.ts
@@ -4,6 +4,7 @@ export const ja: VerifyTranslationKeys = {
   common: {
     cancel: 'キャンセル',
     close: '閉じる',
+    delete: '削除',
     ready: 'Ready',
     verifying: '検証中',
     files: 'ファイル',
@@ -29,6 +30,7 @@ export const ja: VerifyTranslationKeys = {
   activityBar: {
     menu: 'メニュー',
     openFile: 'ファイルを開く',
+    openFolder: 'フォルダを開く',
     explorer: 'エクスプローラー',
     settings: '設定',
     themeToggle: 'テーマ切替',
@@ -41,6 +43,9 @@ export const ja: VerifyTranslationKeys = {
     addFile: 'ファイルを追加',
     addFolder: 'フォルダを追加',
     emptyMessage: 'ファイルを読み込むと\nここに表示されます',
+    removeFile: '削除',
+    removeFolder: 'フォルダを削除',
+    removeConfirm: '「${filename}」をリストから削除しますか？',
   },
 
   welcome: {
@@ -62,10 +67,33 @@ export const ja: VerifyTranslationKeys = {
     samplingDesc: 'チェックポイント区間の部分検証',
     completeStep: '完了',
     completeDesc: '検証結果の表示',
+    statusRunning: '処理中...',
+    statusDone: '完了',
+    statusError: 'エラー',
+    statusSkipped: 'スキップ',
+    statusFallback: 'フォールバック',
+    statusNoCheckpoints: 'チェックポイントなし',
+    chainDetail: '${current} / ${total} イベント',
+    samplingDetail: '${current}イベント検証済み / ${total}イベント',
+    samplingDetailWithTotal:
+      '${current}イベント検証済み / ${total}イベント (全${totalEvents}イベント)',
   },
 
   result: {
     statusVerifying: '検証中...',
+    statusSuccess: '検証成功',
+    statusWarning: '警告あり',
+    statusFailed: '検証失敗',
+    typingPure: '純粋',
+    typingExternal: '外部入力あり',
+    timesCount: '${count}回',
+    externalInputYes: 'あり',
+    externalInputNo: 'なし',
+    eventsUnit: '${count}件',
+    screenshotsMissing: '✗ ${missing}/${total}枚が欠損',
+    screenshotsMissingAndTampered: '✗ ${missing}枚欠損, ${tampered}枚改ざんの可能性',
+    imageLoadFailed: '画像を読み込めませんでした',
+    sourceMismatchBanner: 'ソースファイルと証明内容が一致しません',
     typing: 'タイピング',
     pasteCount: '外部ペースト',
     internalPasteCount: '内部ペースト',
@@ -212,9 +240,28 @@ export const ja: VerifyTranslationKeys = {
     valid: '有効',
     invalid: '無効',
     none: 'なし',
+    validCount: '${valid}/${total} 有効',
     verifiedLegacy: '検証済み（旧形式）',
     exportTimeAuth: 'エクスポート時に認証',
     noAttestation: '人間証明なし',
+  },
+
+  screenshot: {
+    typePeriodic: '定期キャプチャ',
+    typeFocusLost: 'フォーカス喪失',
+    typeManual: '手動',
+  },
+
+  lightbox: {
+    close: '閉じる (Esc)',
+    prev: '前へ (←)',
+    next: '次へ (→)',
+    type: 'タイプ',
+    time: '時刻',
+    resolution: '解像度',
+    hashVerification: 'ハッシュ検証',
+    verified: '✓ 検証済み',
+    unverified: '未検証',
   },
 
   statusBar: {
@@ -231,6 +278,38 @@ export const ja: VerifyTranslationKeys = {
     flight: 'Flight',
     mouse: 'マウス',
     eventFilter: 'イベントフィルター',
+    axisTime: '時刻',
+    secondsShort: '${seconds}秒',
+    datasets: {
+      typingSpeed: 'タイピング速度 (CPS)',
+      internalPaste: '内部ペースト',
+      periodicCapture: '定期撮影',
+      focusLostCapture: 'フォーカス喪失撮影',
+      manualCapture: '手動撮影',
+      humanAttestation: '人間検証',
+      preExportAttestation: 'エクスポート認証',
+      networkStatusChange: 'ネットワーク変更',
+      contentSnapshot: 'スナップショット',
+    },
+    tooltips: {
+      screenshotMissing: '❌ ${type} - ${time} [画像欠損]',
+      screenshotTampered: '⚠️ ${type} - ${time} [改ざんの可能性]',
+      screenshotVerified: '📷 ${type} - ${time} [検証済み]',
+      humanAttestation: '⭐ 人間検証 (Turnstile) - ${time}',
+      externalInput: '⚠️ 外部ペースト/ドロップ',
+      internalPaste: '✅ 内部ペースト（許可） - ${time}',
+      termsAccepted: '📜 利用規約同意 - ${time}',
+      preExportAttestation: '🔐 エクスポート前検証 (Turnstile) - ${time}',
+      editorInitialized: '🚀 エディタ初期化 - ${time}',
+      networkStatusChange: '🌐 ネットワーク状態変更 - ${time}',
+      codeExecution: '▶️ コード実行 - ${time}',
+      terminalInput: '💻 ターミナル入力 - ${time}',
+      screenShareStart: '🎬 画面共有開始 - ${time}',
+      screenShareStop: '🛑 画面共有終了 - ${time}',
+      templateInjection: '📝 テンプレート挿入 - ${time}',
+      windowResize: '📐 ウィンドウリサイズ - ${time}',
+      contentSnapshot: '📋 コンテンツスナップショット - ${time}',
+    },
     categories: {
       content: 'コンテンツ',
       cursor: 'カーソル',
@@ -272,6 +351,40 @@ export const ja: VerifyTranslationKeys = {
 
   trust: {
     screenShareOptOut: '画面共有なしモードで記録されました',
+    summaryVerified: '検証成功',
+    summaryPartial: '警告あり（${count}件）',
+    summaryFailed: '検証失敗（${count}件のエラー）',
+    issueMetadataInvalid: 'メタデータ検証失敗',
+    issueChainInvalid: 'ハッシュチェーン検証失敗',
+    issueScreenshotsTampered: '${count}枚に改竄の可能性',
+    issueScreenshotsMissing: '${count}枚が欠損',
+    issueAttestationBoth: '人間証明の検証に失敗',
+    issueAttestationCreate: '作成時の人間証明が無効',
+    issueAttestationExport: 'エクスポート時の人間証明が無効',
+    issueSourceMismatch:
+      '${filename}: ソースファイルと証明内容が異なります (+${additions}/-${deletions}行)',
+    issueAnchoringInvalid: '署名チェックポイントが無効です',
+    issueAnchoringMissing: '時刻アンカー（署名チェックポイント）がありません',
+    issueAnchoringPostHoc:
+      'post-hoc 一括署名の疑いがあります（サーバ時刻が申告時間より極端に短い）',
+    issueAnchoringSparse:
+      'アンカー密度が疎です（署名チェックポイントが申告セッションに対し少ない/遅い）',
+    issueRootNotAnchored:
+      'チェーン根がサーバアンカーされていません（開始時刻が未固定・オフライン捏造の余地）',
+    issueNotPureTyping: 'ピュアタイピングではありません（ペースト/バルク挿入あり）',
+    issueExamBindingFailed: '問題束縛（署名/内容ハッシュ）の検証に失敗しました',
+    issueExamUnverified: '問題パッケージ未読込のため真正性は未確認です',
+    components: {
+      metadata: 'メタデータ',
+      chain: 'ハッシュチェーン',
+      posw: 'PoSW',
+      attestation: '人間証明',
+      screenshots: 'スクリーンショット',
+      source: 'ソースファイル',
+      anchoring: '時刻アンカー',
+      exam: '試験束縛',
+      typing: 'タイピング',
+    },
   },
 
   process: {
@@ -421,6 +534,13 @@ export const ja: VerifyTranslationKeys = {
     browserNotSupportedDesc:
       '代わりにファイル選択またはドラッグ＆ドロップをご利用ください',
     examInvalidPackage: '問題パッケージ (.tcexam) が不正です',
+    jsonParseError: 'JSONパースエラー: ${filename}',
+    fileLoadFailed: 'ファイル読み込みに失敗しました: ${message}',
+    zipEmpty: 'ZIPにファイルがありません。',
+    zipLoadFailed: 'ZIPファイルの読み込みに失敗しました: ${message}',
+    unsupportedFormat:
+      'サポートされていないフォーマット: メタデータがありません（v3.0.0以降が必要）',
+    noEvents: '証明データにイベントがありません',
   },
 
   messages: {

--- a/packages/verify/src/i18n/types.ts
+++ b/packages/verify/src/i18n/types.ts
@@ -9,6 +9,7 @@ export interface VerifyTranslationKeys {
   common: {
     cancel: string;
     close: string;
+    delete: string;
     ready: string;
     verifying: string;
     files: string;
@@ -38,6 +39,7 @@ export interface VerifyTranslationKeys {
   activityBar: {
     menu: string;
     openFile: string;
+    openFolder: string;
     explorer: string;
     settings: string;
     themeToggle: string;
@@ -51,6 +53,9 @@ export interface VerifyTranslationKeys {
     addFile: string;
     addFolder: string;
     emptyMessage: string;
+    removeFile: string;
+    removeFolder: string;
+    removeConfirm: string;
   };
 
   // Welcome panel
@@ -74,11 +79,33 @@ export interface VerifyTranslationKeys {
     samplingDesc: string;
     completeStep: string;
     completeDesc: string;
+    statusRunning: string;
+    statusDone: string;
+    statusError: string;
+    statusSkipped: string;
+    statusFallback: string;
+    statusNoCheckpoints: string;
+    chainDetail: string;
+    samplingDetail: string;
+    samplingDetailWithTotal: string;
   };
 
   // Result panels
   result: {
     statusVerifying: string;
+    statusSuccess: string;
+    statusWarning: string;
+    statusFailed: string;
+    typingPure: string;
+    typingExternal: string;
+    timesCount: string;
+    externalInputYes: string;
+    externalInputNo: string;
+    eventsUnit: string;
+    screenshotsMissing: string;
+    screenshotsMissingAndTampered: string;
+    imageLoadFailed: string;
+    sourceMismatchBanner: string;
     typing: string;
     pasteCount: string;
     internalPasteCount: string;
@@ -229,9 +256,30 @@ export interface VerifyTranslationKeys {
     valid: string;
     invalid: string;
     none: string;
+    validCount: string;
     verifiedLegacy: string;
     exportTimeAuth: string;
     noAttestation: string;
+  };
+
+  // Screenshot capture type labels (lightbox / overlay / chart tooltips)
+  screenshot: {
+    typePeriodic: string;
+    typeFocusLost: string;
+    typeManual: string;
+  };
+
+  // Screenshot lightbox
+  lightbox: {
+    close: string;
+    prev: string;
+    next: string;
+    type: string;
+    time: string;
+    resolution: string;
+    hashVerification: string;
+    verified: string;
+    unverified: string;
   };
 
   // Status bar
@@ -250,6 +298,38 @@ export interface VerifyTranslationKeys {
     flight: string;
     mouse: string;
     eventFilter: string;
+    axisTime: string;
+    secondsShort: string;
+    datasets: {
+      typingSpeed: string;
+      internalPaste: string;
+      periodicCapture: string;
+      focusLostCapture: string;
+      manualCapture: string;
+      humanAttestation: string;
+      preExportAttestation: string;
+      networkStatusChange: string;
+      contentSnapshot: string;
+    };
+    tooltips: {
+      screenshotMissing: string;
+      screenshotTampered: string;
+      screenshotVerified: string;
+      humanAttestation: string;
+      externalInput: string;
+      internalPaste: string;
+      termsAccepted: string;
+      preExportAttestation: string;
+      editorInitialized: string;
+      networkStatusChange: string;
+      codeExecution: string;
+      terminalInput: string;
+      screenShareStart: string;
+      screenShareStop: string;
+      templateInjection: string;
+      windowResize: string;
+      contentSnapshot: string;
+    };
     categories: {
       content: string;
       cursor: string;
@@ -292,6 +372,36 @@ export interface VerifyTranslationKeys {
   // Trust calculation
   trust: {
     screenShareOptOut: string;
+    summaryVerified: string;
+    summaryPartial: string;
+    summaryFailed: string;
+    issueMetadataInvalid: string;
+    issueChainInvalid: string;
+    issueScreenshotsTampered: string;
+    issueScreenshotsMissing: string;
+    issueAttestationBoth: string;
+    issueAttestationCreate: string;
+    issueAttestationExport: string;
+    issueSourceMismatch: string;
+    issueAnchoringInvalid: string;
+    issueAnchoringMissing: string;
+    issueAnchoringPostHoc: string;
+    issueAnchoringSparse: string;
+    issueRootNotAnchored: string;
+    issueNotPureTyping: string;
+    issueExamBindingFailed: string;
+    issueExamUnverified: string;
+    components: {
+      metadata: string;
+      chain: string;
+      posw: string;
+      attestation: string;
+      screenshots: string;
+      source: string;
+      anchoring: string;
+      exam: string;
+      typing: string;
+    };
   };
 
   // Typing pattern analysis
@@ -445,6 +555,12 @@ export interface VerifyTranslationKeys {
     browserNotSupported: string;
     browserNotSupportedDesc: string;
     examInvalidPackage: string;
+    jsonParseError: string;
+    fileLoadFailed: string;
+    zipEmpty: string;
+    zipLoadFailed: string;
+    unsupportedFormat: string;
+    noEvents: string;
   };
 
   // Messages

--- a/packages/verify/src/services/FileProcessor.ts
+++ b/packages/verify/src/services/FileProcessor.ts
@@ -10,6 +10,7 @@ import { ScreenshotService } from './ScreenshotService.js';
 import { JsonFileProcessor } from './JsonFileProcessor.js';
 import { ZipFileProcessor } from './ZipFileProcessor.js';
 import { getFileType, isProofFilename, getLanguageFromExtension } from './fileUtils.js';
+import { t } from '../i18n/index.js';
 
 // 再エクスポート（利用側の互換性のため）
 export { JsonFileProcessor } from './JsonFileProcessor.js';
@@ -179,7 +180,7 @@ export class FileProcessor {
         success: false,
         mode: 'single',
         files: [],
-        error: `ファイル読み込みに失敗しました: ${errorMessage}`,
+        error: t('errors.fileLoadFailed', { message: errorMessage }),
       };
     }
   }

--- a/packages/verify/src/services/JsonFileProcessor.ts
+++ b/packages/verify/src/services/JsonFileProcessor.ts
@@ -7,6 +7,7 @@
 import type { ProofFile } from '../types.js';
 import type { ParsedFileData, FileProcessResult, FileProcessCallbacks } from './FileProcessor.js';
 import { getLanguageFromExtension } from './fileUtils.js';
+import { t } from '../i18n/index.js';
 
 /**
  * JSON ファイル処理クラス
@@ -94,7 +95,7 @@ export class JsonFileProcessor {
         success: false,
         mode: forceMultiMode ? 'multi' : 'single',
         files: [],
-        error: `ファイル読み込みに失敗しました: ${errorMessage}`,
+        error: t('errors.fileLoadFailed', { message: errorMessage }),
       };
     }
   }

--- a/packages/verify/src/services/TrustCalculator.ts
+++ b/packages/verify/src/services/TrustCalculator.ts
@@ -1,6 +1,10 @@
 /**
  * TrustCalculator - 検証結果から信頼度を計算するサービス
+ *
+ * 注意: メインスレッド専用 (TabController から呼ばれる)。
+ * t() を使うため Web Worker 内では使用しないこと。
  */
+import { t } from '../i18n/index';
 import type {
   TrustLevel,
   TrustIssue,
@@ -45,7 +49,7 @@ export class TrustCalculator {
       issues.push({
         component: 'metadata',
         severity: 'error',
-        message: 'メタデータ検証失敗',
+        message: t('trust.issueMetadataInvalid'),
       });
     }
 
@@ -54,7 +58,7 @@ export class TrustCalculator {
       issues.push({
         component: 'chain',
         severity: 'error',
-        message: verificationResult.message || 'ハッシュチェーン検証失敗',
+        message: verificationResult.message || t('trust.issueChainInvalid'),
       });
     }
 
@@ -63,14 +67,14 @@ export class TrustCalculator {
       issues.push({
         component: 'screenshots',
         severity: 'error',
-        message: `${screenshots.tampered}枚に改竄の可能性`,
+        message: t('trust.issueScreenshotsTampered', { count: screenshots.tampered }),
       });
     }
     if (screenshots.missing > 0) {
       issues.push({
         component: 'screenshots',
         severity: 'warning',
-        message: `${screenshots.missing}枚が欠損`,
+        message: t('trust.issueScreenshotsMissing', { count: screenshots.missing }),
       });
     }
 
@@ -83,19 +87,19 @@ export class TrustCalculator {
         issues.push({
           component: 'attestation',
           severity: 'warning',
-          message: '人間証明の検証に失敗',
+          message: t('trust.issueAttestationBoth'),
         });
       } else if (createFailed) {
         issues.push({
           component: 'attestation',
           severity: 'warning',
-          message: '作成時の人間証明が無効',
+          message: t('trust.issueAttestationCreate'),
         });
       } else if (exportFailed) {
         issues.push({
           component: 'attestation',
           severity: 'warning',
-          message: 'エクスポート時の人間証明が無効',
+          message: t('trust.issueAttestationExport'),
         });
       }
     }
@@ -106,7 +110,11 @@ export class TrustCalculator {
         issues.push({
           component: 'source',
           severity: 'warning',
-          message: `${mismatch.filename}: ソースファイルと証明内容が異なります (+${mismatch.additions}/-${mismatch.deletions}行)`,
+          message: t('trust.issueSourceMismatch', {
+            filename: mismatch.filename,
+            additions: mismatch.additions,
+            deletions: mismatch.deletions,
+          }),
         });
       }
     }
@@ -116,7 +124,7 @@ export class TrustCalculator {
       issues.push({
         component: 'screenshots',
         severity: 'warning',
-        message: '画面共有なしモードで記録されました',
+        message: t('trust.screenShareOptOut'),
       });
     }
 
@@ -130,13 +138,13 @@ export class TrustCalculator {
         issues.push({
           component: 'anchoring',
           severity: 'error',
-          message: '署名チェックポイントが無効です',
+          message: t('trust.issueAnchoringInvalid'),
         });
       } else if (!verificationResult.signedCheckpointAnchored) {
         issues.push({
           component: 'anchoring',
           severity: 'warning',
-          message: '時刻アンカー（署名チェックポイント）がありません',
+          message: t('trust.issueAnchoringMissing'),
         });
       } else {
         // anchored かつ valid。補助的な疑い指標（post-hoc / 密度）は併存しうるので個別に積む。
@@ -144,7 +152,7 @@ export class TrustCalculator {
           issues.push({
             component: 'anchoring',
             severity: 'warning',
-            message: 'post-hoc 一括署名の疑いがあります（サーバ時刻が申告時間より極端に短い）',
+            message: t('trust.issueAnchoringPostHoc'),
           });
         }
         // ADR-0016: 署名 cp が主張イベント数/時間に対して疎（末尾 1 個で長い鎖をアンカー等）。
@@ -152,7 +160,7 @@ export class TrustCalculator {
           issues.push({
             component: 'anchoring',
             severity: 'warning',
-            message: 'アンカー密度が疎です（署名チェックポイントが申告セッションに対し少ない/遅い）',
+            message: t('trust.issueAnchoringSparse'),
           });
         }
       }
@@ -169,7 +177,7 @@ export class TrustCalculator {
       issues.push({
         component: 'anchoring',
         severity: 'warning',
-        message: 'チェーン根がサーバアンカーされていません（開始時刻が未固定・オフライン捏造の余地）',
+        message: t('trust.issueRootNotAnchored'),
       });
     }
 
@@ -178,7 +186,7 @@ export class TrustCalculator {
       issues.push({
         component: 'typing',
         severity: 'warning',
-        message: 'ピュアタイピングではありません（ペースト/バルク挿入あり）',
+        message: t('trust.issueNotPureTyping'),
       });
     }
 
@@ -191,13 +199,13 @@ export class TrustCalculator {
         issues.push({
           component: 'exam',
           severity: 'error',
-          message: '問題束縛（署名/内容ハッシュ）の検証に失敗しました',
+          message: t('trust.issueExamBindingFailed'),
         });
       } else if (!verificationResult.exam.packageProvided) {
         issues.push({
           component: 'exam',
           severity: 'warning',
-          message: '問題パッケージ未読込のため真正性は未確認です',
+          message: t('trust.issueExamUnverified'),
         });
       }
     }
@@ -227,14 +235,14 @@ export class TrustCalculator {
   private static generateSummary(level: TrustLevel, issues: TrustIssue[]): string {
     switch (level) {
       case 'verified':
-        return '検証成功';
+        return t('trust.summaryVerified');
       case 'partial': {
         const warningCount = issues.filter((i) => i.severity === 'warning').length;
-        return `警告あり（${warningCount}件）`;
+        return t('trust.summaryPartial', { count: warningCount });
       }
       case 'failed': {
         const errorCount = issues.filter((i) => i.severity === 'error').length;
-        return `検証失敗（${errorCount}件のエラー）`;
+        return t('trust.summaryFailed', { count: errorCount });
       }
     }
   }

--- a/packages/verify/src/services/ZipFileProcessor.ts
+++ b/packages/verify/src/services/ZipFileProcessor.ts
@@ -10,6 +10,7 @@ import type { ProofFile, ScreenshotManifest, VerifyScreenshot } from '../types.j
 import type { ParsedFileData, FileProcessResult, FileProcessCallbacks } from './FileProcessor.js';
 import { ScreenshotService } from './ScreenshotService.js';
 import { isImageFile, isBinaryFile, getLanguageFromExtension } from './fileUtils.js';
+import { t } from '../i18n/index.js';
 
 /**
  * ZIP ファイル処理クラス
@@ -61,7 +62,7 @@ export class ZipFileProcessor {
           success: false,
           mode: 'multi',
           files: [],
-          error: 'ZIPにファイルがありません。',
+          error: t('errors.zipEmpty'),
         };
       }
 
@@ -85,7 +86,7 @@ export class ZipFileProcessor {
         success: false,
         mode: 'multi',
         files: [],
-        error: `ZIPファイルの読み込みに失敗しました: ${errorMessage}`,
+        error: t('errors.zipLoadFailed', { message: errorMessage }),
       };
     }
   }

--- a/packages/verify/src/ui/ActivityBar.ts
+++ b/packages/verify/src/ui/ActivityBar.ts
@@ -3,7 +3,7 @@
  */
 
 import { FileSystemAccessService } from '../services/FileSystemAccessService.js';
-import { getI18n } from '../i18n/index.js';
+import { getI18n, t } from '../i18n/index.js';
 import type { VerificationMode } from '../types';
 
 const VERIFY_MODE_CYCLE: VerificationMode[] = ['fast', 'audit', 'full'];
@@ -91,7 +91,7 @@ export class ActivityBar {
     openFolderBtn.className = 'dropdown-item';
     openFolderBtn.innerHTML = `
       <i class="fas fa-folder-tree"></i>
-      <span>フォルダを開く</span>
+      <span>${t('activityBar.openFolder')}</span>
     `;
 
     // open-file-btn の後に挿入

--- a/packages/verify/src/ui/ResultPanel.ts
+++ b/packages/verify/src/ui/ResultPanel.ts
@@ -454,7 +454,7 @@ export class ResultPanel {
     banner.id = 'diff-warning-banner';
     banner.innerHTML = `
       <i class="fas fa-exclamation-triangle"></i>
-      <span>ソースファイルと証明内容が一致しません</span>
+      <span>${escapeHtml(t('result.sourceMismatchBanner'))}</span>
       <span class="diff-stats">
         <span class="diff-additions">+${stats.additions}</span>
         <span class="diff-deletions">-${stats.deletions}</span>
@@ -522,7 +522,7 @@ export class ResultPanel {
           </div>
         `;
       } else {
-        codeEl.innerHTML = '<p style="color: var(--text-tertiary);">画像を読み込めませんでした</p>';
+        codeEl.innerHTML = `<p style="color: var(--text-tertiary);">${escapeHtml(t('result.imageLoadFailed'))}</p>`;
       }
       codeEl.className = '';
     }
@@ -545,7 +545,11 @@ export class ResultPanel {
 
       this.statusIcon.className = `result-status-icon ${statusClass}`;
       this.statusIcon.innerHTML = `<i class="fas fa-${isSuccess ? 'check-circle' : isWarning ? 'exclamation-triangle' : 'times-circle'}"></i>`;
-      this.statusTitle.textContent = isSuccess ? '検証成功' : isWarning ? '警告あり' : '検証失敗';
+      this.statusTitle.textContent = isSuccess
+        ? t('result.statusSuccess')
+        : isWarning
+          ? t('result.statusWarning')
+          : t('result.statusFailed');
     }
     this.statusFilename.textContent = filename;
 
@@ -554,21 +558,27 @@ export class ResultPanel {
       this.typingIcon,
       this.typingBadge,
       result.pureTyping,
-      result.pureTyping ? '純粋' : '外部入力あり'
+      result.pureTyping ? t('result.typingPure') : t('result.typingExternal')
     );
-    this.pasteCount.textContent = `${result.pasteCount || 0}回`;
-    this.internalPasteCount.textContent = `${result.internalPasteCount || 0}回`;
-    this.externalInput.textContent = result.pureTyping ? 'なし' : 'あり';
+    this.pasteCount.textContent = t('result.timesCount', { count: result.pasteCount || 0 });
+    this.internalPasteCount.textContent = t('result.timesCount', {
+      count: result.internalPasteCount || 0,
+    });
+    this.externalInput.textContent = result.pureTyping
+      ? t('result.externalInputNo')
+      : t('result.externalInputYes');
 
     // Chain card
     this.renderCard(
       this.chainIcon,
       this.chainBadge,
       result.chainValid,
-      result.chainValid ? '有効' : '無効'
+      result.chainValid ? t('chain.valid') : t('chain.invalid')
     );
     this.chainMethod.textContent = result.verificationMethod || 'standard';
-    this.chainEvents.textContent = `${eventCount.toLocaleString()}件`;
+    this.chainEvents.textContent = t('result.eventsUnit', {
+      count: eventCount.toLocaleString(),
+    });
 
     // Chain error details (show only when verification fails)
     this.renderChainErrorDetails(result.chainErrorDetails);
@@ -627,12 +637,14 @@ export class ResultPanel {
         this.attestationIcon,
         this.attestationBadge,
         validCount === attestations.length,
-        `${validCount}/${attestations.length} 有効`
+        t('attestation.validCount', { valid: validCount, total: attestations.length })
       );
 
       if (createAttestation) {
         this.attestationCreateRow.style.display = 'flex';
-        this.attestationCreate.textContent = createAttestation.valid ? '✓ 有効' : '✗ 無効';
+        this.attestationCreate.textContent = createAttestation.valid
+          ? `✓ ${t('attestation.valid')}`
+          : `✗ ${t('attestation.invalid')}`;
         this.attestationCreate.className = `result-row-value ${createAttestation.valid ? 'text-success' : 'text-danger'}`;
       } else {
         this.attestationCreateRow.style.display = 'none';
@@ -640,7 +652,9 @@ export class ResultPanel {
 
       if (exportAttestation) {
         this.attestationExportRow.style.display = 'flex';
-        this.attestationExport.textContent = exportAttestation.valid ? '✓ 有効' : '✗ 無効';
+        this.attestationExport.textContent = exportAttestation.valid
+          ? `✓ ${t('attestation.valid')}`
+          : `✗ ${t('attestation.invalid')}`;
         this.attestationExport.className = `result-row-value ${exportAttestation.valid ? 'text-success' : 'text-danger'}`;
       } else {
         this.attestationExportRow.style.display = 'none';
@@ -1131,16 +1145,30 @@ export class ResultPanel {
 
     if (missingCount === 0 && tamperedCount === 0) {
       // 全て検証済み
-      this.screenshotVerification.innerHTML = `<span class="success">✓ ${screenshots.verified}/${screenshots.total}枚検証済み</span>`;
+      this.screenshotVerification.innerHTML = `<span class="success">${escapeHtml(
+        t('result.screenshotsAllVerified', {
+          verified: screenshots.verified,
+          total: screenshots.total,
+        })
+      )}</span>`;
     } else if (missingCount > 0 && tamperedCount === 0) {
       // 欠損ファイルあり（改ざんなし）
-      this.screenshotVerification.innerHTML = `<span class="error">✗ ${missingCount}/${screenshots.total}枚が欠損</span>`;
+      this.screenshotVerification.innerHTML = `<span class="error">${escapeHtml(
+        t('result.screenshotsMissing', { missing: missingCount, total: screenshots.total })
+      )}</span>`;
     } else if (missingCount === 0 && tamperedCount > 0) {
       // 改ざんの可能性あり
-      this.screenshotVerification.innerHTML = `<span class="warning">⚠ ${tamperedCount}/${screenshots.total}枚が改ざんの可能性</span>`;
+      this.screenshotVerification.innerHTML = `<span class="warning">${escapeHtml(
+        t('result.screenshotsSomeInvalid', { invalid: tamperedCount, total: screenshots.total })
+      )}</span>`;
     } else {
       // 欠損と改ざん両方
-      this.screenshotVerification.innerHTML = `<span class="error">✗ ${missingCount}枚欠損, ${tamperedCount}枚改ざんの可能性</span>`;
+      this.screenshotVerification.innerHTML = `<span class="error">${escapeHtml(
+        t('result.screenshotsMissingAndTampered', {
+          missing: missingCount,
+          tampered: tamperedCount,
+        })
+      )}</span>`;
     }
   }
 
@@ -1161,7 +1189,7 @@ export class ResultPanel {
     // Reset status
     this.statusIcon.className = 'result-status-icon';
     this.statusIcon.innerHTML = '<i class="fas fa-spinner fa-spin"></i>';
-    this.statusTitle.textContent = '検証中...';
+    this.statusTitle.textContent = t('result.statusVerifying');
     this.statusFilename.textContent = '';
 
     // Reset stats
@@ -1291,10 +1319,10 @@ export class ResultPanel {
     } else if (statusEl) {
       const defaultStatusText: Record<VerificationStepStatus, string> = {
         pending: '',
-        running: '処理中...',
-        success: '完了',
-        error: 'エラー',
-        skipped: 'スキップ',
+        running: t('progress.statusRunning'),
+        success: t('progress.statusDone'),
+        error: t('progress.statusError'),
+        skipped: t('progress.statusSkipped'),
       };
       statusEl.textContent = defaultStatusText[status];
     }
@@ -1410,7 +1438,7 @@ export class ResultPanel {
   finishProgress(): void {
     this.stopProgressTimer();
     this.updateOverallProgress(100);
-    this.updateStepStatus('complete', 'success', '完了');
+    this.updateStepStatus('complete', 'success', t('progress.statusDone'));
   }
 
   /**
@@ -1418,7 +1446,7 @@ export class ResultPanel {
    */
   errorProgress(step: VerificationStepType, errorMessage?: string): void {
     this.stopProgressTimer();
-    this.updateStepStatus(step, 'error', 'エラー');
+    this.updateStepStatus(step, 'error', t('progress.statusError'));
     if (errorMessage) {
       this.showProgressDetail(errorMessage);
     }
@@ -1505,15 +1533,15 @@ export class ResultPanel {
    */
   private getComponentLabel(component: string): string {
     const labels: Record<string, string> = {
-      metadata: 'メタデータ',
-      chain: 'ハッシュチェーン',
-      posw: 'PoSW',
-      attestation: '人間証明',
-      screenshots: 'スクリーンショット',
-      source: 'ソースファイル',
-      anchoring: '時刻アンカー',
-      exam: '試験束縛',
-      typing: 'タイピング',
+      metadata: t('trust.components.metadata'),
+      chain: t('trust.components.chain'),
+      posw: t('trust.components.posw'),
+      attestation: t('trust.components.attestation'),
+      screenshots: t('trust.components.screenshots'),
+      source: t('trust.components.source'),
+      anchoring: t('trust.components.anchoring'),
+      exam: t('trust.components.exam'),
+      typing: t('trust.components.typing'),
     };
     return labels[component] || component;
   }

--- a/packages/verify/src/ui/ScreenshotLightbox.ts
+++ b/packages/verify/src/ui/ScreenshotLightbox.ts
@@ -7,6 +7,7 @@
 
 import type { VerifyScreenshot } from '../types.js';
 import type { ScreenshotService } from '../services/ScreenshotService.js';
+import { t } from '../i18n/index.js';
 
 /** ライトボックス設定 */
 export interface LightboxOptions {
@@ -66,11 +67,11 @@ export class ScreenshotLightbox {
     overlay.className = 'lightbox-overlay';
     overlay.innerHTML = `
       <div class="lightbox-container">
-        <button class="lightbox-close" title="閉じる (Esc)">
+        <button class="lightbox-close" title="${t('lightbox.close')}">
           <i class="fas fa-times"></i>
         </button>
 
-        <button class="lightbox-nav lightbox-prev" title="前へ (←)">
+        <button class="lightbox-nav lightbox-prev" title="${t('lightbox.prev')}">
           <i class="fas fa-chevron-left"></i>
         </button>
 
@@ -81,25 +82,25 @@ export class ScreenshotLightbox {
           </div>
         </div>
 
-        <button class="lightbox-nav lightbox-next" title="次へ (→)">
+        <button class="lightbox-nav lightbox-next" title="${t('lightbox.next')}">
           <i class="fas fa-chevron-right"></i>
         </button>
 
         <div class="lightbox-info">
           <div class="lightbox-info-row">
-            <span class="lightbox-info-label">タイプ:</span>
+            <span class="lightbox-info-label">${t('lightbox.type')}:</span>
             <span class="lightbox-info-value" id="lb-type"></span>
           </div>
           <div class="lightbox-info-row">
-            <span class="lightbox-info-label">時刻:</span>
+            <span class="lightbox-info-label">${t('lightbox.time')}:</span>
             <span class="lightbox-info-value" id="lb-time"></span>
           </div>
           <div class="lightbox-info-row">
-            <span class="lightbox-info-label">解像度:</span>
+            <span class="lightbox-info-label">${t('lightbox.resolution')}:</span>
             <span class="lightbox-info-value" id="lb-resolution"></span>
           </div>
           <div class="lightbox-info-row">
-            <span class="lightbox-info-label">ハッシュ検証:</span>
+            <span class="lightbox-info-label">${t('lightbox.hashVerification')}:</span>
             <span class="lightbox-info-value" id="lb-verified"></span>
           </div>
           <div class="lightbox-counter">
@@ -283,9 +284,9 @@ export class ScreenshotLightbox {
 
     // 情報を更新
     const typeMap: Record<string, string> = {
-      periodic: '定期キャプチャ',
-      focusLost: 'フォーカス喪失',
-      manual: '手動',
+      periodic: t('screenshot.typePeriodic'),
+      focusLost: t('screenshot.typeFocusLost'),
+      manual: t('screenshot.typeManual'),
     };
 
     this.typeEl.textContent = typeMap[screenshot.captureType] ?? screenshot.captureType;
@@ -294,10 +295,10 @@ export class ScreenshotLightbox {
 
     // 検証状態
     if (screenshot.verified) {
-      this.verifiedEl.textContent = '✓ 検証済み';
+      this.verifiedEl.textContent = t('lightbox.verified');
       this.verifiedEl.className = 'lightbox-info-value verified';
     } else {
-      this.verifiedEl.textContent = '未検証';
+      this.verifiedEl.textContent = t('lightbox.unverified');
       this.verifiedEl.className = 'lightbox-info-value unverified';
     }
 

--- a/packages/verify/src/ui/Sidebar.ts
+++ b/packages/verify/src/ui/Sidebar.ts
@@ -2,6 +2,7 @@
  * Sidebar - File tree with verification status (VSCode-like)
  */
 import type { HierarchicalFolder } from '../types.js';
+import { t } from '../i18n/index.js';
 
 export type FileStatus = 'pending' | 'verifying' | 'success' | 'warning' | 'error';
 
@@ -511,7 +512,7 @@ export class Sidebar {
     const removeBtn = document.createElement('button');
     removeBtn.className = 'folder-remove';
     removeBtn.innerHTML = '<i class="fas fa-times"></i>';
-    removeBtn.title = 'フォルダを削除';
+    removeBtn.title = t('sidebar.removeFolder');
 
     item.appendChild(chevron);
     item.appendChild(icon);
@@ -565,7 +566,7 @@ export class Sidebar {
     const removeBtn = document.createElement('button');
     removeBtn.className = 'file-item-remove';
     removeBtn.innerHTML = '<i class="fas fa-times"></i>';
-    removeBtn.title = '削除';
+    removeBtn.title = t('sidebar.removeFile');
 
     item.appendChild(icon);
     item.appendChild(name);
@@ -616,18 +617,18 @@ export class Sidebar {
 
     const message = document.createElement('p');
     message.className = 'remove-confirm-message';
-    message.textContent = `「${file.filename}」をリストから削除しますか？`;
+    message.textContent = t('sidebar.removeConfirm', { filename: file.filename });
 
     const buttons = document.createElement('div');
     buttons.className = 'remove-confirm-buttons';
 
     const cancelBtn = document.createElement('button');
     cancelBtn.className = 'remove-confirm-btn cancel';
-    cancelBtn.textContent = 'キャンセル';
+    cancelBtn.textContent = t('common.cancel');
 
     const confirmBtn = document.createElement('button');
     confirmBtn.className = 'remove-confirm-btn confirm';
-    confirmBtn.textContent = '削除';
+    confirmBtn.textContent = t('common.delete');
 
     buttons.appendChild(cancelBtn);
     buttons.appendChild(confirmBtn);

--- a/packages/verify/src/ui/TabBar.ts
+++ b/packages/verify/src/ui/TabBar.ts
@@ -1,6 +1,8 @@
 /**
  * TabBar - VSCode-like tab management with drag & drop
  */
+import { t } from '../i18n/index.js';
+
 export type TabStatus = 'pending' | 'verifying' | 'success' | 'warning' | 'error';
 
 export interface Tab {
@@ -204,7 +206,7 @@ export class TabBar {
     const closeBtn = document.createElement('button');
     closeBtn.className = 'tab-close';
     closeBtn.innerHTML = '<i class="fas fa-times"></i>';
-    closeBtn.title = '閉じる';
+    closeBtn.title = t('common.close');
 
     tabEl.appendChild(icon);
     tabEl.appendChild(title);

--- a/packages/verify/src/ui/controllers/FileController.ts
+++ b/packages/verify/src/ui/controllers/FileController.ts
@@ -424,7 +424,7 @@ export class FileController {
       this.deps.onStatusBarUpdate?.();
     } catch (error) {
       console.error('Error parsing JSON:', error);
-      this.deps.statusBar.setError(`JSONパースエラー: ${filename}`);
+      this.deps.statusBar.setError(t('errors.jsonParseError', { filename }));
     }
   }
 }

--- a/packages/verify/src/ui/controllers/TabController.ts
+++ b/packages/verify/src/ui/controllers/TabController.ts
@@ -17,6 +17,7 @@ import type { VerifyTabState, ProgressDetails, VerifyScreenshot, ScreenshotVerif
 import { buildResultData, calculateChartStats } from '../../services/ResultDataService';
 import { TrustCalculator } from '../../services/TrustCalculator';
 import { deriveAssurance, summarizeAnalysisForAssurance, summarizeProcess, type AssuranceResult } from '@typedcode/shared';
+import { t } from '../../i18n/index';
 
 export interface TabControllerDependencies {
   tabManager: VerifyTabManager;
@@ -194,12 +195,19 @@ export class TabController {
       this.deps.resultPanel.updateStepProgress('metadata', 100); // メタデータ完了
       // フォールバック時のみchainステップを表示
       this.deps.resultPanel.showFallbackStep();
-      this.deps.resultPanel.updateStepStatus('chain', 'running', 'フォールバック');
+      this.deps.resultPanel.updateStepStatus('chain', 'running', t('progress.statusFallback'));
       // サンプリングはスキップ（チェックポイントなしのため）
-      this.deps.resultPanel.updateStepStatus('sampling', 'skipped', 'チェックポイントなし');
+      this.deps.resultPanel.updateStepStatus(
+        'sampling',
+        'skipped',
+        t('progress.statusNoCheckpoints')
+      );
 
       const chainProgress = (current / total) * 100;
-      const detail = `${current.toLocaleString()} / ${total.toLocaleString()} イベント`;
+      const detail = t('progress.chainDetail', {
+        current: current.toLocaleString(),
+        total: total.toLocaleString(),
+      });
       this.deps.resultPanel.updateStepProgress('chain', chainProgress, detail);
     } else if (phase === 'segment' || phase === 'checkpoint') {
       // サンプリング検証（チェックポイントあり）
@@ -210,8 +218,16 @@ export class TabController {
 
       const samplingProgress = (current / total) * 100;
       // 検証済み / 対象イベント数 (全イベント数) の形式で表示
-      const totalEventsStr = totalEvents ? ` (全${totalEvents.toLocaleString()}イベント)` : '';
-      const detail = `${current.toLocaleString()}イベント検証済み / ${total.toLocaleString()}イベント${totalEventsStr}`;
+      const detail = totalEvents
+        ? t('progress.samplingDetailWithTotal', {
+            current: current.toLocaleString(),
+            total: total.toLocaleString(),
+            totalEvents: totalEvents.toLocaleString(),
+          })
+        : t('progress.samplingDetail', {
+            current: current.toLocaleString(),
+            total: total.toLocaleString(),
+          });
       this.deps.resultPanel.updateStepProgress('sampling', samplingProgress, detail);
     } else if (phase === 'complete') {
       // 全完了

--- a/packages/verify/src/ui/controllers/VerificationController.ts
+++ b/packages/verify/src/ui/controllers/VerificationController.ts
@@ -9,6 +9,7 @@ import type { StatusBarUI } from '../StatusBarUI';
 import type { ResultPanel } from '../ResultPanel';
 import type { TabController } from './TabController';
 import type { ProgressDetails, VerificationResultData } from '../../types';
+import { t } from '../../i18n/index';
 
 export interface VerificationControllerDependencies {
   tabManager: VerifyTabManager;
@@ -146,7 +147,11 @@ export class VerificationController {
   /**
    * 検証エラーを処理
    */
-  handleError(id: string, error: string): void {
+  handleError(id: string, rawError: string): void {
+    // Worker はロケール設定 (localStorage) にアクセスできないため翻訳キーを
+    // そのまま送ってくることがある。ここでメインスレッドのロケールで解決する
+    // (t() は未知のキーをそのまま返すので通常のエラーメッセージには無害)。
+    const error = rawError.startsWith('errors.') ? t(rawError) : rawError;
     this.deps.uiState.incrementCompleted();
     this.deps.tabManager.updateTab(id, { status: 'error', error });
     this.deps.sidebar.updateFileStatus(id, 'error');

--- a/packages/verify/src/workers/verificationWorker.ts
+++ b/packages/verify/src/workers/verificationWorker.ts
@@ -229,7 +229,9 @@ async function verify(request: VerifyRequest): Promise<void> {
       isPureTyping = eventMetadataVerification.isPureTyping;
     } else {
       // メタデータがない場合はサポート対象外（v3.0.0以降が必要）
-      sendError(id, 'サポートされていないフォーマット: メタデータがありません（v3.0.0以降が必要）');
+      // Worker 内ではユーザーのロケール設定 (localStorage) を参照できないため、
+      // 翻訳キーをそのまま送り、メインスレッド側 (VerificationController) で t() 解決する
+      sendError(id, 'errors.unsupportedFormat');
       return;
     }
 
@@ -237,7 +239,7 @@ async function verify(request: VerifyRequest): Promise<void> {
 
     // 2. ハッシュ鎖の検証
     if (!proofData.proof?.events) {
-      sendError(id, 'No events found in proof data');
+      sendError(id, 'errors.noEvents');
       return;
     }
 


### PR DESCRIPTION
## 概要

Issue #150: ja/en の翻訳キー自体は型で完全同期していたが、信頼バッジ (TrustCalculator の全 issue メッセージ) をはじめ UI の主要表示に日本語直書きが残っており、en 利用者には信頼バッジ・issue 一覧・チャートラベル等が日本語で表示されていた。

## 変更

- **i18n 三点同期**: leaf キー **337 → 439 (+102)**。新 namespace: `screenshot` (キャプチャ種別) / `lightbox` / `charts.datasets`・`charts.tooltips` / `trust.issue*`・`trust.components` / `progress.*` / `errors.*`。型 (`VerifyTranslationKeys`) で ja/en の同期を強制
- **TrustCalculator**: 全 issue メッセージ + サマリを t() 化 (メインスレッド専用の旨をヘッダに明記)。Issue 起票後に develop に増えた anchoring/root/pureTyping/exam 系 8 件も対応
- **ResultPanel / ScreenshotLightbox / TabController / FileController / Sidebar ほか**: fallback status・typing/attestation カード・スクショ検証行・進捗文言・diff バナー・削除確認等を t() 化
- **verificationWorker**: Worker 内はロケール設定 (localStorage) に触れないため**翻訳キーを送信し、メインスレッド側 (`VerificationController.handleError`) で t() 解決**する方式
- **IntegratedChart**: dataset ラベルと tooltip を t() 化。ラベル文字列比較だった tooltip 分岐を対応表化し、比較文字列の不一致で dead になっていた 2 分岐 (エクスポート認証・スナップショット) も修復

## 対応外 (意図的)

- `IntegratedChart.ts` の旧ラベル後方互換の比較文字列 1 件 (表示されない)
- コメント / JSDoc 内の日本語
- `AnalysisReport` 由来の文言 (shared 側生成でパッケージ境界外)

## テスト

- typecheck (tsc --noEmit): green (439 キーの ja/en 同期を型で保証)
- `npm run test:run -w @typedcode/verify`: 14 passed
- `npm run build:verify`: 成功
- 全 workspace テスト green

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)