### PR TITLE
fix(doctor): CLOUDFLARE_API_TOKEN のチェックを Environment secret 側に移す

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -376,10 +376,10 @@ npm run doctor -- --maintainer
 検査内容 (M1-M4 で設定した項目を全網羅):
 
 - repo 設定 (`delete_branch_on_merge=true`)
-- repo level secrets (`CLOUDFLARE_API_TOKEN`, `ACCOUNT_ID`, `PROJECT_NAME`)
+- repo level secrets (`ACCOUNT_ID`, `PROJECT_NAME`。`CLOUDFLARE_API_TOKEN` が repo level にあると warn)
 - Environments (`staging`, `production`) の存在
 - production の Required reviewers
-- 各 environment の secrets (`VITE_API_URL`, `VITE_TURNSTILE_SITE_KEY`)
+- 各 environment の secrets (`CLOUDFLARE_API_TOKEN`, `VITE_API_URL`, `VITE_TURNSTILE_SITE_KEY`)
 - `wrangler.staging.toml` / `wrangler.production.toml` の KV ID
 - staging / production Worker のデプロイ状態
 - 各 Worker の secrets (`TURNSTILE_SECRET_KEY`, `ATTESTATION_SECRET_KEY`, `CHECKPOINT_SIGNING_KEY_ID`, `CHECKPOINT_SIGNING_KEY_JWK`)

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -445,8 +445,10 @@ function checkCloudflareResources() {
 // メンテナ専用セクション (--maintainer フラグ時のみ)
 // ============================================================================
 
-const REQUIRED_REPO_SECRETS = ['CLOUDFLARE_API_TOKEN', 'CLOUDFLARE_ACCOUNT_ID', 'CLOUDFLARE_PROJECT_NAME'];
-const REQUIRED_ENV_SECRETS = ['VITE_API_URL', 'VITE_TURNSTILE_SITE_KEY'];
+// CLOUDFLARE_API_TOKEN は repo level ではなく Environment secret (staging/production 別) に置く
+// (docs/setup.md M2: preview/staging に本番デプロイ権限の token を露出させないため)。
+const REQUIRED_REPO_SECRETS = ['CLOUDFLARE_ACCOUNT_ID', 'CLOUDFLARE_PROJECT_NAME'];
+const REQUIRED_ENV_SECRETS = ['CLOUDFLARE_API_TOKEN', 'VITE_API_URL', 'VITE_TURNSTILE_SITE_KEY'];
 const REQUIRED_WORKER_SECRETS = [
   'TURNSTILE_SECRET_KEY',
   'ATTESTATION_SECRET_KEY',
@@ -521,6 +523,16 @@ function checkGitHubSetup() {
     } else {
       report('fail', `repo secret 未設定: ${key}`, `gh secret set ${key}\n値の中身は docs/setup.md M1-M2 参照`);
     }
+  }
+
+  // repo level の CLOUDFLARE_API_TOKEN は方針違反 (Environment secret が同名 repo secret を
+  // 上書きするため動作はするが、preview/staging からも本番権限 token に到達しうる)
+  if (repoSecrets.includes('CLOUDFLARE_API_TOKEN')) {
+    report(
+      'warn',
+      'repo secret CLOUDFLARE_API_TOKEN が存在 (Environment secret への分離を推奨)',
+      `docs/setup.md M2 参照。staging/production 各 Environment に権限を絞った token を置き、repo level は削除:\n  gh secret delete CLOUDFLARE_API_TOKEN`
+    );
   }
 
   // Environments


### PR DESCRIPTION
## 概要

`npm run doctor -- --maintainer` が repo secret `CLOUDFLARE_API_TOKEN` を必須扱いしていたが、docs/setup.md M2 の方針は「repo level に置かず Environment secret に分離」(preview/staging に本番デプロイ権限 token を露出させないため) であり、方針どおりの構成が fail 判定される不整合があった (タグ式 GitHub Flow 移行時の検証で発見)。

## 変更

- `REQUIRED_REPO_SECRETS` から `CLOUDFLARE_API_TOKEN` を除外 (ACCOUNT_ID / PROJECT_NAME のみ)
- `REQUIRED_ENV_SECRETS` に `CLOUDFLARE_API_TOKEN` を追加 (staging / production 各 Environment で検査)
- repo level に `CLOUDFLARE_API_TOKEN` が残存する場合は warn で分離を案内
- setup.md M5 の検査内容リストを追随

## 検証

現構成 (Environment secret 分離済み) で `doctor --maintainer` の GitHub セクションが全 ✓ になることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)