### PR TITLE
test(editor): firstSeenAt テストの pendingCount 同期 assert を waitFor 化し CI flake を解消

### DIFF
--- a/packages/editor/src/services/__tests__/signedCheckpointFirstSeenAt.test.ts
+++ b/packages/editor/src/services/__tests__/signedCheckpointFirstSeenAt.test.ts
@@ -113,7 +113,9 @@ describe('SignedCheckpointService firstSeenAt consistency (#151)', () => {
 
     // 不一致 envelope (t1) は attach されず、最終的に t0 の envelope だけが載る
     expect(attached.map((a) => a.firstSeenAt)).toEqual([t0, t0]);
-    expect(service.pendingCount()).toBe(0);
+    // attach 後、実装は動的 import を await してから queue を削る。attached 起点の
+    // waitFor 直後に同期で見ると 1 が返る瞬間がある (CI で顕在化した flake) ため待つ。
+    await vi.waitFor(() => expect(service.pendingCount()).toBe(0), { timeout: 2000 });
     service.dispose();
   });
 
@@ -178,7 +180,8 @@ describe('SignedCheckpointService session token gate (ADR-0027 / #136)', () => {
     token = makeToken(); // exam の best-effort 取得が後から成功したケース
     service.retryPendingSignatures();
     await vi.waitFor(() => expect(attached).toHaveLength(1), { timeout: 2000 });
-    expect(service.pendingCount()).toBe(0);
+    // attach → queue 削除の間に動的 import の await が挟まるため同期 assert しない (flake 対策)
+    await vi.waitFor(() => expect(service.pendingCount()).toBe(0), { timeout: 2000 });
     service.dispose();
   });
 


### PR DESCRIPTION
## 概要

PR #185 マージ後の develop push CI (run 28630726223) で editor の `signedCheckpointFirstSeenAt.test.ts` が fail した flake の修正。

## 原因

`SignedCheckpointService.signOne` は `attachSignature` (テストが `attached` に記録する箇所) を呼んだ**後**に `hashSignedCheckpointPayload` の動的 import を await してから `queue.delete` する。テストは `vi.waitFor(attached.length === N)` の直後に `pendingCount() === 0` を**同期**で assert していたため、その隙間に評価されると 1 が返る。PR #179 由来の既存レースで、CI の遅い環境で顕在化した (同一ツリーの PR #185 CI では pass)。

## 修正

該当 2 箇所の `pendingCount` assert を `vi.waitFor` 化 (プロダクションコード変更なし)。

## 備考

develop の失敗 run は `--failed` rerun 済み (flake のため rerun で green になり deploy-staging が通る見込み)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)