### PR TITLE
chore(repo): dev サーバのポートをセット単位で自動割当し配線を追従させる (ADR-0030)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,10 +39,12 @@ packages/
 # 依存関係のインストール
 npm install
 
-# 開発 (全パッケージ同時)
+# 開発 (全パッケージ同時。ポートは自動割当 = ADR-0030:
+# 既定 editor 5173 / verify 5174 / workers 8787、使用中ならセットごと +10 へ。
+# 実際の URL は起動バナーに表示され、プロキシ / VITE_API_URL も自動追従)
 npm run dev
 
-# 開発 (個別)
+# 開発 (個別。こちらは従来どおりの固定ポート)
 npm run dev:editor    # http://localhost:5173
 npm run dev:verify    # http://localhost:5174
 npm run dev:workers   # http://localhost:8787

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ git worktree list   # 一覧確認
 ### 気をつけること
 
 - **`node_modules` は worktree ごとに独立。** 作成した直後は必ず `npm ci` する。メインのチェックアウトも、`git pull` で lockfile が変わったら `npm ci` し直す (忘れると「コマンドが見つからない」系のエラーになる)
-- **dev サーバのポートは全 worktree で共有。** editor (5173) / verify (5174) / workers (8787) を複数 worktree で同時起動すると衝突する。併用するときはポートを変える
+- **dev サーバのポートは自動割当 ([ADR-0030](docs/adr/0030-dev-port-autoswitch.md))。** `npm run dev` は既定ポート (editor 5173 / verify 5174 / workers 8787) が使用中だと**セットごと +10** (5183/5184/8797, …) して空きへ移り、editor の `/verify` プロキシと `VITE_API_URL` も追従する。複数 worktree・別プロジェクトとの同時起動は無調整で共存でき、実際の URL は起動バナーで確認する。個別起動 (`npm run dev:editor` 等) は従来どおり固定ポート (衝突時は vite が +1 フォールバックするだけで配線は追従しない点に注意)
 - **skip-worktree はインデックス単位で、worktree 間で共有されない。** メインのチェックアウトで隠している `packages/shared/src/checkpointKeys/localKeys.ts` / `packages/workers/wrangler.toml` のローカル版や `.dev.vars` は、新しい worktree には存在しない (HEAD のプレースホルダ版がチェックアウトされる)。ユニットテストはそのまま通るが、worktree 内で workers をローカル起動するにはこれらの再セットアップが必要 ([packages/workers/CLAUDE.md](packages/workers/CLAUDE.md) の手順)。E2E は `npm run setup -w @typedcode/e2e` が鍵を実行時生成するので不要
 - **`git stash` は全 worktree 共有。** 取り違えやすいので、作業を退避したいときは stash ではなく WIP コミットにする
 - **同じブランチは一つの worktree にしかチェックアウトできない** (main はリポジトリ直下が使っているので、worktree で main は開けない)

