### PR TITLE
fix(editor): 単一タブ export の事前認証を best-effort 化する

### DIFF
--- a/packages/editor/src/export/ProofExporter.ts
+++ b/packages/editor/src/export/ProofExporter.ts
@@ -130,6 +130,31 @@ export class ProofExporter {
   }
 
   /**
+   * エクスポート前 Turnstile 認証が失敗/不達だったときの分岐 (単一タブ / 全タブ共通)。
+   *
+   * best-effort (`preExportBestEffort`) が有効なら、対象タブへ失敗 attestation を記録した
+   * うえで export を続行する (ADR-0006: サーバを critical path に置かない。教室の不安定網で
+   * 受講者が提出物を作れなくなるのを防ぐ)。素通しにはせず、「認証を試みたが取れなかった」
+   * 事実を必ずチェーンに残す。無効なら従来どおり通知して export を中止する。
+   *
+   * #224: 元は全タブ版の中にだけ定義されていて単一タブ版に分岐が無く、class/assignment が
+   * Turnstile 不達で単一タブ ZIP を出せなかった。二重定義を避けるためここへ集約する。
+   *
+   * @param tabs 失敗 attestation を記録する対象タブ (単一タブ export はアクティブタブのみ)
+   * @returns export を続行してよいか
+   */
+  private async failOrBestEffort(tabs: TabState[], reason: string): Promise<boolean> {
+    console.error('[Export] Pre-export verification failed:', reason);
+    if (this.preExportBestEffort) {
+      await this.recordBestEffortPreExportAttestation(tabs, reason);
+      return true; // 提出をブロックしない
+    }
+    this.exportProgressDialog.hide();
+    this.callbacks.onNotification?.(t('export.preAuthFailed'));
+    return false;
+  }
+
+  /**
    * エクスポート前にTurnstile検証を実行し、attestationを記録
    * ExportProgressDialogを使用して進行状況を表示
    */
@@ -143,14 +168,14 @@ export class ProofExporter {
       return true;
     }
 
+    // 失敗時は best-effort 判定へ。記録対象は成功経路と同じくアクティブタブのみ。
+    const failOrBestEffort = (reason: string): Promise<boolean> => this.failOrBestEffort([activeTab], reason);
+
     // Turnstileスクリプトを読み込む
     try {
       await loadTurnstileScript();
     } catch (error) {
-      console.error('[Export] Failed to load Turnstile script:', error);
-      this.exportProgressDialog.hide();
-      this.callbacks.onNotification?.(t('export.preAuthFailed'));
-      return false;
+      return failOrBestEffort(`script_load_failed: ${String(error)}`);
     }
 
     // ExportProgressDialogのTurnstileコンテナを使用
