### PR TITLE
chore(repo): AI 協働の開発運用を明文化 (worktree/sweep・Issue 引き継ぎ・labeler, ADR-0029)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,30 @@
+name: バグ報告
+description: 期待と異なる動作の報告
+labels: ["bug"]
+body:
+  - type: textarea
+    id: actual
+    attributes:
+      label: 何が起きたか
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待した動作
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: 再現手順
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: true
+  - type: input
+    id: env
+    attributes:
+      label: 環境
+      placeholder: 例) macOS / Chrome 140。verify-cli の場合は Node.js のバージョンも

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,41 @@
+name: 機能提案・タスク
+description: 新しい機能や改善のタスク(記憶ゼロから着手できる自己完結の記述にする)
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: purpose
+    attributes:
+      label: 目的
+      description: なぜやるのか。関連する ADR / docs/system-spec.md / 既存 Issue と対応付けられると良い
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 内容
+      description: 何をつくるか・どう振る舞うか。実装方針が決まっていれば理由も
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: 受け入れ条件
+      description: 何ができたら完了か。検証可能な形で(自動テスト・手動確認の別も)
+      placeholder: |
+        - [ ] ...できる(ユニットテストあり)
+        - [ ] ...の場合はエラーになる
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: 関連情報
+      description: 該当ファイル・docs・ADR・依存 Issue へのリンク。前提知識のポインタを惜しまない
+      placeholder: |
+        - 依存: #123
+        - 該当: packages/shared/src/typingProof/, docs/adr/0009-pluggable-analysis-layer.md
+  - type: textarea
+    id: scope
+    attributes:
+      label: スコープ外
+      description: この Issue でやらないこと

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,43 @@
+# PR の変更ファイルからパッケージラベルを自動付与する(.github/workflows/labeler.yml)
+"pkg:shared":
+  - changed-files:
+      - any-glob-to-any-file: "packages/shared/**"
+
+"pkg:editor":
+  - changed-files:
+      - any-glob-to-any-file: "packages/editor/**"
+
+"pkg:verify":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "packages/verify/**"
+          - "packages/verify-cli/**"
+
+"pkg:workers":
+  - changed-files:
+      - any-glob-to-any-file: "packages/workers/**"
+
+"pkg:e2e":
+  - changed-files:
+      - any-glob-to-any-file: "packages/e2e/**"
+
+"pkg:repo":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "scripts/**"
+          - "docs/**"
+          - "biome.json"
+          - "tsconfig.base.json"
+          - ".node-version"
+          - "package.json"
+          - "package-lock.json"
+          - "CLAUDE.md"
+          - "CONTRIBUTING.md"
+          - "README.md"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "**/*.md"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,13 @@
+name: Labeler
+
+on: pull_request_target
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ docs/plans/
 # Playwright MCP output (screenshots, snapshots, e2e fixtures)
 .playwright-mcp/
 fix-*.png
