### PR TITLE
fix(verify): proof の mode を allowlist 検証しエスケープして XSS を塞ぐ

### DIFF
--- a/packages/verify/src/services/ResultDataService.ts
+++ b/packages/verify/src/services/ResultDataService.ts
@@ -15,6 +15,7 @@ import type {
   VerificationResult,
 } from '../types';
 import type { ResultData } from '../ui/ResultPanel';
+import { normalizeProofMode } from './proofMode.js';
 
 // Re-export from shared for backward compatibility
 export {
@@ -149,7 +150,8 @@ export function buildResultData(tabState: VerifyTabState): ResultData | null {
     content: proofData.content || '',
     language: tabState.language,
     // 自己申告モードラベル (ADR-0011)。参考表示のみ — 保証導出には使わない (ADR-0020)。
-    mode: proofData.mode,
+    // proof.json は攻撃者が組み立てられる入力なので、型を信用せず allowlist に落とす (#210)。
+    mode: normalizeProofMode(proofData.mode),
     result,
     poswStats,
     attestations: attestations.length > 0 ? attestations : undefined,

--- a/packages/verify/src/services/__tests__/ResultDataService.test.ts
+++ b/packages/verify/src/services/__tests__/ResultDataService.test.ts
@@ -1,0 +1,48 @@
+/**
+ * ResultDataService (buildResultData) の入力検証のテスト。
+ *
+ * proof.json は攻撃者が自由に組み立てられる入力。UI へ渡す ResultData を組み立てる
+ * この境界で、自己申告 mode を allowlist に落としておく (#210 の入力層の防御)。
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildResultData } from '../ResultDataService.js';
+import type { VerifyTabState } from '../../types.js';
+
+/** mode 以外は最小構成の検証済みタブ状態。 */
+function tabState(mode: unknown): VerifyTabState {
+  return {
+    id: 'tab-1',
+    filename: 'main.py',
+    language: 'python',
+    status: 'verified',
+    progress: 100,
+    proofData: {
+      mode,
+      content: '',
+      proof: { events: [] },
+    },
+    verificationResult: {
+      chainValid: true,
+      isPureTyping: true,
+    },
+  } as unknown as VerifyTabState;
+}
+
+describe('buildResultData — self-asserted mode', () => {
+  it('passes through a known mode', () => {
+    expect(buildResultData(tabState('exam'))?.mode).toBe('exam');
+  });
+
+  it('drops a mode carrying an HTML payload so the UI never renders it', () => {
+    expect(buildResultData(tabState('<img src=x onerror=alert(1)>'))?.mode).toBeUndefined();
+  });
+
+  it('drops an unknown mode label', () => {
+    expect(buildResultData(tabState('teacher'))?.mode).toBeUndefined();
+  });
+
+  it('leaves mode undefined for legacy proofs without the field', () => {
+    expect(buildResultData(tabState(undefined))?.mode).toBeUndefined();
+  });
+});

--- a/packages/verify/src/services/__tests__/proofMode.test.ts
+++ b/packages/verify/src/services/__tests__/proofMode.test.ts
@@ -1,0 +1,30 @@
+/**
+ * proof.json の自己申告モード (ADR-0011) の allowlist 検証のテスト。
+ *
+ * `ExportedProof.mode` は型の上では union だが実体は `JSON.parse` の結果なので、
+ * 実行時は任意の文字列が入りうる (#210)。表示層へ届く前にここで落とすことを固定する。
+ */
+
+import { describe, expect, it } from 'vitest';
+import { PROOF_MODES, normalizeProofMode } from '../proofMode.js';
+
+describe('normalizeProofMode', () => {
+  it.each(PROOF_MODES)('accepts the known mode %s', (mode) => {
+    expect(normalizeProofMode(mode)).toBe(mode);
+  });
+
+  it('rejects a mode carrying an HTML payload', () => {
+    expect(normalizeProofMode('<img src=x onerror=alert(1)>')).toBeUndefined();
+  });
+
+  it('rejects an unknown mode label', () => {
+    expect(normalizeProofMode('Exam')).toBeUndefined();
+  });
+
+  it('rejects non-string values', () => {
+    expect(normalizeProofMode(undefined)).toBeUndefined();
+    expect(normalizeProofMode(null)).toBeUndefined();
+    expect(normalizeProofMode(42)).toBeUndefined();
+    expect(normalizeProofMode({ toString: () => 'exam' })).toBeUndefined();
+  });
+});

--- a/packages/verify/src/services/proofMode.ts
+++ b/packages/verify/src/services/proofMode.ts
@@ -1,0 +1,24 @@
+/**
+ * proof の自己申告モード (ADR-0011) の入力検証。
+ *
+ * `ExportedProof.mode` は型の上では union だが、実体は `JSON.parse` の結果を cast した
+ * だけなので実行時は任意の文字列が入りうる。攻撃者が組み立てた proof.json の値をそのまま
+ * 表示層へ流すと、i18n の `t()` が未登録キーをキー文字列のまま返す性質と組み合わさって
+ * 任意の文字列が innerHTML に到達する (#210)。UI へ渡す前にここで allowlist に落とす。
+ *
+ * `mode` は参考表示のみで保証導出には使わない (ADR-0020) ため、未知の値は捨てて
+ * チップ自体を出さないのが正しい振る舞い (推測して既知の値に寄せない)。
+ */
+
+/** UI が受理する自己申告モード。shared の `ExportedProof['mode']` と同じ集合。 */
+export const PROOF_MODES = ['casual', 'class', 'assignment', 'exam'] as const;
+
+export type ProofMode = (typeof PROOF_MODES)[number];
+
+/**
+ * allowlist に一致する値だけを返す。未知の値・非文字列は `undefined` (= モードチップを出さない)。
+ */
+export function normalizeProofMode(value: unknown): ProofMode | undefined {
+  if (typeof value !== 'string') return undefined;
+  return PROOF_MODES.find((mode) => mode === value);
+}

--- a/packages/verify/src/ui/ResultPanel.ts
+++ b/packages/verify/src/ui/ResultPanel.ts
@@ -20,6 +20,7 @@ import type { SignedCheckpointsVerificationResult, ExamBindingVerificationResult
 import type { SignedCheckpointReport } from '../types';
 import { escapeHtml, type AnalysisReport, type AssuranceResult, type ProcessSummary } from '@typedcode/shared';
 import { SyntaxHighlighter } from '../services/SyntaxHighlighter.js';
+import type { ProofMode } from '../services/proofMode.js';
 import { AnalysisReportCard } from './AnalysisReportCard.js';
 import { ProcessSummaryCard } from './ProcessSummaryCard.js';
 import { t } from '../i18n/index.js';
@@ -41,8 +42,11 @@ export interface ResultData {
   assurance?: AssuranceResult;
   /** プロセス要約 (Phase 8 W3)。制作過程の中立な記述 (疑い指標ではない)。 */
   processSummary?: ProcessSummary;
-  /** proof の自己申告モード (ADR-0011)。参考表示のみで保証導出には使わない。 */
-  mode?: 'casual' | 'class' | 'assignment' | 'exam';
+  /**
+   * proof の自己申告モード (ADR-0011)。参考表示のみで保証導出には使わない。
+   * proof.json 由来なので `normalizeProofMode` を通した値だけを入れること (#210)。
+   */
+  mode?: ProofMode;
   /** 検証モード (Phase 5) */
   verificationMode?: VerificationMode;
   /** PoSW の実行モード (skipped / sampled / full) */
@@ -715,59 +719,7 @@ export class ResultPanel {
       return;
     }
     this.assuranceStrip.style.display = '';
-
-    const integrityClass = assurance.integrity === 'proven' ? 'success' : 'error';
-    const integrityValue =
-      assurance.integrity === 'proven' ? t('assurance.integrityProven') : t('assurance.integrityFailed');
-
-    let temporalClass: string;
-    let temporalValue: string;
-    switch (assurance.temporal) {
-      case 'anchored':
-        temporalClass = 'success';
-        temporalValue = t('assurance.temporalAnchored');
-        break;
-      case 'exam-t0':
-        temporalClass = 'success';
-        temporalValue = t('assurance.temporalExamT0');
-        break;
-      case 'partial':
-        temporalClass = 'warning';
-        temporalValue = t('assurance.temporalPartial');
-        break;
-      default:
-        temporalClass = 'warning';
-        temporalValue = t('assurance.temporalUnanchored');
-    }
-
-    const p = assurance.provenance;
-    const provenanceParts: string[] = [p.pureTyping ? t('assurance.pureTypingYes') : t('assurance.pureTypingNo')];
-    if (p.notableSignals !== null) {
-      provenanceParts.push(`${t('assurance.signals')} ${p.notableSignals}`);
-    }
-
-    const modeChip = mode
-      ? `<span class="assurance-chip neutral" title="${escapeHtml(t('assurance.modeSelfAsserted'))}">
-           <span class="assurance-chip-label">${t('assurance.modeLabel')}</span>
-           <span class="assurance-chip-value">${t(`assurance.mode.${mode}`)}</span>
-         </span>`
-      : '';
-
-    this.assuranceStrip.innerHTML = `
-      <span class="assurance-chip ${integrityClass}" title="${escapeHtml(t('assurance.integrityHint'))}">
-        <span class="assurance-chip-label">${t('assurance.integrity')}</span>
-        <span class="assurance-chip-value">${integrityValue}</span>
-      </span>
-      <span class="assurance-chip ${temporalClass}" title="${escapeHtml(t('assurance.temporalHint'))}">
-        <span class="assurance-chip-label">${t('assurance.temporal')}</span>
-        <span class="assurance-chip-value">${temporalValue}</span>
-      </span>
-      <span class="assurance-chip advisory" title="${escapeHtml(t('assurance.provenanceHint'))}">
-        <span class="assurance-chip-label">${t('assurance.provenance')}</span>
-        <span class="assurance-chip-value">${provenanceParts.map((x) => escapeHtml(x)).join(' · ')}</span>
-      </span>
-      ${modeChip}
-    `;
+    this.assuranceStrip.innerHTML = buildAssuranceStripHtml(assurance, mode);
   }
 
   private renderCard(iconEl: HTMLElement, badgeEl: HTMLElement, isValid: boolean | null, badgeText: string): void {
@@ -1671,4 +1623,67 @@ export class ResultPanel {
       </div>
     `;
   }
+}
+
+/**
+ * 三層保証バッジ列 (ADR-0020) の内側 HTML を組み立てる。`renderAssurance` の純粋部分。
+ *
+ * DOM に触れないので単体テストできる。**戻り値はそのまま innerHTML に入る** ため、
+ * 埋め込む値は例外なく `escapeHtml` を通すこと (#210)。
+ */
+export function buildAssuranceStripHtml(assurance: AssuranceResult, mode?: ResultData['mode']): string {
+  const integrityClass = assurance.integrity === 'proven' ? 'success' : 'error';
+  const integrityValue =
+    assurance.integrity === 'proven' ? t('assurance.integrityProven') : t('assurance.integrityFailed');
+
+  let temporalClass: string;
+  let temporalValue: string;
+  switch (assurance.temporal) {
+    case 'anchored':
+      temporalClass = 'success';
+      temporalValue = t('assurance.temporalAnchored');
+      break;
+    case 'exam-t0':
+      temporalClass = 'success';
+      temporalValue = t('assurance.temporalExamT0');
+      break;
+    case 'partial':
+      temporalClass = 'warning';
+      temporalValue = t('assurance.temporalPartial');
+      break;
+    default:
+      temporalClass = 'warning';
+      temporalValue = t('assurance.temporalUnanchored');
+  }
+
+  const p = assurance.provenance;
+  const provenanceParts: string[] = [p.pureTyping ? t('assurance.pureTypingYes') : t('assurance.pureTypingNo')];
+  if (p.notableSignals !== null) {
+    provenanceParts.push(`${t('assurance.signals')} ${p.notableSignals}`);
+  }
+
+  // mode は proof.json 由来 (自己申告) — 入力層で allowlist 済みだが、`t()` は未登録キーを
+  // キー文字列のまま返すため、表示層でも必ずエスケープする (#210 は二重に防ぐ)。
+  const modeChip = mode
+    ? `<span class="assurance-chip neutral" title="${escapeHtml(t('assurance.modeSelfAsserted'))}">
+         <span class="assurance-chip-label">${escapeHtml(t('assurance.modeLabel'))}</span>
+         <span class="assurance-chip-value">${escapeHtml(t(`assurance.mode.${mode}`))}</span>
+       </span>`
+    : '';
+
+  return `
+    <span class="assurance-chip ${integrityClass}" title="${escapeHtml(t('assurance.integrityHint'))}">
+      <span class="assurance-chip-label">${t('assurance.integrity')}</span>
+      <span class="assurance-chip-value">${integrityValue}</span>
+    </span>
+    <span class="assurance-chip ${temporalClass}" title="${escapeHtml(t('assurance.temporalHint'))}">
+      <span class="assurance-chip-label">${t('assurance.temporal')}</span>
+      <span class="assurance-chip-value">${temporalValue}</span>
+    </span>
+    <span class="assurance-chip advisory" title="${escapeHtml(t('assurance.provenanceHint'))}">
+      <span class="assurance-chip-label">${t('assurance.provenance')}</span>
+      <span class="assurance-chip-value">${provenanceParts.map((x) => escapeHtml(x)).join(' · ')}</span>
+    </span>
+    ${modeChip}
+  `;
 }

--- a/packages/verify/src/ui/__tests__/ResultPanel.test.ts
+++ b/packages/verify/src/ui/__tests__/ResultPanel.test.ts
@@ -1,0 +1,68 @@
+/**
+ * ResultPanel の三層保証バッジ列 (ADR-0020) を組み立てる純関数のテスト。
+ *
+ * ここで返る文字列は `#assurance-strip` の innerHTML にそのまま入る。proof.json 由来の
+ * 値 (自己申告 mode) が未エスケープで混ざると、検証ツール自身が乗っ取られて
+ * 「検証失敗」を「検証成功」に見せられる (#210)。エスケープを仕様として固定する。
+ */
+
+import { describe, expect, it } from 'vitest';
+import { escapeHtml, type AssuranceResult } from '@typedcode/shared';
+import { buildAssuranceStripHtml, type ResultData } from '../ResultPanel.js';
+
+/** 健全な anchored proof の保証導出結果。 */
+function assurance(): AssuranceResult {
+  return {
+    integrity: 'proven',
+    temporal: 'anchored',
+    provenance: { pureTyping: true, notableSignals: 0, reviewPriority: 0 },
+  };
+}
+
+/**
+ * 実行時の `mode` は `JSON.parse` の結果を union に cast しただけなので任意文字列が入りうる。
+ * 型では表現できない実行時の現実を再現するためのキャスト。
+ */
+function asMode(raw: string): ResultData['mode'] {
+  return raw as ResultData['mode'];
+}
+
+describe('buildAssuranceStripHtml', () => {
+  it('escapes a malicious mode so no element is injected into the assurance strip', () => {
+    const payload = '<img src=x onerror=alert(1)>';
+    const html = buildAssuranceStripHtml(assurance(), asMode(payload));
+
+    expect(html).not.toContain(payload);
+    expect(html).not.toContain('<img');
+    expect(html).toContain(escapeHtml(payload));
+  });
+
+  it('escapes a mode that would break out of the chip attribute quoting', () => {
+    const payload = '" onmouseover="alert(1)';
+    const html = buildAssuranceStripHtml(assurance(), asMode(payload));
+
+    expect(html).not.toContain(payload);
+    expect(html).toContain(escapeHtml(payload));
+  });
+
+  it('renders the localized label for a known mode', () => {
+    const html = buildAssuranceStripHtml(assurance(), 'exam');
+
+    // i18n キーがそのまま漏れていないこと (未登録キーは t() がキー文字列を返すため)
+    expect(html).not.toContain('assurance.mode.exam');
+    expect(html).toContain('assurance-chip-value');
+  });
+
+  it('omits the mode chip entirely when no mode is given', () => {
+    const html = buildAssuranceStripHtml(assurance(), undefined);
+
+    expect(html).not.toContain('assurance-chip neutral');
+  });
+
+  it('still renders the three deterministic chips', () => {
+    const html = buildAssuranceStripHtml(assurance(), 'casual');
+
+    expect(html).toContain('assurance-chip success');
+    expect(html).toContain('assurance-chip advisory');
+  });
+});


### PR DESCRIPTION
## 目的

`packages/verify` の三層保証バッジ (ADR-0020) の mode チップで、proof.json 由来の `mode` が
**escapeHtml を通さずに innerHTML** へ入っていた (#210, critical)。

成立条件は 2 つとも現行コードで成立していた:

1. `mode` は `ResultDataService.buildResultData` が `proofData.mode` を無検証で渡す値。型は
   `'casual'|'class'|'assignment'|'exam'` の union だが、実体は `JSON.parse` の結果を cast した
   だけなので実行時は任意文字列
2. `I18nService.t()` は未登録キーに対してキー文字列をそのまま返すため、
   `t('assurance.mode.<payload>')` が payload を含む文字列を返す

結果として、悪意ある `mode` を仕込んだ proof.json を採点者が verify で開いた瞬間に verify
オリジンで任意 JS が実行でき、`#assurance-strip` / ステータスタイトル / trust issue リストを
書き換えて **「検証失敗」を「検証成功」に見せられる**。第三者検証ツール自身が乗っ取られると
他のすべての保証表示が無意味になるため、二重に塞ぐ。

## 変更点

**入力層 (allowlist)** — 新規 `packages/verify/src/services/proofMode.ts`

- `PROOF_MODES` (`casual` / `class` / `assignment` / `exam`) と `normalizeProofMode(value: unknown)` を追加
- 未知の値・非文字列は `undefined` に落とす = **モードチップ自体を出さない** (推測して既知の値へ寄せない)
- `buildResultData` で `mode: normalizeProofMode(proofData.mode)` に変更。`buildResultData` は
  proof から `ResultData` を組み立てる唯一の経路 (`TabController.renderResult` のみが呼ぶ) なので、
  これで全レンダリング経路を覆う
- `ResultData['mode']` の型を `ProofMode` に付け替え、allowlist と型を単一ソースに揃えた

**表示層 (エスケープ)** — `packages/verify/src/ui/ResultPanel.ts`

- mode チップの値 (とラベル) を `escapeHtml` に通し、同ファイル内の他の innerHTML と同じ扱いに揃えた
- テスト可能にするため `renderAssurance` の純粋部分を `buildAssuranceStripHtml(assurance, mode)` として
  切り出した (DOM 非依存。出力の意味は変えていない)

**テスト** — 3 ファイル追加

- `ui/__tests__/ResultPanel.test.ts`: 悪意ある mode (`<img src=x onerror=alert(1)>` / 属性の
  クオートを閉じる payload) で **生の payload が出力に現れず、エスケープ形だけが現れる**ことを固定
- `services/__tests__/proofMode.test.ts`: 既知 4 値は通る / HTML payload・未知ラベル・非文字列は落ちる
- `services/__tests__/ResultDataService.test.ts`: 悪意ある `proofData.mode` が `ResultData.mode` に
  漏れないこと (入力層の回帰)

## 他の innerHTML 経路の洗い直し (#210 の「網羅的に洗い直す価値がある」への対応)

`packages/verify/src` の `innerHTML` 代入 **全 50 箇所**と、`insertAdjacentHTML` / `outerHTML` /
`document.write` (いずれも使用なし) を確認した。攻撃者制御データ (proof.json 由来・ZIP エントリ名・
manifest 由来) が未エスケープで入る経路は **本件以外に無かった**:

- `ResultPanel.buildAnchorDetailsHtml` / `buildKeyRowHtml` / `detailRow` (署名鍵 ID・説明・失敗理由): 全て escapeHtml 済み
- `ResultPanel.renderIssuesList` (trust issue メッセージ) / `updateScreenshotVerification`: escapeHtml 済み
- `ResultPanel.renderImage` (ファイル名), `renderDiffView` (差分行): escapeHtml 済み
- `AnalysisReportCard` (signal summary・evidence note) / `ProcessSummaryCard` (reflection notes): escapeHtml 済み
- `StatusBarUI.setQueueStatus` (ZIP エントリ名・パースエラー): escapeHtml 済み (#134 の修正が残っている)
- `SeekbarController.addLineNumbers` / `SyntaxHighlighter.highlight` (proof の content): 行ごとに escapeHtml、
  hljs 経路も出力がエスケープ済み
- `Sidebar` / `TabBar` のファイル名: `textContent` 経由
- `ScreenshotLightbox` / `ScreenshotOverlay` / `AboutDialog` / `ActivityBar` / `ChartEventSelector` /
  `FolderController` のダイアログ: 静的文字列と i18n のみ

補足 (本 PR の範囲外・別途起票の要否を判断したい点): `tabState.language` は proof.json の
`language` フィールド由来 (`JsonFileProcessor` / `ZipFileProcessor`) で、`ResultPanel` の
`codeEl.className = \`language-${language} hljs\`` に入る。**innerHTML ではなく className 代入なので
マークアップ注入は起きない** (任意の CSS クラスを code 要素に足せるだけ) が、同種の
「型を信用した proof 由来値」ではある。1 PR = 1 関心事のため本 PR では触っていない。

## 確認方法

作業ディレクトリで以下がすべて green:

```
npm ci
npm run lint                          # exit 0 (残る warning は main と同一の既存分)
npm run test:run -w @typedcode/verify # 4 files / 30 tests passed
npx tsc --noEmit -p packages/verify   # exit 0
npm run build:verify                  # exit 0
```

テストが実際にバグを捕まえることも確認済み:

- 修正前 (エスケープ・allowlist 無し) の状態でテストを走らせて **4 件 red** を確認
- 修正後に green を確認したうえで、エスケープと `normalizeProofMode` の両方を一時的に外して
  再度 **同じ 4 件が red** になることを確認 (壊しても緑のままのテストが無いことの確認)

検証ロジックの意味 (valid 判定) は変更していない。表示層と入力検証のみの修正。

Closes #210
