### PR TITLE
fix(e2e): tsx の解決を root .bin 決め打ちから require.resolve('tsx/cli') に変更

### DIFF
--- a/packages/e2e/tests/helpers/verifyCli.ts
+++ b/packages/e2e/tests/helpers/verifyCli.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from 'node:child_process';
 import { readFileSync, existsSync, mkdtempSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -7,7 +8,10 @@ import { fileURLToPath } from 'node:url';
 const HERE = fileURLToPath(new URL('.', import.meta.url));
 const REPO_ROOT = resolve(HERE, '../../../..');
 const CLI_ENTRY = resolve(REPO_ROOT, 'packages/verify-cli/src/cli.ts');
-const TSX_BIN = resolve(REPO_ROOT, 'node_modules/.bin/tsx');
+// tsx の設置場所 (root hoist か packages/e2e 配下か) は lockfile 再生成で変わりうるため、
+// root の node_modules/.bin を決め打ちせず Node の解決機構で引く
+// (Dependabot の lockfile 更新で root hoist が外れ spawn ENOENT になった実績: PR #189)。
+const TSX_CLI = createRequire(import.meta.url).resolve('tsx/cli');
 
 /**
  * verify-cli を実プロセスとして起動して proof を検証する。
@@ -41,7 +45,7 @@ export interface CliResultWithAnalysis extends CliResult {
 }
 
 export function runVerifyCli(file: string, extraArgs: string[] = []): CliResult {
-  const res = spawnSync(TSX_BIN, [CLI_ENTRY, file, ...extraArgs], {
+  const res = spawnSync(process.execPath, [TSX_CLI, CLI_ENTRY, file, ...extraArgs], {
     cwd: REPO_ROOT,
     encoding: 'utf-8',
     // full PoSW 再計算 (10,000 iter/event) は遅い CI ランナー (2 コア・他プロセスと競合) で


### PR DESCRIPTION
## 問題

Dependabot PR #189 の e2e が全滅 (`spawnSync node_modules/.bin/tsx ENOENT`)。

lockfile 再生成で tsx 4.23.0 が root hoist ではなく `packages/e2e/node_modules/` に nest 配置され、[verifyCli.ts](packages/e2e/tests/helpers/verifyCli.ts) が決め打ちしていた root の `.bin/tsx` が存在しなくなったため。tsx の設置場所は npm の hoisting 判断 (他パッケージとのバージョン競合等) で変わりうる。

## 修正

root パス決め打ちをやめ、e2e パッケージ文脈の `createRequire(import.meta.url).resolve('tsx/cli')` で解決した entry を `process.execPath` (node) で直接実行する。root hoist / nest のどちらでも動く。

## 検証

PR #189 の lockfile (nest 配置) を npm ci した状態で、新しい解決経路により verify-cli が exit 0 で起動することを確認済み。typecheck / lint green。

## マージ後

PR #189 に `@dependabot rebase` をコメントして本修正込みで CI を回し直す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)