### PR TITLE
fix(shared): proof の events 要素を構造検証し metadata 水増しを塞ぐ

### DIFF
--- a/packages/shared/src/__tests__/eventStructureGate.test.ts
+++ b/packages/shared/src/__tests__/eventStructureGate.test.ts
@@ -1,0 +1,200 @@
+/**
+ * events 配列の構造ゲート (#221)
+ *
+ * 走査側は防御的に falsy 要素を読み飛ばす一方、`totalEvents` は `events.length` で数えていた。
+ * この非対称のせいで、正規 proof の events 末尾にゴミ要素を積んで `metadata.totalEvents` と
+ * `typingProofHash` を再計算するだけで、チェーン整合を保ったまま metadata を水増しできた。
+ * 再カウント (docs/system-spec.md §7 Layer 1) の手前で構造検証して弾くことを保証する。
+ *
+ * 注: PoSW は setup.ts の MockWorker が偽データを返すため、verifyProofFile は 'fast' モードで
+ * 呼ぶ (verifyChainModes.test.ts と同じ理由)。
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  TypingProof,
+  computeHash,
+  verifyEventArrayStructure,
+  verifyProofFile,
+  verifyProofMetadata,
+  type ExportedProof,
+  type FingerprintComponents,
+  type ProofFile,
+  type StoredEvent,
+} from '../index.js';
+
+const createMockFingerprintComponents = (): FingerprintComponents => ({
+  userAgent: 'Mozilla/5.0 (Event Structure Gate Test)',
+  language: 'en',
+  languages: ['en'],
+  platform: 'TestOS',
+  hardwareConcurrency: 4,
+  deviceMemory: 8,
+  screen: {
+    width: 1440,
+    height: 900,
+    availWidth: 1440,
+    availHeight: 860,
+    colorDepth: 24,
+    pixelDepth: 24,
+    devicePixelRatio: 2,
+  },
+  timezone: 'UTC',
+  timezoneOffset: 0,
+  canvas: 'mock-canvas',
+  webgl: { vendor: 'Mock', renderer: 'Mock' },
+  fonts: ['Arial'],
+  cookieEnabled: true,
+  doNotTrack: 'unspecified',
+  maxTouchPoints: 0,
+});
+
+/** 正規の (改ざんされていない) proof を 1 つ作る。 */
+async function buildGenuineProof(charCount = 3): Promise<{ exported: ExportedProof; content: string }> {
+  const components = createMockFingerprintComponents();
+  const fingerprintHash = await computeHash(JSON.stringify(components, null, 0));
+  const proof = new TypingProof();
+  await proof.initialize(fingerprintHash, components);
+
+  let content = '';
+  for (let i = 0; i < charCount; i++) {
+    const ch = String.fromCharCode('a'.charCodeAt(0) + i);
+    await proof.recordEvent({
+      type: 'contentChange',
+      inputType: 'insertText',
+      data: ch,
+      rangeOffset: content.length,
+      rangeLength: 0,
+    });
+    content += ch;
+  }
+
+  return { exported: await proof.exportProof(content), content };
+}
+
+/**
+ * 攻撃者がエクスポート済み JSON を編集する手順を再現する。
+ * 1. events 末尾にゴミ要素を積む
+ * 2. metadata.totalEvents を配列長に合わせる
+ * 3. typingProofHash を再計算する
+ * 秘密情報は要らず、sequence / previousHash / finalHash は実イベントのみで整合したままになる。
+ */
+async function forgeInflatedProof(
+  base: { exported: ExportedProof; content: string },
+  filler: unknown
+): Promise<ProofFile> {
+  // 実際の攻撃と同じく JSON を経由する (undefined は落ち、null はそのまま残る)。
+  const forged = JSON.parse(JSON.stringify(base.exported)) as ExportedProof;
+  (forged.proof.events as unknown[]).push(filler);
+  forged.typingProofData.metadata.totalEvents = forged.proof.events.length;
+  forged.typingProofHash = await computeHash(JSON.stringify(forged.typingProofData));
+  return { ...forged, content: base.content, language: 'text' };
+}
+
+let genuine: { exported: ExportedProof; content: string };
+
+beforeAll(async () => {
+  genuine = await buildGenuineProof(3);
+});
+
+describe('event array structure gate', () => {
+  it('accepts an untampered proof', async () => {
+    const proofFile: ProofFile = { ...genuine.exported, content: genuine.content, language: 'text' };
+    const result = await verifyProofFile(proofFile, undefined, { mode: 'fast' });
+
+    expect(result.valid).toBe(true);
+    expect(result.metadataValid).toBe(true);
+  });
+
+  it('rejects a proof padded with null events even after totalEvents and typingProofHash are recomputed', async () => {
+    const forged = await forgeInflatedProof(genuine, null);
+    const result = await verifyProofFile(forged, undefined, { mode: 'fast' });
+
+    expect(result.valid).toBe(false);
+    expect(result.metadataValid).toBe(false);
+    expect(result.errorMessage).toMatch(/Invalid event structure at event 3/);
+  });
+
+  it('rejects a proof padded with a string event', async () => {
+    const forged = await forgeInflatedProof(genuine, 'not-an-event');
+    const result = await verifyProofFile(forged, undefined, { mode: 'fast' });
+
+    expect(result.valid).toBe(false);
+    expect(result.metadataValid).toBe(false);
+  });
+
+  it('rejects a proof padded with a number event', async () => {
+    const forged = await forgeInflatedProof(genuine, 42);
+    const result = await verifyProofFile(forged, undefined, { mode: 'fast' });
+
+    expect(result.valid).toBe(false);
+    expect(result.metadataValid).toBe(false);
+  });
+
+  it('rejects a proof padded with an array event', async () => {
+    const forged = await forgeInflatedProof(genuine, []);
+    const result = await verifyProofFile(forged, undefined, { mode: 'fast' });
+
+    expect(result.valid).toBe(false);
+    expect(result.metadataValid).toBe(false);
+  });
+
+  it('rejects a null-padded proof before the recomputed totalTypingTime collapses to zero', async () => {
+    const forged = await forgeInflatedProof(genuine, null);
+    const result = verifyProofMetadata(forged.typingProofData, forged.proof.events);
+
+    expect(result.valid).toBe(false);
+    // 再カウント自体を行わないので、0 に落ちた totalTypingTime が申告値の照合に使われない。
+    expect(result.recomputedMetadata.totalTypingTime).toBe(0);
+    expect(result.recomputedMetadata.totalEvents).toBe(0);
+  });
+});
+
+describe('verifyEventArrayStructure', () => {
+  it('accepts the events of a genuine proof', () => {
+    expect(verifyEventArrayStructure(genuine.exported.proof.events)).toEqual({ valid: true });
+  });
+
+  it('accepts an empty events array', () => {
+    expect(verifyEventArrayStructure([])).toEqual({ valid: true });
+  });
+
+  it('reports the index of the first malformed event', () => {
+    const events = [...genuine.exported.proof.events] as unknown[];
+    events.splice(1, 0, null);
+
+    expect(verifyEventArrayStructure(events)).toMatchObject({ valid: false, errorAt: 1 });
+  });
+
+  it('rejects an events value that is not an array', () => {
+    expect(verifyEventArrayStructure({ length: 3 })).toMatchObject({
+      valid: false,
+      reason: 'Proof events is not an array',
+    });
+  });
+
+  it('rejects an event missing its posw block', () => {
+    const [first] = genuine.exported.proof.events;
+    const { posw: _posw, ...withoutPosw } = first as StoredEvent;
+
+    expect(verifyEventArrayStructure([withoutPosw])).toMatchObject({
+      valid: false,
+      reason: 'Invalid event structure at event 0: posw must be an object',
+    });
+  });
+
+  it('rejects an event whose sequence is not a number', () => {
+    const [first] = genuine.exported.proof.events;
+
+    expect(verifyEventArrayStructure([{ ...(first as StoredEvent), sequence: '0' }])).toMatchObject({
+      valid: false,
+      reason: 'Invalid event structure at event 0: sequence must be a finite number',
+    });
+  });
+
+  it('accepts an event whose previousHash is null (chain root without a fingerprint anchor)', () => {
+    const [first] = genuine.exported.proof.events;
+
+    expect(verifyEventArrayStructure([{ ...(first as StoredEvent), previousHash: null }])).toEqual({ valid: true });
+  });
+});