+
+# git worktree の展開先 (CONTRIBUTING「並行作業 (git worktree)」参照)
+.claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,14 @@ npm run test -w @typedcode/e2e
 # 注: CI は「ユニット (test job) + e2e (e2e job)」を全 deploy のゲートにしている
 ```
 
+## 開発フロー
+
+- ブランチ運用は**タグ式 GitHub Flow** (main 1 本 + `v*` タグ → production)。手順は [CONTRIBUTING.md](CONTRIBUTING.md)、根拠は [ADR-0028](docs/adr/0028-tag-based-github-flow.md)
+- **作業は git worktree で行う** (メインのチェックアウトのブランチを切り替えない)。ブランチ名は `<type>/<短い説明>` (type はコミット型と同じ)
+- コミットと **PR タイトル**は Conventional Commits (`feat(editor): ...`)。squash merge で PR タイトルがマージコミットのメッセージになる
+- **マージしたら、メインのチェックアウトから `git sweep` を実行して** worktree とローカルブランチを掃除する (使用中・dirty な worktree は自動スキップ。[ADR-0029](docs/adr/0029-merge-cleanup-script.md))
+- **引き継ぎの真実は Issue に置く**: 着手時は Issue 本文と全コメントを読む。重要な決定・発見はその場で Issue コメントに記録し、中断時は「完了・残作業・注意点・次の一歩」の引き継ぎコメントを残す。セッションメモリ・チャット履歴は効率化のために使ってよいが、**そこにしかない情報を作らない** (詳細は CONTRIBUTING「Issue の書き方と引き継ぎ」)
+
 ## ドキュメント階層
 
 - **CLAUDE.md (本ファイル)**: 玄関口 / ナビゲーション
@@ -74,7 +82,7 @@ npm run test -w @typedcode/e2e
 - **[docs/system-spec.md](docs/system-spec.md)**: クロスカット仕様 (定数、アルゴリズム、用語集)
 - **[docs/adr/](docs/adr/)**: 設計判断の蓄積 (Architecture Decision Records)
 - **`packages/*/README.md`**: ユーザー視点のドキュメント (API、使い方)
-- **[CONTRIBUTING.md](CONTRIBUTING.md)**: ブランチ運用 (タグ式 GitHub Flow) の手順。根拠は [ADR-0028](docs/adr/0028-tag-based-github-flow.md)
+- **[CONTRIBUTING.md](CONTRIBUTING.md)**: 開発の進め方 (ブランチ運用 / worktree 並行作業 / Issue 引き継ぎ / マージ後の掃除)。根拠は [ADR-0028](docs/adr/0028-tag-based-github-flow.md) / [ADR-0029](docs/adr/0029-merge-cleanup-script.md)
 
 仕様は `docs/system-spec.md`、判断の根拠は `docs/adr/`、コードの触り方は `CLAUDE.md` が真実の在処です。
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing — ブランチ運用ガイド
+# Contributing — 開発の進め方
 
-TypedCode のブランチ運用は **タグ式 GitHub Flow** です。判断の根拠は [ADR-0028](docs/adr/0028-tag-based-github-flow.md) を参照。本ファイルは日々の**手順**を扱います。
+TypedCode のブランチ運用は **タグ式 GitHub Flow** です。判断の根拠は [ADR-0028](docs/adr/0028-tag-based-github-flow.md) を参照。本ファイルは日々の**手順** (ブランチ運用・worktree 並行作業・Issue の引き継ぎ・マージ後の掃除) を扱います。
 
 ## 全体像
 
@@ -16,34 +16,129 @@ feature   ●─●    ●─●        ●─●               ← 機能ごと
 |---|---|---|
 | `main` | 唯一の長命ブランチ・常時統合 | push → **staging** 自動 (`staging.<project>.pages.dev`) |
 | `v*` タグ | 番号付きリリース | タグ push → **production** (承認ゲート付き) |
-| `feature/*` | 機能開発 | PR → preview URL 自動発行 |
+| `<type>/*` | 機能開発 (`feat/*`, `fix/*`, ...) | PR → preview URL 自動発行 |
 
 - `develop` / `release/*` / `hotfix/*` ブランチは**ありません**。main が常にリリース候補です。
 - **`staging` はブランチ名として予約** (staging Pages エイリアスと衝突するため使用禁止)。
 
 ## 普段の開発フロー
 
-```bash
-# 1. main から feature を切る
-git switch main
-git pull
-git switch -c feature/my-change
+ブランチは `<type>/<短い説明>` で命名します。type は下記コミット型と同じものを使います (例: `feat/exam-timer`, `fix/posw-worker-race`, `docs/adr-0029`, `chore/ci-cache`)。
 
-# 2. 作業してコミット (Conventional Commits: feat:/fix:/docs:/test:/refactor: ...)
+```bash
+# 1. main 最新から worktree を作る (メインのチェックアウトは main のまま。詳細は「並行作業」)
+git fetch origin
+git worktree add .claude/worktrees/my-change -b feat/my-change origin/main
+cd .claude/worktrees/my-change && npm ci
+
+# 2. 作業してコミット (Conventional Commits: feat:/fix:/docs:/test:/refactor:/chore:/ci: ...)
 git add -A
 git commit -m "feat(editor): add foo"
 
 # 3. push して PR を作る (base = main)
-git push -u origin feature/my-change
+git push -u origin feat/my-change
 gh pr create --fill
 
-# 4. CI 通過 + セルフレビュー後、Squash and Merge
+# 4. CI 通過 + セルフレビュー後、Squash and Merge → 掃除
 gh pr merge --squash --delete-branch
 ```
 
 - **PR は小さく** (目安 ±400 行)。1 PR = 1 つの関心事。
+- **PR タイトルも Conventional Commits 形式にする**。Squash and Merge では PR タイトルがマージコミットのメッセージになります。
 - マージ前に lint / type check / test / build が緑であること (main は required status checks で強制)。
 - マージされると main push の CI が staging へ自動デプロイする。動作確認は `staging.<project>.pages.dev` で。
+- **マージしたら、メインのチェックアウトから `git sweep` を実行して**ローカルブランチと worktree を掃除する (下記「マージ後の掃除」)。
+
+## 並行作業 (git worktree)
+
+作業はメインのチェックアウトでブランチを切り替えるのではなく、git worktree で並行作業します。リポジトリ直下は常に main のままにしておき、ブランチでの作業は worktree 側で行います。これにより、レビュー中に別タスクを並行で進めたり、main で動作確認しながらブランチを編集したりできます。Claude Code のセッションも同じ流儀で `.claude/worktrees/` 配下に worktree を作って動きます。
+
+```sh
+# 作成 (main 最新からブランチを切って .claude/worktrees/ 配下に展開)
+git fetch origin
+git worktree add .claude/worktrees/<name> -b <type>/<説明> origin/main
+cd .claude/worktrees/<name>
+npm ci
+
+# ...編集 → commit → push → PR...
+
+git worktree list   # 一覧確認
+```
+
+### 気をつけること
+
+- **`node_modules` は worktree ごとに独立。** 作成した直後は必ず `npm ci` する。メインのチェックアウトも、`git pull` で lockfile が変わったら `npm ci` し直す (忘れると「コマンドが見つからない」系のエラーになる)
+- **dev サーバのポートは全 worktree で共有。** editor (5173) / verify (5174) / workers (8787) を複数 worktree で同時起動すると衝突する。併用するときはポートを変える
+- **skip-worktree はインデックス単位で、worktree 間で共有されない。** メインのチェックアウトで隠している `packages/shared/src/checkpointKeys/localKeys.ts` / `packages/workers/wrangler.toml` のローカル版や `.dev.vars` は、新しい worktree には存在しない (HEAD のプレースホルダ版がチェックアウトされる)。ユニットテストはそのまま通るが、worktree 内で workers をローカル起動するにはこれらの再セットアップが必要 ([packages/workers/CLAUDE.md](packages/workers/CLAUDE.md) の手順)。E2E は `npm run setup -w @typedcode/e2e` が鍵を実行時生成するので不要
+- **`git stash` は全 worktree 共有。** 取り違えやすいので、作業を退避したいときは stash ではなく WIP コミットにする
+- **同じブランチは一つの worktree にしかチェックアウトできない** (main はリポジトリ直下が使っているので、worktree で main は開けない)
+- worktree の実体は `.claude/worktrees/` にあり、git 管理外 (.gitignore 済み)。消すときは `rm -rf` ではなく `git worktree remove` (または下記 sweep) を使う (git 側の登録も一緒に消えるため)
+
+## マージ後の掃除 (git sweep)
+
+掃除は個別の手作業ではなく `git sweep` に寄せます (方針の背景は [ADR-0029](docs/adr/0029-merge-cleanup-script.md))。仕組みは三段構え:
+
+1. **リモートブランチ**: GitHub の「Automatically delete head branches」が有効なので、PR マージで自動削除される
+2. **リモート追跡ブランチ**: `fetch.prune = true` (clone ごとに `git config fetch.prune true`) で fetch 時に自動削除される
+3. **ローカルブランチと worktree**: [scripts/sweep.sh](scripts/sweep.sh) が upstream の消えた (`[gone]`) ブランチを worktree ごと削除する
+
+セットアップ (clone ごとに一度):
+
+```sh
+git config fetch.prune true
+git config alias.sweep '!bash scripts/sweep.sh'
+```
+
+運用方針: **PR をマージしたら、その流れでメインのチェックアウトから `git sweep` を実行する** (人でもエージェントでも、マージした者が実行する)。定期バッチにはせず、マージ直後の習慣として回します。
+
+スクリプトは安全側に倒してあり、次の worktree はスキップして残します:
+
+- 現在いる worktree
+- 未コミットの変更がある worktree
+- **使用中の worktree** (その中を cwd とするプロセスがいる。中で動いている Claude Code セッションやシェルなど)
+
+スキップの理由が「自分自身」の場合——マージを終えたセッションがまだその worktree の中にいて「使用中のプロセスあり」と出る場合——セッションを閉じる必要はありません。Claude Code の `ExitWorktree` ツール (action: `keep`) でメインのチェックアウトに戻ってから `git sweep` を再実行すれば、その worktree も削除できます。`action: remove` で直接消す手もありますが、squash merge ではローカルコミットが「未マージ」と誤検知され確認を求められがちなので、`keep` で抜けて sweep に任せるほうが安全です (sweep は upstream の消滅で判定するため誤検知しない)。
+
+スクリプトの動作検証は `npx vitest run scripts/sweep.test.ts` (使い捨てのリポジトリを組み立てる統合テスト)。CI 常設ではなく、スクリプトを変更したときに手元で回します。
+
+### 注意: worktree を消すと、その中のセッションは再開できない
+
+Claude Code のセッションは作業ディレクトリ単位で管理されるため、worktree を削除すると、その中で動いていたセッションは後から再開・追加依頼ができなくなります (`No conversation found with session ID` エラー)。
+
+- **マージ後の追加依頼は、worktree の古いセッションに投げず、main から新しいセッション・新しい worktree で始める**
+- 引き継ぎの真実を Issue に置く運用 (下記) を守っていれば、セッションが消えても失われる情報はない
+- どうしても再開したい場合は、同じパスに worktree を作り直せば resume できる (会話ログ自体は `~/.claude/projects/` に残っている)
+
+## Issue の書き方と引き継ぎ
+
+このプロジェクトは AI エージェント (Claude Code など) との協働を前提とします。情報は二層で管理します。
+
+- **作業レイヤー (揮発してよい)**: セッションのコンテキスト、エージェントのローカルメモリ、チャット履歴。作業効率を最大化するために積極的に活用する
+- **恒久レイヤー (真実の置き場)**: Issue 本文・コメント、docs / ADR、コード、PR。**作業再開に必要な情報は必ずここに残す**
+
+エージェントのメモリやチャット履歴はいつでもリセットされうる前提で、**Issue 本文・コメント・docs・コードだけを読めば、記憶ゼロの状態からでも作業を再開できる**状態を常に保ちます。メモリを使うことは問題ないが、メモリにしかない情報を作らない。
+
+### Issue 本文に書くこと
+
+[Issue テンプレート](.github/ISSUE_TEMPLATE/) がこの型を強制します。
+
+- **目的** — なぜやるのか。関連する ADR / [docs/system-spec.md](docs/system-spec.md) / 既存 Issue と対応付ける
+- **内容** — 何をつくるか。実装方針が決まっている場合はその理由も
+- **受け入れ条件** — 「何ができたら完了か」を検証可能な形で (自動テスト・手動確認の別も)
+- **関連情報** — 該当ファイル・docs・ADR・依存 Issue へのリンク。前提知識のポインタを惜しまない
+- **スコープ外** — やらないことを明示し、スコープの膨張を防ぐ
+
+### 作業中・引き継ぎ時のコメント
+
+- **重要な決定・発見・方針変更は、その場で Issue コメントに記録する** (例: 試して駄目だったアプローチ、既存コードの罠)。恒久的な設計判断に昇格するものは ADR へ
+- **作業を中断するとき・部分的に完了したときは引き継ぎコメントを残す**: ①完了したこと (PR 番号) ②残作業 ③詰まりどころ・注意点 ④次の一歩
+- PR をマージしても Issue に残作業があるなら、Issue は閉じずに引き継ぎコメントで残作業を明確にする
+
+### ラベル
+
+- **種類ラベル** (Issue / PR に一つ): `bug` / `enhancement` / `documentation` / `security` など。Issue テンプレートが自動で付けるものはそのまま使う
+- **パッケージラベル** (`pkg:shared` / `pkg:editor` / `pkg:verify` / `pkg:workers` / `pkg:e2e` / `pkg:repo`): PR には変更ファイルから **labeler が自動付与**する ([.github/labeler.yml](.github/labeler.yml))。Issue には着手対象が明らかな場合に手動で付ける
+- `severity:*` はレビュー・トリアージ時の重要度の明示に使う
 
 ## リリース (v* タグ)
 
@@ -67,8 +162,8 @@ gh release create vX.Y.Z --target main --title "vX.Y.Z" --generate-notes
 専用ブランチはありません。通常フローの最短経路で回します:
 
 ```bash
-git switch main && git pull
-git switch -c fix/critical-bug
+git fetch origin
+git worktree add .claude/worktrees/critical-bug -b fix/critical-bug origin/main
 # 修正 → PR → squash merge → staging で確認
 gh release create vX.Y.(Z+1) --target main --generate-notes   # 即パッチリリース
 ```
@@ -85,7 +180,7 @@ Settings → General → Pull Requests:
 
 - **Default to squash merging** を有効化 (普段の feature→main を squash 既定に)
 - Rebase merging も有効のまま (stacked PR の flatten 用)
-- **Automatically delete head branches** を有効化 (長命ブランチは main のみで、ruleset が削除から保護している)
+- **Automatically delete head branches** を有効化 (長命ブランチは main のみで、ruleset が削除から保護している。`git sweep` の 1 段目でもある)
 
 Rulesets:
 

--- a/docs/adr/0029-merge-cleanup-script.md
+++ b/docs/adr/0029-merge-cleanup-script.md
@@ -1,0 +1,53 @@
+# ADR-0029: マージ後の掃除はバージョン管理されたスクリプト (git sweep) に集約する
+
+- **Status**: Accepted
+- **Date**: 2026-07-09
+- **Deciders**: (PR 上の合意者 / レビュアー)
+- **PR / Commit**: 導入 PR
+
+## Context
+
+ADR-0028 のタグ式 GitHub Flow では feature ブランチを頻繁に切り、作業は git worktree (`.claude/worktrees/`) で並行して行う (Claude Code のセッションも worktree 単位で動く)。PR マージのたびにローカルブランチと worktree の掃除が発生するが、これまで手順は暗黙で、掃除は各自の手作業だった。
+
+同じ worktree 運用の姉妹プロジェクト (skopos) では「`git sweep` が、中で Claude Code セッションが動いている worktree を削除してしまい、セッションが再開不能になる」事故が実際に起きている (Claude Code のセッションは作業ディレクトリ単位で管理されるため、worktree が消えると `No conversation found with session ID` になり、未消化の依頼が宙に浮く)。対策として安全チェック付きスクリプトをバージョン管理する判断が下された (skopos ADR-0007)。TypedCode は同じ運用形態であり、同じ事故クラスを持つ。
+
+## Considered Options
+
+### Option A: CONTRIBUTING に手順・スニペットを書くだけ
+- Pros: 実装不要。
+- Cons: 危険な操作はドキュメントの注意書きでは防げない。「sweep 前にセッション有無を確認」と書いても、読み飛ばした瞬間に事故が再現する。スニペットを各自の `.git/config` に写す方式は修正が行き渡らずレビューもされない (コピペ運用は静かに腐る)。→ 却下。
+
+### Option B: バージョン管理されたスクリプト + 薄い git alias (本 ADR)
+- `scripts/sweep.sh` をリポジトリに置き、`git sweep` エイリアスは薄いエントリポイント (`!bash scripts/sweep.sh`) に留める。
+- 安全側スキップ (現在地 / dirty / 使用中プロセス) を機械的なガードとして持つ。
+- Pros: 安全判定が人・エージェントの注意力に依存しない。掃除ロジックの変更が PR としてレビュー・共有される。実行可能な実体があると指示が「`git sweep` を実行」の一語で済み、エージェントが手順書を毎回再解釈するブレがなくなる。
+- Cons: clone ごとに一度のセットアップ (`fetch.prune` + alias 登録) が必要。→ **採用**。
+
+### Option C: さらに自動化 (git hook / 定期実行で sweep)
+- Cons: pull のたび・時間経過で worktree が消えるのは削除タイミングが予測できず、事故をむしろ起こしやすい。「マージ直後に明示的に実行」で十分軽い。→ 却下。
+
+## Decision
+
+**Option B** を採る。
+
+- **削除対象** (worktree ごと削除): upstream が消えた (`[gone]`) ローカルブランチ、および一度も push されず既定ブランチに完全に含まれる `worktree-*` プレースホルダ (Claude Code の EnterWorktree が自動生成し、作業が別名ブランチで PR されると固有コミットなしで残るもの)。
+- **安全側スキップ**: ①現在いる worktree ②未コミットの変更がある worktree ③使用中の worktree (lsof で「その中を cwd とするプロセス」を検出。生きているセッション・シェル等)。
+- **運用**: PR をマージした者 (人・エージェント問わず) が、その流れでメインのチェックアウトから `git sweep` を実行する。定期バッチにはしない。
+- **検証**: `scripts/sweep.test.ts` (vitest。使い捨ての bare origin + clone を組み立てて実挙動を確認する統合テスト) をスクリプト変更時に手元で回す (`npx vitest run scripts/sweep.test.ts`)。ユニット CI には常設しない (git 実環境依存かつ変更頻度が低いため。頻繁に触るようになったら再検討)。
+
+## Consequences
+
+### Positive
+- 「生きているセッション入りの worktree を消す」事故クラスが機械的に防がれる。
+- 掃除がコマンド一語になり、人にもエージェントにも運用が定着する。マージ→掃除までを 1 つの流れにできる。
+
+### Negative / Trade-offs
+- clone ごとに一度の初期設定が必要: `git config fetch.prune true` と `git config alias.sweep '!bash scripts/sweep.sh'` (CONTRIBUTING に記載)。
+- lsof が使えない環境では使用中チェックは働かない (現在地・dirty チェックは働く)。
+- **終了済みセッションの worktree は保護されない**。マージ後の追加依頼は古いセッションに投げず、main から新しいセッション・新しい worktree で始める運用とセットで機能する。引き継ぎの真実を Issue に置く運用 (CONTRIBUTING「Issue の書き方と引き継ぎ」) を守っていれば、セッションが消えても失われる情報はない。
+
+## References
+
+- skopos ADR-0007 (同運用での実事故と判断の原典。スクリプト・テストの移植元)
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) 「マージ後の掃除 (git sweep)」(日々の手順)
+- [ADR-0028](0028-tag-based-github-flow.md) (worktree 運用の前提となるブランチモデル)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -59,6 +59,7 @@
 | [0026](0026-lightweight-git-flow-branching.md) | Superseded by 0028 | ブランチ運用を軽量 Git Flow にする (release/* を省き develop→main は merge commit・feature→develop は squash) |
 | [0027](0027-checkpoint-sign-requires-session-token.md) | Accepted | /api/checkpoint/sign を sessionStartToken 前提にする (DO 化は据え置き・無認証リクエストに KV コストを払わない) |
 | [0028](0028-tag-based-github-flow.md) | Accepted | ブランチ運用をタグ式 GitHub Flow にする (main 1 本 + v* タグで production リリース・0026 を supersede) |
+| [0029](0029-merge-cleanup-script.md) | Accepted | マージ後の掃除はバージョン管理されたスクリプト (git sweep) に集約する |
 
 ## 参考
 

--- a/scripts/sweep.sh
+++ b/scripts/sweep.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# マージ済みブランチと worktree の掃除(`git sweep` エイリアスの実体)。
+# 背景と判断は docs/adr/0029-merge-cleanup-script.md を参照。
+#
+# 削除対象(いずれも対応する worktree ごと削除する):
+#   - upstream が消えた([gone])ローカルブランチ。GitHub 側で
+#     「Automatically delete head branches」が有効なので、PR マージ後に
+#     メインのチェックアウトからこれを実行するだけでローカルも片付く
+#   - 一度も push されておらず、既定ブランチに完全に含まれる worktree-* ブランチ
+#     (セッションの EnterWorktree が自動生成するプレースホルダー。作業が別名の
+#     ブランチで PR されると、固有のコミットを持たないまま残る)
+#
+# 安全側スキップ(削除しないケース):
+#   - 現在いる worktree
+#   - 未コミットの変更がある worktree
+#   - 使用中の worktree(そのディレクトリを cwd とするプロセスがいる。
+#     例: 中で動いている Claude Code セッションやシェル。worktree を消すと
+#     その中のセッションは再開できなくなるため)
+#
+# セットアップ(clone ごとに一度): git config alias.sweep '!bash scripts/sweep.sh'
+set -euo pipefail
+
+git fetch --prune
+
+top=$(git rev-parse --show-toplevel)
+main_ref=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD || echo origin/main)
+
+# ディレクトリ以下を cwd とするプロセスがいるか(lsof が使えない環境では偽を返す)
+# 注意: grep -q を使うと lsof が SIGPIPE になり pipefail に拾われるので、全読みしてから判定する
+in_use() {
+  local hits
+  hits=$(lsof -Fn -d cwd 2>/dev/null | grep -E "^n$1(/|$)" || true)
+  [ -n "$hits" ]
+}
+
+git for-each-ref refs/heads --format='%(refname:short)|%(upstream)|%(upstream:track)|%(worktreepath)' |
+while IFS='|' read -r branch upstream track wt; do
+  if [ "$track" = "[gone]" ]; then
+    : # マージ済み(upstream 消滅)
+  elif [ -z "$upstream" ] && [[ "$branch" == worktree-* ]] &&
+    git merge-base --is-ancestor "$branch" "$main_ref" 2>/dev/null; then
+    : # EnterWorktree のプレースホルダー(未 push・固有コミットなし)
+  else
+    continue
+  fi
+
+  if [ -n "$wt" ] && [ "$wt" = "$top" ]; then
+    echo "skip: ${branch}(現在いる worktree: ${wt})"
+    continue
+  fi
+
+  if [ -n "$wt" ]; then
+    if [ -n "$(git -C "$wt" status --porcelain)" ]; then
+      echo "skip: ${branch}(未コミットの変更あり: ${wt})"
+      continue
+    fi
+    if in_use "$wt"; then
+      echo "skip: ${branch}(使用中のプロセスあり。セッションが動いていないか確認: ${wt})"
+      continue
+    fi
+    git worktree remove "$wt" || {
+      echo "skip: ${branch}(worktree remove 失敗: ${wt})"
+      continue
+    }
+  fi
+
+  git branch -D "$branch" >/dev/null
+  if [ -n "$wt" ]; then
+    echo "removed: ${branch}(worktree も削除: ${wt})"
+  else
+    echo "removed: $branch"
+  fi
+done

--- a/scripts/sweep.test.ts
+++ b/scripts/sweep.test.ts
@@ -1,0 +1,122 @@
+// scripts/sweep.sh の動作検証。
+// 使い捨ての origin(bare リポジトリ)と clone を作り、実際に sweep を走らせて
+// 「消すべきブランチを消し、消してはいけないブランチを残す」ことを確認する。
+// CI 常設ではなくスクリプト変更時に手元で回す: npx vitest run scripts/sweep.test.ts
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const SWEEP = join(import.meta.dirname, 'sweep.sh');
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+function sweep(cwd: string): string {
+  return execFileSync('bash', [SWEEP], { cwd, encoding: 'utf8' });
+}
+
+function localBranches(cwd: string): string[] {
+  return git(cwd, 'for-each-ref', 'refs/heads', '--format=%(refname:short)').split('\n');
+}
+
+describe('sweep.sh', () => {
+  let dir: string;
+  let clone: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'sweep-test-'));
+    const origin = join(dir, 'origin.git');
+    clone = join(dir, 'clone');
+    execFileSync('git', ['init', '--bare', '--initial-branch=main', origin]);
+    execFileSync('git', ['clone', origin, clone]);
+    git(clone, 'config', 'user.name', 'test');
+    git(clone, 'config', 'user.email', 'test@example.com');
+    writeFileSync(join(clone, 'README.md'), 'hello\n');
+    git(clone, 'add', '.');
+    git(clone, 'commit', '-m', 'init');
+    git(clone, 'push', '-u', 'origin', 'main');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('upstream が消えたブランチを worktree ごと削除する', () => {
+    git(clone, 'branch', 'feat/x');
+    git(clone, 'push', '-u', 'origin', 'feat/x');
+    const wt = join(dir, 'wt-x');
+    git(clone, 'worktree', 'add', wt, 'feat/x');
+    git(clone, 'push', 'origin', '--delete', 'feat/x');
+
+    const out = sweep(clone);
+
+    expect(out).toContain('removed: feat/x');
+    expect(localBranches(clone)).not.toContain('feat/x');
+    expect(existsSync(wt)).toBe(false);
+  });
+
+  it('upstream が残っているブランチは削除しない', () => {
+    git(clone, 'branch', 'feat/y');
+    git(clone, 'push', '-u', 'origin', 'feat/y');
+
+    sweep(clone);
+
+    expect(localBranches(clone)).toContain('feat/y');
+  });
+
+  // EnterWorktree のプレースホルダー掃除:
+  // 「worktree-* という名前」「未 push」「main に完全に含まれる」の三条件が
+  // そろったときだけ削除する。近傍例(名前が一致しない・固有コミットあり)は残す。
+  it.each([
+    { branch: 'worktree-old-session', ahead: false, removed: true },
+    { branch: 'worktree-wip', ahead: true, removed: false },
+    { branch: 'worktree', ahead: false, removed: false },
+    { branch: 'my-worktree-old', ahead: false, removed: false },
+    { branch: 'local-notes', ahead: false, removed: false },
+  ])('未 push ブランチ $branch(固有コミット: $ahead)→ 削除: $removed', ({ branch, ahead, removed }) => {
+    git(clone, 'branch', branch);
+    if (ahead) {
+      git(clone, 'checkout', branch);
+      writeFileSync(join(clone, 'wip.txt'), 'wip\n');
+      git(clone, 'add', '.');
+      git(clone, 'commit', '-m', 'wip');
+      git(clone, 'checkout', 'main');
+    }
+
+    sweep(clone);
+
+    if (removed) {
+      expect(localBranches(clone)).not.toContain(branch);
+    } else {
+      expect(localBranches(clone)).toContain(branch);
+    }
+  });
+
+  it('プレースホルダーでも未コミットの変更がある worktree はスキップする', () => {
+    git(clone, 'branch', 'worktree-dirty');
+    const wt = join(dir, 'wt-dirty');
+    git(clone, 'worktree', 'add', wt, 'worktree-dirty');
+    writeFileSync(join(wt, 'uncommitted.txt'), 'dirty\n');
+
+    const out = sweep(clone);
+
+    expect(out).toContain('skip: worktree-dirty');
+    expect(localBranches(clone)).toContain('worktree-dirty');
+    expect(existsSync(wt)).toBe(true);
+  });
+
+  it('クリーンなプレースホルダーの worktree はブランチごと削除する', () => {
+    git(clone, 'branch', 'worktree-clean');
+    const wt = join(dir, 'wt-clean');
+    git(clone, 'worktree', 'add', wt, 'worktree-clean');
+
+    const out = sweep(clone);
+
+    expect(out).toContain('removed: worktree-clean');
+    expect(localBranches(clone)).not.toContain('worktree-clean');
+    expect(existsSync(wt)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

skopos_old で実績のある AI 協働運用を TypedCode に移植する。①git worktree 並行作業の明文化と `git sweep` (scripts/sweep.sh) によるマージ後掃除 (ADR-0029)、②「引き継ぎの真実は Issue に置く」二層情報管理 + Issue テンプレート、③labeler による `pkg:*` ラベル自動付与、④PR タイトル = Conventional Commits / ブランチ命名 `<type>/<説明>` の明文化。CONTRIBUTING.md を「開発の進め方」として改訂し、ルート CLAUDE.md に「開発フロー」節を追加。

追加コミット (a2fbea6): ⑤**モデルの役割分担 (コスト最適化)** — 高コストモデル (Fable) をメインループにする場合、コード編集は `.claude/agents/` のサブエージェント (implementer = Opus 4.8 / mechanic = Sonnet 5) に委譲する構成と運用ルールを追加。

## Test plan

- [x] `npx vitest run scripts/sweep.test.ts` — sweep.sh の統合テスト 9 件 pass (使い捨て origin+clone を組み立てて実挙動を検証。CI 常設ではなくスクリプト変更時に手元で回す方針、ADR-0029 参照)
- [x] `npm run lint` — exit 0 (新規ファイルへの警告なし)
- [ ] マージ後に確認: labeler が以降の PR に `pkg:*` を自動付与すること (`pull_request_target` のため main 反映後に有効)・New issue にテンプレートが出ること
- [ ] マージ後に確認: 新しいセッションで `implementer` / `mechanic` エージェントが Agent ツールから見えること

## Documentation impact

- [x] **設計判断をした** → `docs/adr/0029-merge-cleanup-script.md` を追加した
- [x] CONTRIBUTING.md 改訂 (worktree 並行作業 / git sweep / Issue 引き継ぎ / ラベル運用 / PR タイトル規約)
- [x] ルート CLAUDE.md に「開発フロー」「モデルの役割分担」節を追加、ドキュメント階層の CONTRIBUTING 説明を更新

## ADR (該当する場合)

- ADR-0029: マージ後の掃除はバージョン管理されたスクリプト (git sweep) に集約する

## Related issues / PRs

- 移植元: skopos_old ADR-0007 / CONTRIBUTING (worktree・sweep・Issue 二層管理の原典)

## 付随作業 (リポジトリ設定・ローカル設定)

- GitHub ラベル `pkg:e2e` を作成済み (labeler.yml が参照)
- この clone に `git config fetch.prune true` / `git config alias.sweep '!bash scripts/sweep.sh'` を設定済み (他の clone では CONTRIBUTING の手順で各自設定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)