### PR TITLE
test(e2e): 署名済み checkpoint の取得を happy-path で assert する

### DIFF
--- a/packages/e2e/tests/happy-path.spec.ts
+++ b/packages/e2e/tests/happy-path.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
-import { EditorApp, readProofEvents } from './helpers/app.js';
+import { EditorApp, readProofEvents, readProofJson } from './helpers/app.js';
+import type { ProofCheckpoint } from './helpers/app.js';
 import { runVerifyCliWithAnalysis } from './helpers/verifyCli.js';
 
 /**
@@ -55,4 +56,23 @@ test('casual: 打鍵→export→CLI 検証が pass する', async ({ page }) => 
     events.some((e) => e.type === 'screenShareOptOut'),
     'screenShareOptOut recorded at startup (casual defaults to opt-out)'
   ).toBe(true);
+
+  // ④ 時刻アンカリング (#228): `/api/checkpoint/sign` 経路が生きていて、署名済み
+  // checkpoint envelope が実際に proof に載っている。ADR-0004 により未アンカーの proof も
+  // valid なので、sign API が恒常 401 になっても export は console.warn だけで成功し
+  // verify-cli も exit 0 を返す。ここで envelope そのものを見張らないと、時刻アンカリングの
+  // 全損が E2E 緑のまま本番へ抜ける (rootAnchored / sessionStartToken は `/api/session/start`
+  // 経路であり、close-tab-recovery.spec が担当する別経路)。
+  const proof = (await readProofJson(zipPath)) as { checkpoints?: ProofCheckpoint[] };
+  const signed = (proof.checkpoints ?? []).filter((cp) => cp.signature);
+  expect(signed.length, 'at least one checkpoint carries a signed envelope').toBeGreaterThan(0);
+
+  // envelope が中身のある応答であること (署名サービスが本当に応答した) の軽い確認。
+  // **深追いはしない**: envelope が 1 つでも載っていれば ① の verify-cli が payload の
+  // 全フィールド・鍵解決・署名・連鎖・root 一致まで厳密に検証し、壊れていれば exit 1 になる。
+  // この spec が独自に守るのは「envelope が 1 つも無い」という verify-cli には見えない穴だけ。
+  const envelope = signed[0]!.signature!;
+  expect(envelope.keyId, 'signed checkpoint carries a keyId').toBeTruthy();
+  expect(envelope.signature, 'signed checkpoint carries a signature').toBeTruthy();
+  expect(envelope.payload?.serverTimestamp, 'server-side timestamp is the anchor itself').toBeTruthy();
 });

--- a/packages/e2e/tests/helpers/app.ts
+++ b/packages/e2e/tests/helpers/app.ts
@@ -269,6 +269,25 @@ export interface ProofEvent {
   [k: string]: unknown;
 }
 
+/**
+ * 署名済み checkpoint envelope (`/api/checkpoint/sign` の戻り) の緩い型。
+ * 全フィールドを optional にしてあるのは、E2E が assert したいのが「envelope が実在して
+ * 中身が空でない」ことだけだから (payload の厳密な検証は verify-cli と shared が担う)。
+ */
+export interface ProofSignedCheckpoint {
+  payload?: { serverTimestamp?: string; [k: string]: unknown };
+  signature?: string;
+  keyId?: string;
+  [k: string]: unknown;
+}
+
+/** proof の checkpoint 1 件 (署名 envelope の有無を見るための緩い型)。 */
+export interface ProofCheckpoint {
+  eventIndex?: number;
+  signature?: ProofSignedCheckpoint;
+  [k: string]: unknown;
+}
+
 /** ZIP 内の最初の proof.json 全体を読み出す (rootAnchored / sessionStartToken 等のトップレベル assert 用)。 */
 export async function readProofJson(zipPath: string): Promise<Record<string, unknown>> {
   const buf = await readFileBuffer(zipPath);


### PR DESCRIPTION
## 目的

E2E の全 spec が **署名済み checkpoint envelope の存在を一度も assert していない**という盲点を塞ぐ。

ADR-0004 により未アンカーの proof も valid（これは正しい仕様）なので、`/api/checkpoint/sign` が恒常 401 になる回帰が起きても:

1. `ProofExporter` は `console.warn` するだけで export は成功する
2. verify-cli は unanchored proof を valid と判定して exit 0
3. **全 E2E が緑のまま**、時刻アンカリングの全損が staging / production に到達する

`close-tab-recovery.spec.ts` が assert している `rootAnchored` / `sessionStartToken` は `/api/session/start` 経路であり、`/api/checkpoint/sign` 経路は未カバーだった。

## 変更点

- `packages/e2e/tests/happy-path.spec.ts`: export した proof.json を読み、**署名 envelope を持つ checkpoint が 1 つ以上ある**ことを assert（④ として追加）。あわせて envelope が空応答でないこと（`keyId` / `signature` / `payload.serverTimestamp` が非空）を軽く確認する
- `packages/e2e/tests/helpers/app.ts`: 既存の `ProofEvent` と同じ方針の緩い型 `ProofCheckpoint` / `ProofSignedCheckpoint` を追加（e2e は `@typedcode/shared` に依存していないため）

### 意図的に「深追いしない」設計

envelope が 1 つでも載っていれば、verify-cli が payload 全フィールド・鍵解決・署名・連鎖・**root 一致**まで厳密に検証して exit 1 になる（`signedCheckpoints.ts` の `verifySignedCheckpoints`）。実際、クライアントが誤った `initialEventChainHash` で署名要求するよう壊して試したところ、既存の ① の assert が `Signed checkpoint initialEventChainHash does not match proof root` で先に赤くなった。

したがって envelope 内容の厳密な assert は verify-cli と shared のユニットテストに任せ、**この spec が独自に守るのは「envelope が 1 つも無い」という verify-cli には構造的に見えない穴だけ**に絞っている（CLAUDE.md 不変条件 1「オラクルは verify-cli の結論」に沿う）。

### CI 時間

新しい spec ファイルは追加せず既存 spec への追記に留めたので、増分は proof.json の追加読み出しのみで実質ゼロ。`--mode fast` 方針（不変条件 4）にも影響しない。

## 確認方法

すべて worktree のローカルで実行:

```
npm ci
npm run setup -w @typedcode/e2e   # Turnstile テストキー + checkpoint 署名鍵を実行時生成
npm run lint                      # exit 0（新規の指摘なし）
npm run typecheck -w @typedcode/e2e  # exit 0
npx playwright test               # 17 passed (2.0m)
```

### assert が本当に意味を持つことの確認（意図的な破壊）

Workers の `/api/checkpoint/sign` を一時的に恒常 401 を返すよう改変して happy-path を実行:

```
[workers] POST /api/checkpoint/sign 401 Unauthorized  (x7, backoff リトライ)
[editor]  [SignedCheckpointService] giving up on checkpoint event=127 after 10 attempts: HTTP 401 TOKEN_INVALID

  ✘  tests/happy-path.spec.ts:15:1 › casual: 打鍵→export→CLI 検証が pass する

    Error: at least one checkpoint carries a signed envelope
    expect(received).toBeGreaterThan(expected)
    Expected: > 0
    Received:   0
```

**追加した assert だけが赤くなり、その手前の既存 assert（verify-cli exit 0 / `Verification PASSED` / `Pure Typing: YES` / analysis valid）はすべて緑のままだった** — Issue が指摘する「正しい仕様が署名経路の全損を CI から見えなくしている」構造がそのまま再現され、本 PR がそれを塞いでいることを確認。改変は確認後に revert 済み（作業ツリーに残っていないことを `grep TEMP-BREAK` で確認）。

Closes #228