--- a/docs/adr/0030-dev-port-autoswitch.md
+++ b/docs/adr/0030-dev-port-autoswitch.md
@@ -1,0 +1,59 @@
+# ADR-0030: dev サーバのポートはランチャーがセット単位で自動割当し、配線を環境変数で追従させる
+
+- **Status**: Accepted
+- **Date**: 2026-07-19
+- **Deciders**: (PR 上の合意者 / レビュアー)
+- **PR / Commit**: 導入 PR (Issue #196)
+
+## Context
+
+root の `npm run dev` は concurrently で editor (vite :5173) / verify (vite :5174) / workers (wrangler dev :8787) を同時起動する。ポート間には固定の配線がある:
+
+- editor の `/verify` プロキシ → `http://localhost:5174` (vite.config に直書き)
+- editor の Workers API → `VITE_API_URL` (.env に `http://localhost:8787` を直書き)
+
+vite の既定 (`strictPort: false`) では、ポートが使用中だと**黙って +1 ずつずれて起動する**。別プロジェクトや別 worktree の dev サーバが先にポートを取っていると、editor だけが未知のポートへ流れ、上記の配線は**エラーも出さずに**別物 (前回セッションの残骸プロセス等) へつながる。実際に「別プロジェクトが 5173 を占有 → editor がずれ、`npm run dev` すると verify のページばかり目に付く」という混乱が起きた (concurrently の `[0][1][2]` 出力では 3 サーバの判別も難しい)。
+
+CONTRIBUTING はこれまで「dev サーバのポートは全 worktree で共有。併用するときはポートを変える」と**手動運用**を注意書きしてきたが、「ポートを変える」は editor / verify / workers のポートに加えプロキシと `VITE_API_URL` を同期して変える作業であり、忘れた箇所から黙って壊れる。複数プロジェクト・複数 worktree を同時にデバッグする運用は今後も続くため、無調整で共存できる仕組みが要る。
+
+## Considered Options
+
+### Option A: `strictPort: true` を入れるだけ (fail-fast)
+- Pros: 実装最小。黙認ずれによる誤配線は防げる (衝突が即エラーになる)。
+- Cons: 衝突時に起動自体ができず、「同時にデバッグしたい」という要件に応えない。ユーザーが手でポートを探して指定する手間は残る。→ 却下 (ただしランチャー割当時の保険として部分採用)。
+
+### Option B: worktree / プロジェクトごとに固定ポートを手で変える (現行 CONTRIBUTING の運用)
+- Pros: 仕組み不要。
+- Cons: ポート 3 つ + プロキシ + `VITE_API_URL` の 5 点を手で同期する運用で、忘れた箇所が黙って壊れる。実際に混乱が起きた。→ 却下。
+
+### Option C: 起動ランチャーがセット単位で空きポートを探し、環境変数で配線ごと注入 (本 ADR)
+- `scripts/dev.mjs` が起動前に {editor, verify, workers} の 3 ポートを**セットとして**確保し、決定値を `EDITOR_PORT` / `VERIFY_PORT` / `WORKERS_PORT` で各プロセスへ渡す。vite.config / wrangler がそれを読み、プロキシ先と `VITE_API_URL` も同じ値から導出する。
+- Pros: 衝突時も無調整で起動し、配線が常に自己整合する。concurrently に名前 (`editor` / `verify` / `workers`) と色を付けられ、どの URL が何かも起動バナーで明示できる。個別起動 (`npm run dev:editor` 等) は従来挙動のまま。
+- Cons: ランチャーという新しい可動部品が増える。→ **採用**。
+
+### Option D: 各サーバが実ポートをファイル等で公示し、他が動的に発見する (service discovery)
+- Cons: 起動順依存が生まれ、dev 用途には過剰な複雑さ。→ 却下。
+
+## Decision
+
+**Option C** を採る。
+
+- **セット探索**: 既定 {editor 5173, verify 5174, workers 8787}。1 つでも使用中なら**セットごと +10** (5183/5184/8797, …) して再試行 (最大 10 セット)。個別に詰めず一貫したオフセットで動かすのは、覚えやすさと「編集系は 517x、API は 87xx」という帯の維持のため。
+- **空き判定**: `127.0.0.1` と `::1` の両方で listen を試す (vite は `::1`、workerd は両方で listen するため片方だけでは見逃す)。`EADDRINUSE` / `EACCES` のみ使用中と判定し、IPv6 無効環境のエラーは空き扱い。
+- **配線追従**: editor の `/verify` プロキシ先は `VERIFY_PORT` から導出。`VITE_API_URL` は .env の値が**ローカル既定 (`http://localhost:<port>`) のときだけ** `WORKERS_PORT` へ追従させ、staging 等の外部 URL を明示している場合は触らない (Vite は process.env を .env ファイルより優先する仕様を利用)。
+- **黙認ずれの禁止**: ランチャーがポートを割り当てた場合 (`EDITOR_PORT` 等が設定されている場合) は `strictPort: true`。探索と listen の間の race で衝突したら黙ってずれず失敗させる (再実行すれば次の空きセットが選ばれる)。手動の個別起動 (env 未設定) は従来どおり vite のフォールバックに任せる。
+- **変更しないもの**: workers の CORS (dev は localhost をポート不問で許可済み)。e2e (`E2E_EDITOR_PORT` / `E2E_WORKERS_PORT` で既に可変・独自起動)。
+
+## Consequences
+
+### Positive
+
+- 複数プロジェクト・複数 worktree の dev サーバ同時起動が無調整で共存できる (CONTRIBUTING の手動注意書きを置換)。
+- 「ずれた editor が古い残骸プロセスの verify / workers につながる」誤配線クラスの問題が根絶される (配線は常に同一セット内で自己整合)。
+- concurrently の名前付き出力と起動バナーで「どの URL が何のサーバか」が一目で分かる。
+
+### Negative
+
+- ランチャー (`scripts/dev.mjs`) という保守対象が増える。ポート帯の変更はランチャーと各 vite.config の既定値の 2 箇所に現れる (env のフォールバック値)。
+- 探索と実 listen の間の TOCTOU race は原理的に残る (strictPort により「黙って壊れる」ではなく「即失敗 → 再実行で回復」に倒してある)。
+- `.env` の `VITE_API_URL` にローカル以外を書いている場合は追従しない (意図尊重)。ローカルの workers ではなく staging API に向けたデバッグは従来どおり可能。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -60,6 +60,7 @@
 | [0027](0027-checkpoint-sign-requires-session-token.md) | Accepted | /api/checkpoint/sign を sessionStartToken 前提にする (DO 化は据え置き・無認証リクエストに KV コストを払わない) |
 | [0028](0028-tag-based-github-flow.md) | Accepted | ブランチ運用をタグ式 GitHub Flow にする (main 1 本 + v* タグで production リリース・0026 を supersede) |
 | [0029](0029-merge-cleanup-script.md) | Accepted | マージ後の掃除はバージョン管理されたスクリプト (git sweep) に集約する |
+| [0030](0030-dev-port-autoswitch.md) | Accepted | dev サーバのポートはランチャーがセット単位で自動割当し、配線 (プロキシ / VITE_API_URL) を環境変数で追従させる |
 
 ## 参考
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "packages/*"
   ],
   "scripts": {
-    "dev": "concurrently \"npm run dev:editor\" \"npm run dev:verify\" \"npm run dev:workers\"",
+    "dev": "node scripts/dev.mjs",
     "dev:editor": "npm run dev -w @typedcode/editor",
     "dev:verify": "npm run dev -w @typedcode/verify",
     "dev:workers": "npm run dev -w @typedcode/workers",

--- a/packages/editor/vite.config.ts
+++ b/packages/editor/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import wasm from 'vite-plugin-wasm';
 import topLevelAwait from 'vite-plugin-top-level-await';
 import { execSync } from 'child_process';
@@ -26,6 +26,25 @@ function getBuildInfo() {
 
 const buildInfo = getBuildInfo();
 
+// dev ランチャー (scripts/dev.mjs) が割り当てたポート。個別起動時は未設定で、
+// その場合は既定 (5173/5174) にフォールバックする。verifyPort は /verify プロキシの
+// 追従先。
+const editorPort = Number(process.env.EDITOR_PORT) || 5173;
+const verifyPort = Number(process.env.VERIFY_PORT) || 5174;
+
+// ランチャー (scripts/dev.mjs) がポート割当した場合、.env の VITE_API_URL が
+// ローカル既定 (http://localhost:<port>) のままなら実際の workers ポートへ追従させる。
+// staging 等の外部 URL を明示している場合は触らない。
+// (Vite は process.env に既にある変数を .env ファイルより優先する)
+const workersPort = process.env.WORKERS_PORT;
+if (workersPort) {
+  const fileEnv = loadEnv('development', __dirname, '');
+  const current = process.env.VITE_API_URL ?? fileEnv.VITE_API_URL;
+  if (!current || /^https?:\/\/(localhost|127\.0\.0\.1):\d+\/?$/.test(current)) {
+    process.env.VITE_API_URL = `http://localhost:${workersPort}`;
+  }
+}
+
 export default defineConfig({
   plugins: [
     wasm(),
@@ -49,14 +68,19 @@ export default defineConfig({
     format: 'es',
   },
   server: {
-    port: 5173,
+    port: editorPort,
+    // ランチャー割当時 (EDITOR_PORT あり) は strictPort で「ずれたら失敗」にする。
+    // ポートがずれると /verify プロキシ (verifyPort 固定) や VITE_API_URL の配線が
+    // 別プロセスを指してしまうため、黙ってずらさず即エラーにして気付かせる。
+    // 手動の個別起動 (EDITOR_PORT なし) は従来どおり vite のフォールバックに任せる。
+    strictPort: Boolean(process.env.EDITOR_PORT),
     headers: {
       'Cross-Origin-Opener-Policy': 'same-origin',
       'Cross-Origin-Embedder-Policy': 'credentialless',
     },
     proxy: {
       '/verify': {
-        target: 'http://localhost:5174',
+        target: `http://localhost:${verifyPort}`,
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/verify/, ''),
       },

--- a/packages/verify/vite.config.ts
+++ b/packages/verify/vite.config.ts
@@ -26,10 +26,18 @@ function getBuildInfo() {
 
 const buildInfo = getBuildInfo();
 
+// dev ランチャー (scripts/dev.mjs) が割り当てたポート。個別起動時は未設定で既定
+// (5174) にフォールバックする。
+const verifyPort = Number(process.env.VERIFY_PORT) || 5174;
+
 export default defineConfig({
   base: isDev ? '/' : '/verify/',
   server: {
-    port: 5174,
+    port: verifyPort,
+    // ランチャー割当時 (VERIFY_PORT あり) は strictPort。editor の /verify プロキシが
+    // このポート固定で追従するため、ずれると配線が壊れる。黙ってずらさず失敗させる。
+    // 手動の個別起動 (VERIFY_PORT なし) は従来どおりフォールバック可。
+    strictPort: Boolean(process.env.VERIFY_PORT),
   },
   build: {
     target: 'esnext',

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * dev launcher — ポートセット単位で空きを探して dev サーバ群を起動する (Issue #196)。
+ *
+ * 背景:
+ *   root の `npm run dev` は editor(5173) / verify(5174) / workers(8787) を
+ *   concurrently で同時起動する。別 worktree や別プロジェクトの dev サーバが
+ *   これらを占有していると vite は黙って +1 ずつポートをずらし、editor の
+ *   `/verify` プロキシ (5174 固定) や `VITE_API_URL` (8787 固定) の配線が壊れたり
+ *   古いプロセスへつながる。
+ *
+ * 設計方針:
+ *   - **ポートセット単位で切替**: 3 ポートを個別にずらすと配線が追えなくなるため、
+ *     3 つすべて空いているセットだけを採用する。1 つでも埋まっていればセットごと
+ *     +STEP して再試行する (5173/5174/8787 → 5183/5184/8797 → …)。
+ *   - **配線を追従させる**: 割り当てたポートを環境変数 (EDITOR_PORT / VERIFY_PORT /
+ *     WORKERS_PORT) で各 dev サーバへ渡す。vite.config が server.port・proxy target・
+ *     VITE_API_URL をそのポートへ向け、workers は --port で wrangler dev を固定する。
+ *   - **空きチェックは IPv4/IPv6 両方**: vite は `::1`、workerd は両スタックで listen
+ *     するため、`127.0.0.1` と `::1` の双方が空いて初めて「空き」と判定する。
+ *   - 読み取り専用の探索 (何も書き換えない)。個別起動 (`npm run dev:editor` 等) は
+ *     EDITOR_PORT なしで従来どおり動き、vite のポートフォールバックに任せる。
+ */
+
+import net from 'node:net';
+import concurrently from 'concurrently';
+
+// 既定ポートセット。1 つでも埋まっていたらセットごと STEP ずつずらして再試行する。
+const BASE_PORTS = { editor: 5173, verify: 5174, workers: 8787 };
+const STEP = 10;
+const MAX_SETS = 10;
+
+const C = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  yellow: '\x1b[33m',
+  cyan: '\x1b[36m',
+};
+
+/**
+ * 指定ホストで port を listen 可能か (= 空いているか) を判定する。
+ * listen できれば空き。EADDRINUSE / EACCES は使用中。それ以外のエラー
+ * (EADDRNOTAVAIL 等 = そのホストで bind できない環境。IPv6 無効など) は
+ * 「そのスタックには誰もいない」とみなして空き扱いにする。
+ */
+function isFreeOnHost(port, host) {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.once('error', (err) => {
+      resolve(!(err.code === 'EADDRINUSE' || err.code === 'EACCES'));
+    });
+    server.once('listening', () => {
+      server.close(() => resolve(true));
+    });
+    // exclusive: true で SO_REUSEADDR による相乗り listen を防ぎ、既存プロセスとの
+    // 衝突を確実に EADDRINUSE として検出する。
+    server.listen({ port, host, exclusive: true });
+  });
+}
+
+/** IPv4 (127.0.0.1) と IPv6 (::1) の両方で空いているときだけ true */
+async function isPortFree(port) {
+  for (const host of ['127.0.0.1', '::1']) {
+    if (!(await isFreeOnHost(port, host))) return false;
+  }
+  return true;
+}
+
+/** セット内の全ポートが空いているか */
+async function isSetFree(ports) {
+  for (const port of Object.values(ports)) {
+    if (!(await isPortFree(port))) return false;
+  }
+  return true;
+}
+
+/** 空いているポートセットを探す。見つからなければ null */
+async function findFreeSet() {
+  for (let i = 0; i < MAX_SETS; i++) {
+    const offset = i * STEP;
+    const ports = {
+      editor: BASE_PORTS.editor + offset,
+      verify: BASE_PORTS.verify + offset,
+      workers: BASE_PORTS.workers + offset,
+    };
+    if (await isSetFree(ports)) return { ports, offset };
+  }
+  return null;
+}
+
+const found = await findFreeSet();
+if (!found) {
+  const lastEditor = BASE_PORTS.editor + (MAX_SETS - 1) * STEP;
+  console.error(
+    `${C.bold}空きポートセットが見つかりませんでした${C.reset} (${MAX_SETS} セット試行)。\n` +
+      `占有中のプロセスを調べるには:\n` +
+      `  ${C.cyan}lsof -nP -iTCP:${BASE_PORTS.editor}-${lastEditor} -sTCP:LISTEN${C.reset}\n` +
+      `不要な dev サーバを停止してから再実行してください。`
+  );
+  process.exit(1);
+}
+
+const { ports, offset } = found;
+
+// ---- バナー ----
+console.log('');
+if (offset > 0) {
+  console.log(
+    `${C.yellow}⚠ 既定ポート (${BASE_PORTS.editor}/${BASE_PORTS.verify}/${BASE_PORTS.workers}) の一部が使用中のため ` +
+      `+${offset} で起動します${C.reset}`
+  );
+}
+console.log(`${C.bold}dev servers${C.reset} ${C.dim}(ポートセット +${offset})${C.reset}`);
+console.log(`  ${C.cyan}editor ${C.reset} http://localhost:${ports.editor}/`);
+console.log(`  ${C.cyan}verify ${C.reset} http://localhost:${ports.verify}/`);
+console.log(`  ${C.cyan}workers${C.reset} http://localhost:${ports.workers}/`);
+console.log('');
+
+// ---- 起動 ----
+// 割り当てポートを環境変数で各 dev サーバへ渡す。editor/verify の vite.config は
+// EDITOR_PORT/VERIFY_PORT で server.port と proxy/VITE_API_URL を追従させ、workers は
+// --port フラグで wrangler dev のポートを固定する (env の WORKERS_PORT は editor 側の
+// VITE_API_URL 追従にも使う)。
+const env = {
+  ...process.env,
+  EDITOR_PORT: String(ports.editor),
+  VERIFY_PORT: String(ports.verify),
+  WORKERS_PORT: String(ports.workers),
+};
+
+const { result } = concurrently(
+  [
+    { command: 'npm run dev -w @typedcode/editor', name: 'editor', env, prefixColor: 'cyan' },
+    { command: 'npm run dev -w @typedcode/verify', name: 'verify', env, prefixColor: 'magenta' },
+    {
+      command: `npm run dev -w @typedcode/workers -- --port ${ports.workers}`,
+      name: 'workers',
+      env,
+      prefixColor: 'yellow',
+    },
+  ],
+  { prefix: 'name', killOthersOn: ['failure'] }
+);
+
+result.then(
+  () => process.exit(0),
+  () => process.exit(1)
+);


### PR DESCRIPTION
## 目的

別プロジェクト (例: subimage) や別 worktree の dev サーバがポートを占有していると、vite が黙って +1 ずつずれ、editor の `/verify` プロキシ (5174 固定) や `VITE_API_URL` (8787 固定) が**エラーも出さずに**古い残骸プロセスや別物へつながる。実際に「5173 を別プロジェクトに取られ、`npm run dev` すると verify ばかり目に付く」混乱が発生した。複数サービスの同時デバッグを無調整で共存させる。

Closes #196 / 設計判断は [ADR-0030](docs/adr/0030-dev-port-autoswitch.md)

## 変更点

- **`scripts/dev.mjs` (新規)**: `npm run dev` の起動ランチャー。既定セット {editor 5173, verify 5174, workers 8787} の 3 ポートがすべて空くまで**セットごと +10** (5183/5184/8797, …) で探索し (127.0.0.1 / ::1 の両方を検査、最大 10 セット)、決定値を `EDITOR_PORT` / `VERIFY_PORT` / `WORKERS_PORT` で各プロセスへ注入。concurrently に names (`editor`/`verify`/`workers`) と色を付け、起動バナーで実 URL を明示
- **`packages/editor/vite.config.ts`**: `server.port` / `/verify` プロキシ target を env から解決。`VITE_API_URL` は .env がローカル既定 (`http://localhost:<port>`) のときのみ実 workers ポートへ追従 (staging 等の外部 URL は非干渉)。ランチャー割当時は `strictPort: true` (黙認ずれ禁止)
- **`packages/verify/vite.config.ts`**: 同様に `server.port` + `strictPort`
- **`package.json`**: `"dev"` を `node scripts/dev.mjs` に。個別起動 (`dev:editor` 等) は従来どおり固定ポート + vite フォールバック
- **docs**: ADR-0030 追加、ADR 索引・CLAUDE.md・CONTRIBUTING (「併用するときはポートを変える」手動運用の置換) を更新

**変更しないもの**: workers の CORS (dev は localhost ポート不問許可済み)、e2e (`E2E_EDITOR_PORT`/`E2E_WORKERS_PORT` で既に可変・`EDITOR_PORT` 未設定起動のため干渉なし)

## 確認方法

実機 (5173 = 別プロジェクト、5174/5175/8787 = 既存 dev サーバが占有中) で検証済み:

```
$ npm run dev
⚠ 既定ポート (5173/5174/8787) の一部が使用中のため +10 で起動します
  editor  http://localhost:5183/
  verify  http://localhost:5184/
  workers http://localhost:8797/
```

- `curl http://localhost:5183/` → `<title>TypedCode</title>` / `:5184/` → `<title>TypedCode Verify</title>`
- `curl http://localhost:5183/verify/` → `<title>TypedCode Verify</title>` (プロキシが 5184 へ追従)
- `curl http://localhost:8797/health` → `{"status":"ok","environment":"development"}`
- 配信 JS 内で `VITE_API_URL` が `http://localhost:8797` に置換されていることを確認
- strictPort: 起動中に `EDITOR_PORT=5183 npm run dev:editor` → フォールバックせず即失敗 (exit 1)
- `npm run lint` / `npm run typecheck` / unit tests (editor 106, verify 14) すべて green

🤖 Generated with [Claude Code](https://claude.com/claude-code)