@@ -158,10 +183,7 @@ export class ProofExporter {
     const parentContainer = document.getElementById('export-turnstile-container');
 
     if (!widgetContainer) {
-      console.error('[Export] Turnstile container not found');
-      this.exportProgressDialog.hide();
-      this.callbacks.onNotification?.(t('export.preAuthFailed'));
-      return false;
+      return failOrBestEffort('turnstile_container_missing');
     }
 
     const result = await performTurnstileVerification('export_proof', {
@@ -170,10 +192,7 @@ export class ProofExporter {
     });
 
     if (!result.success || !result.attestation) {
-      console.error('[Export] Pre-export verification failed:', result.error);
-      this.exportProgressDialog.hide();
-      this.callbacks.onNotification?.(t('export.preAuthFailed'));
-      return false;
+      return failOrBestEffort(result.error ?? 'verification_failed');
     }
 
     // アクティブタブのTypingProofにエクスポート前attestationを記録
@@ -200,24 +219,15 @@ export class ProofExporter {
     this.exportProgressDialog.show();
     this.exportProgressDialog.updatePhase('verification');
 
-    if (!isTurnstileConfigured() || !this.tabManager) {
+    const tabManager = this.tabManager;
+    if (!isTurnstileConfigured() || !tabManager) {
       // 開発環境ではスキップ、次のフェーズへ
       return true;
     }
 
-    // 試験モードでは認証を best-effort 化: 試行して結果を記録するが、失敗/不達でも
-    // 提出 ZIP をブロックしない (ADR-0006: サーバを critical path に置かない)。
-    // 失敗時は best-effort の失敗 attestation を記録してエクスポートを続行する。
-    const failOrBestEffort = async (reason: string): Promise<boolean> => {
-      console.error('[Export] Pre-export verification failed:', reason);
-      if (this.preExportBestEffort) {
-        await this.recordBestEffortPreExportAttestation(reason);
-        return true; // 提出をブロックしない
-      }
-      this.exportProgressDialog.hide();
-      this.callbacks.onNotification?.(t('export.preAuthFailed'));
-      return false;
-    };
+    // 失敗時は best-effort 判定へ。記録対象は成功経路と同じく全タブ。
+    const failOrBestEffort = (reason: string): Promise<boolean> =>
+      this.failOrBestEffort(tabManager.getAllTabs(), reason);
 
     // Turnstileスクリプトを読み込む
     try {
@@ -244,7 +254,7 @@ export class ProofExporter {
     }
 
     // 全タブのTypingProofにエクスポート前attestationを記録
-    const allTabs = this.tabManager.getAllTabs();
+    const allTabs = tabManager.getAllTabs();
     for (const tab of allTabs) {
       await tab.typingProof.recordPreExportAttestation({
         success: true,
@@ -262,14 +272,12 @@ export class ProofExporter {
   }
 
   /**
-   * 試験モードで Turnstile 認証が失敗/不達のとき、全タブに best-effort の失敗
-   * attestation を記録する (ADR-0006)。これにより「認証を試みたが取得できなかった」
-   * 事実がチェーンに残りつつ、提出 ZIP の生成はブロックされない。
+   * Turnstile 認証が失敗/不達のとき、対象タブに best-effort の失敗 attestation を記録する
+   * (ADR-0006/0011)。これにより「認証を試みたが取得できなかった」事実がチェーンに残りつつ、
+   * 提出 ZIP の生成はブロックされない。exam / class / assignment で有効。
    */
-  private async recordBestEffortPreExportAttestation(reason: string): Promise<void> {
-    if (!this.tabManager) return;
-    const allTabs = this.tabManager.getAllTabs();
-    for (const tab of allTabs) {
+  private async recordBestEffortPreExportAttestation(tabs: TabState[], reason: string): Promise<void> {
+    for (const tab of tabs) {
       await tab.typingProof.recordPreExportAttestation({
         success: false,
         verified: false,
@@ -280,7 +288,9 @@ export class ProofExporter {
         signature: '',
       });
     }
-    console.warn(`[Export] Exam mode: pre-export attestation best-effort (recorded failure, not blocking): ${reason}`);
+    console.warn(
+      `[Export] pre-export attestation best-effort for ${tabs.length} tab(s) (recorded failure, not blocking): ${reason}`
+    );
   }
 
   /**

--- a/packages/editor/src/export/__tests__/ProofExporter.preExportVerification.test.ts
+++ b/packages/editor/src/export/__tests__/ProofExporter.preExportVerification.test.ts
@@ -1,0 +1,227 @@
+/**
+ * ProofExporter のエクスポート前 Turnstile 認証 (best-effort 分岐) のテスト。
+ *
+ * editor/CLAUDE.md 不変条件 6: export は Turnstile 検証を通すが、exam/class/assignment は
+ * `preExportBestEffort=true` で、不達/失敗でも**失敗 attestation を記録して**提出 ZIP を出す
+ * (ADR-0006/0011: 教室の不安定網で提出そのものを不能にしない)。casual は従来どおりブロックする。
+ *
+ * #224: 単一タブ用の `performPreExportVerification` にだけこの分岐が無く、class/assignment の
+ * 受講者が Turnstile 不達で単一タブ ZIP を一切出せなくなっていた。全タブ版と同じ意味論
+ * (失敗 attestation を記録してから続行) に揃えたことをここで固定する。
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { HumanAttestationEventData } from '@typedcode/shared';
+import type { TabManager, TabState } from '../../ui/tabs/TabManager.js';
+
+/** Turnstile 層の振る舞いを差し替えるためのハンドル (vi.mock はホイストされるので hoisted で共有)。 */
+const turnstile = vi.hoisted(() => ({
+  configured: true,
+  loadScript: async (): Promise<void> => {},
+  verify: async (): Promise<{ success: boolean; error?: string; attestation?: unknown }> => ({
+    success: true,
+    attestation: {
+      verified: true,
+      score: 1,
+      action: 'export_proof',
+      timestamp: '2026-08-05T00:00:00.000Z',
+      hostname: 'unit-test.local',
+      signature: 'sig',
+    },
+  }),
+}));
+
+/** ExportProgressDialog は DOM を触るのでモックし、hide 呼び出し回数だけ観測する。 */
+const progressDialog = vi.hoisted(() => ({
+  hideCount: 0,
+  turnstileContainer: {} as unknown as HTMLElement | null,
+}));
+
+vi.mock('../../services/TurnstileService.js', () => ({
+  isTurnstileConfigured: () => turnstile.configured,
+  loadTurnstileScript: () => turnstile.loadScript(),
+  performTurnstileVerification: () => turnstile.verify(),
+}));
+
+vi.mock('../../ui/components/ExportProgressDialog.js', () => ({
+  ExportProgressDialog: class {
+    show(): void {}
+    hide(): void {
+      progressDialog.hideCount++;
+    }
+    updatePhase(): void {}
+    updateProgress(): void {}
+    getTurnstileContainer(): HTMLElement | null {
+      return progressDialog.turnstileContainer;
+    }
+  },
+}));
+
+const { ProofExporter } = await import('../ProofExporter.js');
+
+/** private な検証メソッドを直接叩くためのビュー (export 全体は DOM/ZIP 依存が厚い)。 */
+interface PreExportVerifier {
+  performPreExportVerification(activeTab: TabState): Promise<boolean>;
+  performPreExportVerificationForAllTabs(): Promise<boolean>;
+}
+
+interface FakeTab {
+  tab: TabState;
+  attestations: HumanAttestationEventData[];
+}
+
+function makeTab(id: string): FakeTab {
+  const attestations: HumanAttestationEventData[] = [];
+  const tab = {
+    id,
+    typingProof: {
+      recordPreExportAttestation: async (attestation: HumanAttestationEventData) => {
+        attestations.push(attestation);
+      },
+    },
+  } as unknown as TabState;
+  return { tab, attestations };
+}
+
+function createExporter(tabs: FakeTab[], bestEffort: boolean) {
+  const exporter = new ProofExporter();
+  const notifications: string[] = [];
+  exporter.setPreExportBestEffort(bestEffort);
+  exporter.setCallbacks({ onNotification: (message) => notifications.push(message) });
+  exporter.setTabManager({
+    getAllTabs: () => tabs.map((t) => t.tab),
+    getActiveTab: () => tabs[0]?.tab ?? null,
+  } as unknown as TabManager);
+  return { exporter, verifier: exporter as unknown as PreExportVerifier, notifications };
+}
+
+beforeEach(() => {
+  turnstile.configured = true;
+  turnstile.loadScript = async () => {};
+  turnstile.verify = async () => ({
+    success: true,
+    attestation: {
+      verified: true,
+      score: 1,
+      action: 'export_proof',
+      timestamp: '2026-08-05T00:00:00.000Z',
+      hostname: 'unit-test.local',
+      signature: 'sig',
+    },
+  });
+  progressDialog.hideCount = 0;
+  progressDialog.turnstileContainer = {} as unknown as HTMLElement;
+  // node 環境には DOM が無い。検証経路が読む範囲だけ偽装する。
+  vi.stubGlobal('document', { getElementById: () => null });
+  vi.stubGlobal('window', { location: { hostname: 'unit-test.local' } });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('ProofExporter.performPreExportVerification (single tab, #224)', () => {
+  it('continues the export when the Turnstile script cannot be loaded in best-effort mode', async () => {
+    const tab = makeTab('tab-1');
+    const { verifier } = createExporter([tab], true);
+    turnstile.loadScript = async () => {
+      throw new Error('network down');
+    };
+
+    await expect(verifier.performPreExportVerification(tab.tab)).resolves.toBe(true);
+  });
+
+  it('records a failure attestation on the active tab when Turnstile is unreachable in best-effort mode', async () => {
+    const tab = makeTab('tab-1');
+    const { verifier } = createExporter([tab], true);
+    turnstile.loadScript = async () => {
+      throw new Error('network down');
+    };
+
+    await verifier.performPreExportVerification(tab.tab);
+
+    expect(tab.attestations).toEqual([
+      {
+        success: false,
+        verified: false,
+        score: 0,
+        action: 'export_proof',
+        timestamp: expect.any(String),
+        hostname: 'unit-test.local',
+        signature: '',
+      },
+    ]);
+  });
+
+  it('continues the export when Turnstile verification itself fails in best-effort mode', async () => {
+    const tab = makeTab('tab-1');
+    const { verifier } = createExporter([tab], true);
+    turnstile.verify = async () => ({ success: false, error: 'timeout' });
+
+    await expect(verifier.performPreExportVerification(tab.tab)).resolves.toBe(true);
+    expect(tab.attestations[0]?.success).toBe(false);
+  });
+
+  it('records the best-effort failure attestation only on the active tab', async () => {
+    const active = makeTab('tab-1');
+    const other = makeTab('tab-2');
+    const { verifier } = createExporter([active, other], true);
+    turnstile.verify = async () => ({ success: false, error: 'timeout' });
+
+    await verifier.performPreExportVerification(active.tab);
+
+    expect(active.attestations).toHaveLength(1);
+    expect(other.attestations).toHaveLength(0);
+  });
+
+  it('aborts the export and notifies the user when Turnstile fails and best-effort is disabled', async () => {
+    const tab = makeTab('tab-1');
+    const { verifier, notifications } = createExporter([tab], false);
+    turnstile.verify = async () => ({ success: false, error: 'timeout' });
+
+    await expect(verifier.performPreExportVerification(tab.tab)).resolves.toBe(false);
+    expect(tab.attestations).toHaveLength(0);
+    expect(notifications).toHaveLength(1);
+    expect(progressDialog.hideCount).toBe(1);
+  });
+
+  it('records a successful attestation on the active tab when Turnstile verification succeeds', async () => {
+    const tab = makeTab('tab-1');
+    const { verifier } = createExporter([tab], true);
+
+    await expect(verifier.performPreExportVerification(tab.tab)).resolves.toBe(true);
+    expect(tab.attestations[0]).toMatchObject({ success: true, verified: true, signature: 'sig' });
+  });
+
+  it('skips verification without recording an attestation when Turnstile is not configured', async () => {
+    const tab = makeTab('tab-1');
+    const { verifier } = createExporter([tab], false);
+    turnstile.configured = false;
+
+    await expect(verifier.performPreExportVerification(tab.tab)).resolves.toBe(true);
+    expect(tab.attestations).toHaveLength(0);
+  });
+});
+
+describe('ProofExporter.performPreExportVerificationForAllTabs', () => {
+  it('records a failure attestation on every tab when Turnstile fails in best-effort mode', async () => {
+    const first = makeTab('tab-1');
+    const second = makeTab('tab-2');
+    const { verifier } = createExporter([first, second], true);
+    turnstile.verify = async () => ({ success: false, error: 'timeout' });
+
+    await expect(verifier.performPreExportVerificationForAllTabs()).resolves.toBe(true);
+    expect(first.attestations[0]?.success).toBe(false);
+    expect(second.attestations[0]?.success).toBe(false);
+  });
+
+  it('aborts the export when Turnstile fails and best-effort is disabled', async () => {
+    const first = makeTab('tab-1');
+    const { verifier, notifications } = createExporter([first], false);
+    turnstile.verify = async () => ({ success: false, error: 'timeout' });
+
+    await expect(verifier.performPreExportVerificationForAllTabs()).resolves.toBe(false);
+    expect(first.attestations).toHaveLength(0);
+    expect(notifications).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## 目的

`Closes #224`

単一タブ用の `performPreExportVerification` に best-effort 分岐が無く、Turnstile 不達 / 失敗で無条件に export を中止していた。

class / assignment は `capabilities.preExportBestEffort=true` かつ汎用ダウンロードメニュー (`#export-current-tab-btn`) が生きている (CSS で非表示になるのは `body.exam-mode` だけ) ため、**教室の不安定網で受講者が単一タブ ZIP を一切出せず、提出そのものが不能**になっていた。

これは [packages/editor/CLAUDE.md](../blob/main/packages/editor/CLAUDE.md) の不変条件 6 —「export は exam/class/assignment は失敗 attestation を記録して提出 ZIP を出す」(ADR-0006/0011) — と正面から矛盾する。

## 変更点

`packages/editor/src/export/ProofExporter.ts`

- 全タブ版 (`performPreExportVerificationForAllTabs`) の中にローカル定義されていた `failOrBestEffort` を、**対象タブを引数に取る private メソッドへ抽出**して単一タブ版と共有した。今回の不具合の原因は「同じ判定が 2 箇所に別々に書かれていた」ことなので、単に分岐をコピーせず共通化して二重定義自体を解消している
- 単一タブ版の 3 つの失敗経路 (script load 失敗 / Turnstile コンテナ欠落 / 検証失敗) を共通経路に載せ替えた。理由文字列も全タブ版と同じ形式 (`script_load_failed: …` / `turnstile_container_missing` / `result.error ?? 'verification_failed'`)
- best-effort 有効時は **失敗 attestation を対象タブのチェーンへ記録してから** 続行する (記録なしの素通しにはしない = 監査証跡を消さない)。記録対象は成功経路と揃え、単一タブ版はアクティブタブのみ / 全タブ版は全タブ
- best-effort 無効 (casual) では従来どおり通知して中止する
- `recordBestEffortPreExportAttestation` を `(tabs, reason)` 受け取りに変更 (`this.tabManager` 依存を解消)。ログ文言も「試験モード」限定の表現をやめ、対象タブ数を出すようにした

**変えていないこと**: 失敗 attestation のペイロードは従来と完全に同一で、proof フォーマット・チェーンの意味づけは不変。exam の挙動 (`exportAllTabsAsZip` 経路) も変わらない。

`packages/editor/src/export/__tests__/ProofExporter.preExportVerification.test.ts` (新規)

不変条件 1 つにつき 1 ケースで固定した (計 9 ケース):

- best-effort 有効 + Turnstile 不達 → 単一タブ export が **続行する**
- best-effort 有効 + Turnstile 不達 → アクティブタブに **失敗 attestation が記録される**
- best-effort 有効 + Turnstile 検証失敗 → 続行する
- best-effort 有効 → 失敗 attestation は **アクティブタブにだけ** 記録される (他タブを汚さない)
- best-effort 無効 → 従来どおり中止 + 通知 + attestation を記録しない (回帰防止)
- 成功経路 → 成功 attestation が記録される
- Turnstile 未設定 (dev) → スキップし attestation を記録しない
- 全タブ版: best-effort 有効時は全タブに失敗 attestation を記録して続行する
- 全タブ版: best-effort 無効時は中止する

DOM / ZIP 依存が厚い `exportCurrentTab` 全体ではなく、不変条件が宿る検証メソッドを直接叩く粒度にした (`exportCurrentTab` はこの戻り値だけで早期 return を決めるため、これで十分に固定できる)。プロダクションコードの構造はテストのために変えていない。

## 確認方法

修正前に再現テストが **赤** になることを確認済み (4 failed / 5 passed)。さらに `preExportBestEffort` の判定を常に true に潰す変異を入れて、「best-effort 無効なら中止する」2 ケースが確かに落ちることも確認した (テストが空振りしないことの検証)。

作業ディレクトリで以下すべて green:

```
npm ci
npm run lint                              # exit 0 (警告数は main と同一 = 新規指摘なし)
npm run test:run --workspaces --if-present # editor 115 / shared 439 / verify 14 / verify-cli 15 / workers 50 すべて pass
npm run typecheck                         # 全 package pass
npm run build:editor                      # pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