--- a/packages/shared/src/__tests__/verification.test.ts
+++ b/packages/shared/src/__tests__/verification.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  POSW_ITERATIONS,
   TypingProof,
   computeHash,
   verifyCheckpoints,
@@ -13,6 +14,36 @@ import {
   verifyProofMetadata,
 } from '../index.js';
 import type { ExportedProof, FingerprintComponents, ProofData, StoredEvent } from '../types.js';
+
+/**
+ * metadata 再カウントの意味論だけを見る最小イベント列を組み立てる。
+ *
+ * `verifyProofMetadata` は再カウントの手前で events の構造 (sequence / timestamp / type /
+ * previousHash / posw) を検査するため (#221)、観点に関係ないフィールドはここで既定値を埋める。
+ * これらは実際に export された proof が必ず持つフィールド (verifyChain も同じものを参照する)。
+ */
+const metadataEvents = (partials: Array<Partial<StoredEvent>>): StoredEvent[] =>
+  partials.map(
+    (partial, index) =>
+      ({
+        sequence: index,
+        timestamp: 0,
+        type: 'contentChange',
+        inputType: null,
+        data: null,
+        rangeOffset: null,
+        rangeLength: null,
+        range: null,
+        previousHash: null,
+        posw: {
+          iterations: POSW_ITERATIONS,
+          nonce: '0'.repeat(16),
+          intermediateHash: '0'.repeat(64),
+          computeTimeMs: 1,
+        },
+        ...partial,
+      }) as StoredEvent
+  );
 
 const createMockFingerprintComponents = (): FingerprintComponents => ({
   userAgent: 'Mozilla/5.0 (Verification Test)',
@@ -167,14 +198,14 @@ describe('verification utilities', () => {
   it('recomputes metadata and flags a multi-line bulk insertText as non-pure-typing', () => {
     // 複数行のコード一括投入 (AI/snippet) は bulk insert として数え、Pure Typing を崩す。
     // (単一行の補完は benign 扱いになったので、ここでは複数行で検出経路を検証する。)
-    const events = [
+    const events = metadataEvents([
       {
         type: 'contentChange',
         inputType: 'insertText',
         data: 'a\nb',
         timestamp: 10,
       },
-    ] as StoredEvent[];
+    ]);
     const proofData = {
       metadata: {
         totalEvents: 1,
@@ -205,9 +236,9 @@ describe('verification utilities', () => {
   it('treats a single-line editor completion up to the length cap as pure typing while still counting it in bulkInsertEvents', () => {
     // 1 キー入力 → 複数文字の正規な補完 (括弧自動閉じ・Tab 補完)。Pure Typing を崩さないが、
     // bulkInsertEvents の申告メタデータ照合は従来どおり数える (既存 proof と後方互換)。
-    const events = [
+    const events = metadataEvents([
       { type: 'contentChange', inputType: 'insertReplacementText', data: '()', timestamp: 10 },
-    ] as StoredEvent[];
+    ]);
     const proofData = {
       metadata: {
         totalEvents: 1,
@@ -233,7 +264,7 @@ describe('verification utilities', () => {
     // 改行を含まないため従来は「補完」扱いで isPureTyping=true を保てていた。
     // metadata 照合 (bulkInsertEvents=1) は従来どおり一致し valid は保つ (advisory のみの変化)。
     const oneLiner = 'const f=(n)=>n<2?n:f(n-1)+f(n-2);console.log(f(30));'.repeat(8); // 416 chars
-    const events = [{ type: 'contentChange', inputType: 'insertText', data: oneLiner, timestamp: 10 }] as StoredEvent[];
+    const events = metadataEvents([{ type: 'contentChange', inputType: 'insertText', data: oneLiner, timestamp: 10 }]);
     const proofData = {
       metadata: {
         totalEvents: 1,
@@ -256,7 +287,7 @@ describe('verification utilities', () => {
 
   it('flags a content-bearing insertFromInternalPaste as a bulk insert (forgery guard) but not the rangeOffset==null audit marker', () => {
     // 手製 proof が大きな挿入を「内部ペースト」と偽装するケース (rangeOffset あり = 実挿入)。
-    const forged = [
+    const forged = metadataEvents([
       {
         type: 'contentChange',
         inputType: 'insertFromInternalPaste',
@@ -264,7 +295,7 @@ describe('verification utilities', () => {
         rangeOffset: 0,
         timestamp: 10,
       },
-    ] as StoredEvent[];
+    ]);
     expect(
       verifyProofMetadata(
         {
@@ -285,7 +316,7 @@ describe('verification utilities', () => {
     ).toMatchObject({ valid: true, isPureTyping: false, suspiciousBulkInsertEventIndexes: [0] });
 
     // editor が出す正規の内部ペースト監査イベント (rangeOffset==null、replay 上スキップ) は flag しない。
-    const auditMarker = [
+    const auditMarker = metadataEvents([
       {
         type: 'contentChange',
         inputType: 'insertFromInternalPaste',
@@ -293,7 +324,7 @@ describe('verification utilities', () => {
         rangeOffset: null,
         timestamp: 10,
       },
-    ] as StoredEvent[];
+    ]);
     expect(
       verifyProofMetadata(
         {
@@ -318,7 +349,7 @@ describe('verification utilities', () => {
     // 手製 proof で「マーカー(data=AI コード) + insertParagraph(同一 data)」のペアを作る手口。
     // マーカーは自己申告なので根拠にせず、内容がセッション内に実在した replay 証拠を要求する。
     const ai = 'int solve() {\n  return 42;\n}\n';
-    const events = [
+    const events = metadataEvents([
       {
         type: 'contentChange',
         inputType: 'insertFromInternalPaste',
@@ -328,7 +359,7 @@ describe('verification utilities', () => {
         timestamp: 5,
       },
       { type: 'contentChange', inputType: 'insertParagraph', data: ai, rangeOffset: 0, rangeLength: 0, timestamp: 10 },
-    ] as StoredEvent[];
+    ]);
     const proofData = {
       metadata: {
         totalEvents: 2,
@@ -351,7 +382,7 @@ describe('verification utilities', () => {
   it('keeps a genuine internal paste of session-typed content as pure typing (#138)', () => {
     // 実際にセッション内で 1 文字ずつ打った内容をコピーして貼り直す正規フロー。
     // copyOperation がコピー時点の文書と突合され、複数行の実挿入が許可される。
-    const events = [
+    const events = metadataEvents([
       { type: 'contentChange', inputType: 'insertText', data: 'a', rangeOffset: 0, rangeLength: 0, timestamp: 1 },
       { type: 'contentChange', inputType: 'insertText', data: '\n', rangeOffset: 1, rangeLength: 0, timestamp: 2 },
       { type: 'contentChange', inputType: 'insertText', data: 'b', rangeOffset: 2, rangeLength: 0, timestamp: 3 },
@@ -372,7 +403,7 @@ describe('verification utilities', () => {
         rangeLength: 0,
         timestamp: 6,
       },
-    ] as StoredEvent[];
+    ]);
     const proofData = {
       metadata: {
         totalEvents: 6,
@@ -396,10 +427,10 @@ describe('verification utilities', () => {
     // 手製 proof が contentSnapshot 1 イベントで AI 解答全体を持ち込む laundering。
     // 挿入イベントが無いので paste/drop/bulk のどのカウントにも載らず、従来は
     // isPureTyping=true のまま通った。metadata 照合カウントは従来どおり (valid 不変)。
-    const events = [
+    const events = metadataEvents([
       { type: 'contentChange', inputType: 'insertText', data: 'a', rangeOffset: 0, rangeLength: 0, timestamp: 10 },
       { type: 'contentSnapshot', inputType: null, data: 'int solve() {\n  return 42;\n}\n', timestamp: 20 },
-    ] as StoredEvent[];
+    ]);
     const proofData = {
       metadata: {
         totalEvents: 2,
@@ -423,10 +454,10 @@ describe('verification utilities', () => {
   it('keeps pure typing for the regular contentSnapshot that matches the replayed document (#175)', () => {
     // editor が 100 イベント毎に出す正規 snapshot は取得時のエディタ内容 = replay 文書と
     // 常に一致する no-op。既存 proof の isPureTyping を変えない (後方互換)。
-    const events = [
+    const events = metadataEvents([
       { type: 'contentChange', inputType: 'insertText', data: 'a', rangeOffset: 0, rangeLength: 0, timestamp: 10 },
       { type: 'contentSnapshot', inputType: null, data: 'a', timestamp: 20 },
-    ] as StoredEvent[];
+    ]);
     const proofData = {
       metadata: {
         totalEvents: 2,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -44,6 +44,7 @@ export {
   verifyFinalChainHash,
   verifyContentReplay,
   verifyCheckpoints,
+  verifyEventArrayStructure,
   verifyProofMetadata,
   verifyTypingProofHash,
   verifyChain,
@@ -58,6 +59,7 @@ export type {
   PoswStats,
   VerificationMode,
   VerifyProofFileOptions,
+  EventArrayStructureResult,
 } from './verification.js';
 
 // Signed checkpoints (long-term verifiability)

--- a/packages/shared/src/verification.ts
+++ b/packages/shared/src/verification.ts
@@ -9,6 +9,7 @@ import type {
   ContentReplayVerificationResult,
   ProofMetadataVerificationResult,
   ProofData,
+  ProofMetadata,
   PoSWData,
   EventHashData,
   ExportedProof,
@@ -364,6 +365,97 @@ export function verifyFinalChainHash(
   return { valid: true, computedFinalHash: finalHash, expectedFinalHash: finalHash };
 }
 
+/** イベント配列の構造検証結果 (#221) */
+export interface EventArrayStructureResult {
+  valid: boolean;
+  reason?: string;
+  /** 最初に構造違反が見つかった要素の index。配列そのものが不正なときは undefined */
+  errorAt?: number;
+}
+
+/**
+ * `proof.proof.events` の各要素が構造的に `EventHashData` であることを検証する (#221)。
+ *
+ * 走査側 (`verifyChain` / `recomputeProofMetadata` / `verifyContentReplay`) は防御的に
+ * `if (!event) continue;` で falsy 要素を飛ばす一方、`totalEvents` は `events.length` で
+ * 数える。この非対称のせいで、正規 proof の末尾に `null` を積んで `metadata.totalEvents`
+ * と `typingProofHash` を再計算するだけで、チェーン整合 (sequence / previousHash /
+ * finalHash / 署名 cp) を保ったまま totalEvents を水増しできた。さらに末尾が `null` だと
+ * `totalTypingTime` の再計算が 0 に落ちて `claimed < recomputed` 検査も無力化する。
+ *
+ * そこで「数える対象」と「走査される対象」が必ず一致するよう、再カウント (docs/system-spec.md
+ * §7 の Layer 1) の**手前**で構造を検査して弾く。検査は最低限のフィールド
+ * (sequence / timestamp / type / previousHash / posw) に留め、proof フォーマット自体は
+ * 変えない — 正規に export された proof は `MIN_SUPPORTED_VERSION` の頃から
+ * これらを常に持つため、既存 proof の検証性は変わらない。
+ */
+export function verifyEventArrayStructure(events: unknown): EventArrayStructureResult {
+  if (!Array.isArray(events)) {
+    return { valid: false, reason: 'Proof events is not an array' };
+  }
+
+  for (let i = 0; i < events.length; i++) {
+    const event: unknown = events[i];
+
+    if (typeof event !== 'object' || event === null || Array.isArray(event)) {
+      return { valid: false, reason: `Invalid event structure at event ${i}: expected an object`, errorAt: i };
+    }
+
+    const candidate = event as Record<string, unknown>;
+
+    if (typeof candidate.sequence !== 'number' || !Number.isFinite(candidate.sequence)) {
+      return {
+        valid: false,
+        reason: `Invalid event structure at event ${i}: sequence must be a finite number`,
+        errorAt: i,
+      };
+    }
+
+    if (typeof candidate.timestamp !== 'number' || !Number.isFinite(candidate.timestamp)) {
+      return {
+        valid: false,
+        reason: `Invalid event structure at event ${i}: timestamp must be a finite number`,
+        errorAt: i,
+      };
+    }
+
+    if (typeof candidate.type !== 'string') {
+      return { valid: false, reason: `Invalid event structure at event ${i}: type must be a string`, errorAt: i };
+    }
+
+    if (typeof candidate.previousHash !== 'string' && candidate.previousHash !== null) {
+      return {
+        valid: false,
+        reason: `Invalid event structure at event ${i}: previousHash must be a string or null`,
+        errorAt: i,
+      };
+    }
+
+    const posw = candidate.posw;
+    if (typeof posw !== 'object' || posw === null || Array.isArray(posw)) {
+      return { valid: false, reason: `Invalid event structure at event ${i}: posw must be an object`, errorAt: i };
+    }
+  }
+
+  return { valid: true };
+}
+
+/**
+ * 構造検証で弾いたときに返す再計算メタデータ。再計算そのものを行わないのでゼロ埋めする
+ * (呼び出し側は `valid: false` の `reason` を見る)。呼び出しごとに新しい object を返す。
+ */
+const uncountedMetadata = (): ProofMetadata => ({
+  totalEvents: 0,
+  pasteEvents: 0,
+  internalPasteEvents: 0,
+  dropEvents: 0,
+  insertEvents: 0,
+  deleteEvents: 0,
+  bulkInsertEvents: 0,
+  totalTypingTime: 0,
+  averageTypingSpeed: 0,
+});
+
 function recomputeProofMetadata(events: StoredEvent[]): ProofMetadataVerificationResult {
   let pasteEvents = 0;
   let internalPasteEvents = 0;
@@ -440,8 +532,24 @@ function recomputeProofMetadata(events: StoredEvent[]): ProofMetadataVerificatio
 
 /**
  * Recompute proof metadata from events and compare self-reported counts.
+ *
+ * 再カウントの前に `verifyEventArrayStructure` で events の構造を検査する (#221)。
+ * verify (web) の verificationWorker と verify-cli (`verifyProofFile` 経由) は
+ * どちらも必ず本関数を通るため、構造検証はここ 1 箇所で両経路に効く。
  */
 export function verifyProofMetadata(proofData: ProofData, events: StoredEvent[]): ProofMetadataVerificationResult {
+  const structure = verifyEventArrayStructure(events);
+  if (!structure.valid) {
+    return {
+      valid: false,
+      reason: structure.reason,
+      isPureTyping: false,
+      recomputedMetadata: uncountedMetadata(),
+      suspiciousBulkInsertEventIndexes: [],
+      divergentContentSnapshotEventIndexes: [],
+    };
+  }
+
   const result = recomputeProofMetadata(events);
   const claimed = proofData.metadata;
   const recomputed = result.recomputedMetadata;


### PR DESCRIPTION
## 目的

`events` 配列の要素型が未検証で、`null` 要素により `totalEvents` / `totalTypingTime` を水増しできる問題 (#221, security/high) を塞ぐ。

検証経路 (`verifyChain` / `recomputeProofMetadata` / `verifyContentReplay`) は `if (!event) continue;` で falsy 要素を黙って読み飛ばす一方、`recomputeProofMetadata` の `totalEvents` は `events.length` で数えていた。この非対称のため、秘密情報なしで次の手順が成立していた。

1. 正規 proof の `events` 末尾に `null` を大量に積む
2. `typingProofData.metadata.totalEvents` を配列長に合わせる
3. `typingProofHash` を再計算する

sequence / previousHash / finalHash / 署名チェックポイントはすべて実イベントのみで整合するため、**`valid: true` のまま totalEvents を任意に水増しできた**。さらに末尾が `null` だと `totalTypingTime` の再計算が `events[events.length-1]?.timestamp ?? 0` → 0 に落ち、`claimed < recomputed` 検査も無力化していた。

docs/system-spec.md §7 の攻撃マトリクス「metadata の偽装は Layer 1 の再カウントで検出」という保証が破れている状態だった。

## 変更点

- `packages/shared/src/verification.ts`
  - `verifyEventArrayStructure(events)` を追加。`events` が配列であり、全要素が `sequence` (有限数) / `timestamp` (有限数) / `type` (string) / `previousHash` (string | null) / `posw` (object) を持つ object であることを検証する。最初の違反要素の index を `errorAt` で返す
  - `verifyProofMetadata` の**先頭**でこのゲートを通す。通らなければ再カウントを行わず `valid: false` で返す
- `packages/shared/src/index.ts`: `verifyEventArrayStructure` / `EventArrayStructureResult` を公開
- `packages/shared/src/__tests__/eventStructureGate.test.ts` (新規): 攻撃再現と構造検証の単体テスト
- `packages/shared/src/__tests__/verification.test.ts`: metadata 系 fixture を構造を満たす `metadataEvents` ヘルパ経由に変更 (アサーションは変更なし)

### ゲートを `verifyProofMetadata` に置いた理由

Issue の修正案は「parse 直後の入口」だが、**verify (web) と verify-cli が共通で必ず通る入口は parse 段階には存在しない**。

- verify (web) は `packages/verify/src/workers/verificationWorker.ts` が shared の検証関数群を直接呼ぶ。`verifyProofFile` は使わない
- verify (web) は shared の `fileProcessing/parser.ts` (`isProofFile`) を使わない (verify 独自の `FileProcessor` / `ZipFileProcessor`)
- verify-cli は `verifyProofFile` 経由

両者が共通で必ず通り、かつ壊れている保証 (Layer 1 の再カウント) そのものを担うのが `verifyProofMetadata` なので、ここ 1 箇所に置いた。web/CLI どちらも `metadataValid = false` → 全体 invalid に伝播する。

既存の `if (!event) continue;` は防御的コードとしてそのまま残している。

### 後方互換

検査する 5 フィールドはいずれも **`verifyChain` が既に無条件で参照・比較しているもの** (`event.sequence` / `event.timestamp` / `event.previousHash` / `event.posw.iterations`) なので、これらを欠く proof は現時点でも検証を通らない。したがって**現在検証できる正規 proof が新たに弾かれることはない** (`MIN_SUPPORTED_VERSION` 1.0.0 の proof を含む)。proof フォーマット自体は変更していない。

## 確認方法

先に再現テストを書き、修正を一時的に無効化して赤くなること (攻撃シナリオ 5 件が fail) を確認してから仕上げた。

```
npm ci
npm run lint                              # 0 errors (warnings 60 は main と同数)
npm run test:run -w @typedcode/shared     # 452 passed / 3 skipped
npm run test:run --workspaces --if-present # editor 106 / shared 452 / verify 14 / verify-cli 15 / workers 50 すべて green
npm run build                             # 全パッケージ成功
```

追加テスト (`eventStructureGate.test.ts`, 13 件):

- 正規 proof が引き続き valid (回帰防止)
- `null` を積んで `totalEvents` と `typingProofHash` を再計算した proof が reject される (攻撃再現)
- 文字列 / 数値 / 配列を積んだ proof が reject される
- 0 に落ちた `totalTypingTime` が申告値の照合に使われない
- `verifyEventArrayStructure` の単体 (空配列は valid / 最初の違反 index / 非配列 / posw 欠落 / sequence 型違反 / `previousHash: null` は許容)

## 残課題 (このPRの範囲外)

`summarizeProcess` (`packages/shared/src/processSummary.ts:147` の `events[i]!`) など advisory 層は `null` 要素で TypeError を投げうる。verify-cli は本 PR の後も「検証は invalid と判定 → その後 advisory 層で例外 → cli.ts の catch で exit 1」という経路になり、判定自体は正しいがメッセージが分かりにくい。別 Issue にするのが妥当 (#221 でも副作用として言及されている)。

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)
