### PR TITLE
fix(editor): drain 未完了時に content と chain が食い違う proof を export しない

### DIFF
--- a/packages/editor/src/export/ProofExporter.ts
+++ b/packages/editor/src/export/ProofExporter.ts
@@ -26,6 +26,11 @@ export interface ExportCallbacks {
 }
 
 export class ProofExporter {
+  /** 記録キュー排出待ち (#225): 残件が減らないまま何 ms 経ったら諦めるか。 */
+  private static readonly DRAIN_STALL_MS = 5000;
+  /** 記録キュー排出待ち (#225): 進捗が続いていても待ち続ける上限。無限待ちを防ぐ。 */
+  private static readonly DRAIN_MAX_WAIT_MS = 60000;
+
   private tabManager: TabManager | null = null;
   private processingDialog: ProcessingDialog | null = null;
   private exportProgressDialog: ExportProgressDialog;
@@ -294,6 +299,42 @@ export class ProofExporter {
   }
 
   /**
+   * 記録キューの排出を待ち、待ちきれなければ export を中止する (#225)。
+   *
+   * export は `model.getValue()` を content として焼くが、exportProof が同梱する events は
+   * 排出済みイベントのスナップショットしか含まない。排出しきれないまま export すると
+   * 「content にはあるが chain には無い」proof になり、content replay (検証 Layer 4) が
+   * 最終内容と一致せず **proof 全体が invalid** になる — 学生に過失が無いまま答案が検証不能
+   * になるので絶対に出さない。content を replay 結果へ切り詰める案 (#225 の選択肢 A) は
+   * 「画面に見えている直前の打鍵が提出物から黙って消える」ためデータ欠落として採らない
+   * (復元経路の `reconcileRestoredContent` が切り詰めるのは、クラッシュ後で buffer を信用
+   * できずチェーンだけが真実という別状況だから)。
+   *
+   * 待ち方は進捗ベース: PoSW は Worker 障害時もメインスレッドにフォールバックして必ず完了
+   * するので、排出が終わらない主因は「キューが長い」。残件が減り続けている限り待ち、
+   * 停滞したときだけ諦める (上限 `DRAIN_MAX_WAIT_MS`)。長引く間は残件数をダイアログに出す。
+   *
+   * @returns export を続行してよいか
+   */
+  private async drainQueueOrAbort(tab: TabState): Promise<boolean> {
+    const result = await tab.typingProof.waitForQueueDrain({
+      stallTimeoutMs: ProofExporter.DRAIN_STALL_MS,
+      maxWaitMs: ProofExporter.DRAIN_MAX_WAIT_MS,
+      onProgress: (remaining) => {
+        if (remaining > 0) this.exportProgressDialog.showDrainProgress(remaining);
+      },
+    });
+    if (result.drained) return true;
+
+    console.error(
+      `[ProofExporter] tab ${tab.id}: event queue did not drain (${result.reason}, ${result.remaining} remaining after ${Math.round(result.waitedMs)}ms); aborting export to avoid a proof whose content is not on the chain`
+    );
+    this.exportProgressDialog.hide();
+    this.callbacks.onNotification?.(t('export.queueNotDrained'));
+    return false;
+  }
+
+  /**
    * タイムスタンプ文字列を生成
    */
   private generateTimestamp(): string {
@@ -350,11 +391,11 @@ export class ProofExporter {
       // エクスポート前に明示的に同期を取る必要がある
       await this.tabManager?.flushToIndexedDB();
 
-      // #143: 直前の打鍵がまだ PoSW キューにあると「content には載っているのに
-      // チェーンに無い」export になり content replay で fail する。先に排出を待つ。
-      const drained = await activeTab.typingProof.waitForQueueDrain(5000);
-      if (!drained) {
-        console.warn('[ProofExporter] event queue did not drain within 5s; exporting the chain-consistent snapshot');
+      // #143/#225: 直前の打鍵がまだ PoSW キューにあると「content には載っているのに
+      // チェーンに無い」export になり content replay で fail する。先に排出を待ち、
+      // 待ちきれなければ export を中止する。
+      if (!(await this.drainQueueOrAbort(activeTab))) {
+        return;
       }
       const content = activeTab.model.getValue();
       // exportProof() は最終 checkpoint を作成して onCheckpointCreated フックを発火する。
@@ -529,12 +570,11 @@ export class ProofExporter {
           total: allTabs.length,
         });
 
-        // #143: waitForProcessingComplete はアクティブタブしか待たない。タブ毎に
-        // キュー排出を待ってから content を確定する (排出しきれなくてもスナップショット
-        // 一貫性で proof 自体は整合するが、直前の打鍵が export に載らない)。
-        const drained = await tab.typingProof.waitForQueueDrain(5000);
-        if (!drained) {
-          console.warn(`[ProofExporter] tab ${tab.id}: event queue did not drain within 5s`);
+        // #143/#225: waitForProcessingComplete はアクティブタブしか待たない。タブ毎に
+        // キュー排出を待ってから content を確定する。1 タブでも排出しきれなければ
+        // ZIP 全体を中止する (そのタブだけ invalid な proof を混ぜない)。
+        if (!(await this.drainQueueOrAbort(tab))) {
+          return;
         }
         const content = tab.model.getValue();
         const proof = await tab.typingProof.exportProof(content);

--- a/packages/editor/src/export/__tests__/ProofExporter.drainConsistency.test.ts
+++ b/packages/editor/src/export/__tests__/ProofExporter.drainConsistency.test.ts
@@ -1,0 +1,233 @@
+/**
+ * ProofExporter の「content と chain の一貫性」テスト (#225)。
+ *
+ * export は `model.getValue()` を content として proof に焼くが、exportProof が同梱する
+ * events は記録キュー排出済みのスナップショットしか含まない。直前の打鍵がまだ PoSW キューに
+ * 残ったまま export すると「content にはあるが chain には無い」proof になり、
+ * content replay (検証 Layer 4) で **proof 全体が invalid** になる。学生に過失が無いまま
+ * 答案が検証不能になるので、排出できなかったときは **export を中止**して再試行させる
+ * (content を切り詰めると提出物からデータが黙って消えるため採らない)。
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import JSZip from 'jszip';
+import { TypingProof, computeHash, verifyContentReplay } from '@typedcode/shared';
+import type { FingerprintComponents, QueueDrainResult } from '@typedcode/shared';
+import type { TabManager, TabState } from '../../ui/tabs/TabManager.js';
+
+const turnstile = vi.hoisted(() => ({ configured: false }));
+
+vi.mock('../../services/TurnstileService.js', () => ({
+  isTurnstileConfigured: () => turnstile.configured,
+  loadTurnstileScript: async (): Promise<void> => {},
+  performTurnstileVerification: async () => ({ success: true, attestation: null }),
+}));
+
+vi.mock('../../ui/components/ExportProgressDialog.js', () => ({
+  ExportProgressDialog: class {
+    show(): void {}
+    hide(): void {}
+    updatePhase(): void {}
+    updateProgress(): void {}
+    showDrainProgress(): void {}
+    getTurnstileContainer(): HTMLElement | null {
+      return null;
+    }
+  },
+}));
+
+const { ProofExporter } = await import('../ProofExporter.js');
+
+const createMockFingerprintComponents = (): FingerprintComponents => ({
+  userAgent: 'Mozilla/5.0 (DrainConsistency Test)',
+  language: 'en',
+  languages: ['en'],
+  platform: 'TestOS',
+  hardwareConcurrency: 4,
+  deviceMemory: 8,
+  screen: {
+    width: 1440,
+    height: 900,
+    availWidth: 1440,
+    availHeight: 860,
+    colorDepth: 24,
+    pixelDepth: 24,
+    devicePixelRatio: 2,
+  },
+  timezone: 'UTC',
+  timezoneOffset: 0,
+  canvas: 'mock-canvas',
+  webgl: { vendor: 'Mock', renderer: 'Mock' },
+  fonts: ['Arial'],
+  cookieEnabled: true,
+  doNotTrack: 'unspecified',
+  maxTouchPoints: 0,
+});
+
+/** チェーンに `chained` を記録済みで、buffer には `bufferContent` が入っているタブを作る。 */
+async function makeTab(id: string, chained: string, bufferContent: string): Promise<TabState> {
+  const components = createMockFingerprintComponents();
+  const fingerprintHash = await computeHash(JSON.stringify(components, null, 0));
+  const typingProof = new TypingProof();
+  await typingProof.initialize(fingerprintHash, components);
+
+  let content = '';
+  for (const ch of chained) {
+    await typingProof.recordEvent({
+      type: 'contentChange',
+      inputType: 'insertText',
+      data: ch,
+      rangeOffset: content.length,
+      rangeLength: 0,
+    });
+    content += ch;
+  }
+
+  return {
+    id,
+    filename: `${id}.txt`,
+    language: 'plaintext',
+    typingProof,
+    model: { getValue: () => bufferContent } as unknown as TabState['model'],
+    createdAt: Date.now(),
+    verificationState: 'unverified',
+  } as unknown as TabState;
+}
+
+/** 排出しきれない (停滞した) 状態を模す。実キューを止める代わりに待機結果だけ差し替える。 */
+function stallQueue(tab: TabState, remaining = 1): void {
+  const stalled: QueueDrainResult = { drained: false, remaining, reason: 'stalled', waitedMs: 5000 };
+  tab.typingProof.waitForQueueDrain = async () => stalled;
+}
+
+interface Download {
+  blob: Blob;
+  filename: string;
+}
+
+function createExporter(tabs: TabState[]) {
+  const exporter = new ProofExporter();
+  const notifications: string[] = [];
+  const downloads: Download[] = [];
+  exporter.setCallbacks({ onNotification: (message) => notifications.push(message) });
+  exporter.setTabManager({
+    getAllTabs: () => tabs,
+    getActiveTab: () => tabs[0] ?? null,
+    getActiveProof: () => tabs[0]?.typingProof ?? null,
+    getTabSwitches: () => [],
+    flushToIndexedDB: async () => {},
+  } as unknown as TabManager);
+  // ダウンロード経路は DOM 依存なので差し替えて blob を捕捉する。
+  (exporter as unknown as { downloadBlob: (blob: Blob, filename: string) => void }).downloadBlob = (blob, filename) => {
+    downloads.push({ blob, filename });
+  };
+  return { exporter, notifications, downloads };
+}
+
+/** ZIP から proof JSON を取り出す。 */
+async function readProof(download: Download): Promise<{ content: string; proof: { events: unknown[] } }> {
+  const zip = await JSZip.loadAsync(await download.blob.arrayBuffer());
+  const name = Object.keys(zip.files).find((f) => f.endsWith('_proof.json'));
+  const json = await zip.file(name!)!.async('string');
+  return JSON.parse(json);
+}
+
+/**
+ * PoSW Web Worker のスタブ (node 環境には Worker が無い)。
+ * PoSW 値そのものはこのテストの関心ではない (関心は content と chain の一貫性) ので、
+ * shared のテスト setup と同じくダミー値を返して計算コストを避ける。
+ */
+class MockPoswWorker {
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: ErrorEvent) => void) | null = null;
+
+  postMessage(message: Record<string, unknown>): void {
+    queueMicrotask(() => {
+      if (!this.onmessage) return;
+      const data =
+        message.type === 'compute-posw'
+          ? {
+              type: 'posw-result',
+              requestId: message.requestId,
+              iterations: message.iterations,
+              nonce: 'mock-nonce',
+              intermediateHash: 'mock-intermediate-hash',
+              computeTimeMs: 1,
+            }
+          : { type: 'verify-result', requestId: message.requestId, valid: true };
+      this.onmessage({ data } as MessageEvent);
+    });
+  }
+
+  terminate(): void {}
+}
+
+beforeEach(() => {
+  turnstile.configured = false;
+  vi.stubGlobal('Worker', MockPoswWorker);
+  vi.stubGlobal('document', { getElementById: () => null });
+  vi.stubGlobal('window', { location: { hostname: 'unit-test.local' } });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('ProofExporter.exportCurrentTab drain consistency (#225)', () => {
+  it('aborts the export when the record queue could not be drained', async () => {
+    const tab = await makeTab('tab-1', 'ab', 'abc');
+    stallQueue(tab);
+    const { exporter, downloads, notifications } = createExporter([tab]);
+
+    await exporter.exportCurrentTab();
+
+    expect(downloads).toHaveLength(0);
+    expect(notifications).toEqual([expect.any(String)]);
+  });
+
+  it('does not build a proof from buffer content that is not on the chain', async () => {
+    const tab = await makeTab('tab-1', 'ab', 'abc');
+    stallQueue(tab);
+    const exportProof = vi.spyOn(tab.typingProof, 'exportProof');
+    const { exporter } = createExporter([tab]);
+
+    await exporter.exportCurrentTab();
+
+    expect(exportProof).not.toHaveBeenCalled();
+  });
+
+  it('exports a proof whose content replays from the chain when the queue drains', async () => {
+    const tab = await makeTab('tab-1', 'abc', 'abc');
+    const { exporter, downloads } = createExporter([tab]);
+
+    await exporter.exportCurrentTab();
+
+    expect(downloads).toHaveLength(1);
+    const exported = await readProof(downloads[0]!);
+    expect(verifyContentReplay(exported.proof.events as never, exported.content)).toMatchObject({ valid: true });
+  });
+});
+
+describe('ProofExporter.exportAllTabsAsZip drain consistency (#225)', () => {
+  it('aborts the whole export when any tab could not drain its record queue', async () => {
+    const first = await makeTab('tab-1', 'abc', 'abc');
+    const second = await makeTab('tab-2', 'ab', 'abc');
+    stallQueue(second);
+    const { exporter, downloads, notifications } = createExporter([first, second]);
+
+    await exporter.exportAllTabsAsZip();
+
+    expect(downloads).toHaveLength(0);
+    expect(notifications).toEqual([expect.any(String)]);
+  });
+
+  it('exports every tab when all record queues drain', async () => {
+    const first = await makeTab('tab-1', 'ab', 'ab');
+    const second = await makeTab('tab-2', 'cd', 'cd');
+    const { exporter, downloads } = createExporter([first, second]);
+
+    await exporter.exportAllTabsAsZip();
+
+    expect(downloads).toHaveLength(1);
+  });
+});

--- a/packages/editor/src/i18n/translations/en.ts
+++ b/packages/editor/src/i18n/translations/en.ts
@@ -405,6 +405,9 @@ export const en: TranslationKeys = {
     statusScreenshots: 'Collecting screenshots...',
     statusGenerating: 'Generating ZIP file...',
     statusComplete: 'Complete',
+    statusDraining: 'Recording your keystrokes... (${count} left)',
+    queueNotDrained:
+      'Export cancelled because your keystrokes are still being recorded (a proof that omits them cannot be verified). Your code is untouched — please wait a few seconds and download again.',
   },
 
   terminal: {

--- a/packages/editor/src/i18n/translations/ja.ts
+++ b/packages/editor/src/i18n/translations/ja.ts
@@ -404,6 +404,9 @@ export const ja: TranslationKeys = {
     statusScreenshots: 'スクリーンショットを取得しています...',
     statusGenerating: 'ZIPファイルを生成しています...',
     statusComplete: '完了',
+    statusDraining: '打鍵の記録を処理しています...（残り${count}件）',
+    queueNotDrained:
+      '打鍵の記録が完了していないため、エクスポートを中止しました（未処理の打鍵を含む証明は検証できなくなるため）。コードはそのまま残っています。数秒待ってから、もう一度ダウンロードしてください。',
   },
 
   terminal: {

--- a/packages/editor/src/i18n/types.ts
+++ b/packages/editor/src/i18n/types.ts
@@ -411,6 +411,10 @@ export interface TranslationKeys {
     statusScreenshots: string;
     statusGenerating: string;
     statusComplete: string;
+    /** 記録キュー排出待ちの進捗 (#225)。`${count}` = 残件数 */
+    statusDraining: string;
+    /** 排出できず export を中止したときの通知 (#225) */
+    queueNotDrained: string;
   };
 
   // Terminal / Runtime

--- a/packages/editor/src/ui/components/ExportProgressDialog.ts
+++ b/packages/editor/src/ui/components/ExportProgressDialog.ts
@@ -193,6 +193,17 @@ export class ExportProgressDialog {
   }
 
   /**
+   * 記録キューの排出待ち状況を表示する (#225)。
+   * 打鍵が多いと排出に数秒〜数十秒かかることがあるので、無言で固まったように見せず
+   * 「残り何件を処理中か」を出す。フェーズ自体は preparing のまま。
+   */
+  showDrainProgress(remaining: number): void {
+    if (this.statusText) {
+      this.statusText.textContent = t('export.statusDraining', { count: remaining });
+    }
+  }
+
+  /**
    * 進行状況を更新（詳細）
    */
   updateProgress(progress: ExportProgress): void {

--- a/packages/shared/src/__tests__/exportSnapshot.test.ts
+++ b/packages/shared/src/__tests__/exportSnapshot.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { TypingProof, computeHash, verifyProofMetadata, verifyCheckpoints } from '../index.js';
+import { TypingProof, computeHash, verifyProofMetadata, verifyCheckpoints, verifyContentReplay } from '../index.js';
 import type { FingerprintComponents } from '../types.js';
 
 const createMockFingerprintComponents = (): FingerprintComponents => ({
@@ -96,6 +96,20 @@ describe('exportProof snapshot consistency (#143)', () => {
 
   it('waitForQueueDrain resolves once all recorded events are on the chain', async () => {
     const { proof } = await buildProof('a');
-    await expect(proof.waitForQueueDrain(1000)).resolves.toBe(true);
+    await expect(proof.waitForQueueDrain({ maxWaitMs: 1000 })).resolves.toMatchObject({
+      drained: true,
+      remaining: 0,
+      reason: 'drained',
+    });
+  });
+
+  // #225: snapshot 一貫性は content との整合を守らない。exporter が排出待ちに失敗したまま
+  // buffer 内容で proof を作ってはいけない理由 (= 何が壊れるか) をここで固定する。
+  it('rejects exported content that contains a keystroke missing from the chain', async () => {
+    const { proof, content } = await buildProof('ab');
+    // 直前の 'c' がまだ PoSW キューにあり、チェーンには載っていない状況。
+    const bufferContent = `${content}c`;
+    const exported = await proof.exportProof(bufferContent);
+    expect(verifyContentReplay(exported.proof.events, bufferContent)).toMatchObject({ valid: false });
   });
 });

--- a/packages/shared/src/__tests__/queueDrainWait.test.ts
+++ b/packages/shared/src/__tests__/queueDrainWait.test.ts
@@ -1,0 +1,154 @@
+/**
+ * 記録キュー排出待ちの待機ポリシー (#225) のテスト。
+ *
+ * 固定タイムアウトだと「キューが長いだけ」の正常なケースで諦めてしまい、export が
+ * content と chain の食い違いに至る。進捗が続く限り待ち、停滞したときだけ諦めることを固定する。
+ * 時計と sleep は注入し、実時間に依存させない。
+ */
+
+import { describe, expect, it } from 'vitest';
+import { waitForQueueDrain, type QueueDrainProbe } from '../typingProof/queueDrain.js';
+
+/** 各ポーリングで返す観測値を並べた台本ドリブンの probe。最後の値は以後繰り返す。 */
+function scriptedProbe(script: QueueDrainProbe[]): () => QueueDrainProbe {
+  let index = 0;
+  return () => {
+    const value = script[Math.min(index, script.length - 1)]!;
+    index++;
+    return value;
+  };
+}
+
+/** 仮想時計: sleep するたびに指定 ms だけ時刻を進める。 */
+function virtualClock() {
+  let current = 0;
+  return {
+    now: () => current,
+    sleep: async (ms: number) => {
+      current += ms;
+    },
+    advance: (ms: number) => {
+      current += ms;
+    },
+  };
+}
+
+describe('waitForQueueDrain (#225)', () => {
+  it('returns immediately when the queue is already empty', async () => {
+    const clock = virtualClock();
+    const result = await waitForQueueDrain(scriptedProbe([{ remaining: 0, committed: 3 }]), {
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+
+    expect(result).toMatchObject({ drained: true, remaining: 0, reason: 'drained' });
+  });
+
+  it('keeps waiting past the stall window while the queue is still shrinking', async () => {
+    const clock = virtualClock();
+    // 1 ポーリング (1000ms) ごとに 1 件ずつ減る = 合計 4000ms かかり stall 窓 (1500ms) を超える。
+    const script: QueueDrainProbe[] = [
+      { remaining: 4, committed: 0 },
+      { remaining: 3, committed: 1 },
+      { remaining: 2, committed: 2 },
+      { remaining: 1, committed: 3 },
+      { remaining: 0, committed: 4 },
+    ];
+
+    const result = await waitForQueueDrain(scriptedProbe(script), {
+      stallTimeoutMs: 1500,
+      maxWaitMs: 60000,
+      pollIntervalMs: 1000,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+
+    expect(result).toMatchObject({ drained: true, reason: 'drained' });
+  });
+
+  it('gives up with reason "stalled" when the queue stops shrinking for the stall window', async () => {
+    const clock = virtualClock();
+    const result = await waitForQueueDrain(scriptedProbe([{ remaining: 2, committed: 5 }]), {
+      stallTimeoutMs: 1000,
+      maxWaitMs: 60000,
+      pollIntervalMs: 400,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+
+    expect(result).toMatchObject({ drained: false, remaining: 2, reason: 'stalled' });
+  });
+
+  it('gives up with reason "timeout" when progress continues past the overall limit', async () => {
+    const clock = virtualClock();
+    // 毎ポーリングで確定数が増える (= 進捗はある) が、残件は減らない状況。
+    let tick = 0;
+    const probe = (): QueueDrainProbe => ({ remaining: 3, committed: tick++ });
+
+    const result = await waitForQueueDrain(probe, {
+      stallTimeoutMs: 5000,
+      maxWaitMs: 3000,
+      pollIntervalMs: 500,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+
+    expect(result).toMatchObject({ drained: false, remaining: 3, reason: 'timeout' });
+  });
+
+  it('counts a growing chain as progress even when new events keep the remaining count up', async () => {
+    const clock = virtualClock();
+    // 残件は 2 のまま (export 中の broadcast で積み増される) が確定数は伸び続ける。
+    // 最小残件だけを進捗判定にすると停滞と誤判定する状況。
+    const script: QueueDrainProbe[] = [
+      { remaining: 2, committed: 0 },
+      { remaining: 2, committed: 1 },
+      { remaining: 2, committed: 2 },
+      { remaining: 2, committed: 3 },
+      { remaining: 0, committed: 5 },
+    ];
+
+    const result = await waitForQueueDrain(scriptedProbe(script), {
+      stallTimeoutMs: 1500,
+      maxWaitMs: 60000,
+      pollIntervalMs: 1000,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+
+    expect(result).toMatchObject({ drained: true, reason: 'drained' });
+  });
+
+  it('reports the remaining count through onProgress whenever it changes', async () => {
+    const clock = virtualClock();
+    const seen: number[] = [];
+    const script: QueueDrainProbe[] = [
+      { remaining: 2, committed: 0 },
+      { remaining: 2, committed: 1 },
+      { remaining: 1, committed: 2 },
+      { remaining: 0, committed: 3 },
+    ];
+
+    await waitForQueueDrain(scriptedProbe(script), {
+      stallTimeoutMs: 5000,
+      pollIntervalMs: 100,
+      now: clock.now,
+      sleep: clock.sleep,
+      onProgress: (remaining) => seen.push(remaining),
+    });
+
+    expect(seen).toEqual([2, 1, 0]);
+  });
+
+  it('reports how long it waited before giving up', async () => {
+    const clock = virtualClock();
+    const result = await waitForQueueDrain(scriptedProbe([{ remaining: 1, committed: 0 }]), {
+      stallTimeoutMs: 1000,
+      pollIntervalMs: 250,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+
+    expect(result.waitedMs).toBe(1000);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,6 +8,14 @@ export * from './types.js';
 // タイピング証明
 export { TypingProof } from './typingProof.js';
 
+// 記録キューの排出待ち (#225) — exporter が待機ポリシーを指定し、結果で export 継続を判断する
+export type { QueueDrainOptions, QueueDrainResult, QueueDrainReason } from './typingProof/queueDrain.js';
+export {
+  DEFAULT_QUEUE_DRAIN_STALL_MS,
+  DEFAULT_QUEUE_DRAIN_MAX_WAIT_MS,
+  DEFAULT_QUEUE_DRAIN_POLL_MS,
+} from './typingProof/queueDrain.js';
+
 // フィンガープリント
 export { Fingerprint } from './fingerprint.js';
 

--- a/packages/shared/src/typingProof/TypingProof.ts
+++ b/packages/shared/src/typingProof/TypingProof.ts
@@ -42,6 +42,7 @@ import type { CheckpointCreatedHook } from './CheckpointManager.js';
 import type { SignedCheckpointEnvelope } from '../types.js';
 import { StatisticsCalculator } from './StatisticsCalculator.js';
 import { isAllowedInputType, isProhibitedInputType } from './InputTypeValidator.js';
+import { waitForQueueDrain, type QueueDrainOptions, type QueueDrainResult } from './queueDrain.js';
 import { sharedDebugLog } from '../utils/debug.js';
 
 export class TypingProof {
@@ -604,6 +605,11 @@ export class TypingProof {
    * を持つ proof ができ、verifier (verifyProofMetadata / verifyCheckpoints) で丸ごと invalid
    * になる。冒頭で 1 度だけスナップショットし、以降すべて同じ配列に対して計算する。
    * スナップショット後に記録されたイベントはこの export に含まれない (チェーンには残る)。
+   *
+   * #225: このスナップショット一貫性が守るのは署名 / メタデータ / checkpoint までで、
+   * **`finalContent` との整合は守らない**。スナップショットに載っていない打鍵を含む content
+   * を渡すと content replay (検証 Layer 4) が最終内容と一致せず proof 全体が invalid になる。
+   * 呼び出し側は `waitForQueueDrain` で排出を確認してから content を確定すること。
    */
   async exportProof(finalContent: string): Promise<ExportedProof> {
     const events = this.events.slice();
@@ -668,23 +674,31 @@ export class TypingProof {
   }
 
   /**
-   * 記録キュー (pendingEvents / PoSW 計算待ち) が空になるまで待つ (#143)。
+   * 記録キュー (pendingEvents / PoSW 計算待ち) が空になるまで待つ (#143, #225)。
    *
    * exportProof はスナップショット一貫だが、直前の打鍵がまだキューにあると
    * 「content (エディタ buffer) には載っているのにチェーンに無い」export になり、
-   * content replay (Layer 4) で fail する。exporter は**タブ毎に**これを待ってから
-   * model 内容を確定して exportProof を呼ぶこと (アクティブタブだけ待つのでは不足)。
+   * content replay (検証 Layer 4) が最終内容と一致せず **proof 全体が invalid** になる。
+   * スナップショット一貫性が守るのは署名 / メタデータ / checkpoint の整合だけで、
+   * content との整合は守らない。exporter は**タブ毎に**これを待ってから model 内容を
+   * 確定して exportProof を呼び、**排出できなかったときは export を中止すること**
+   * (アクティブタブだけ待つのでは不足)。
    *
-   * @returns 排出しきれば true、timeout なら false (呼び出し側は警告して続行してよい —
-   *   その場合もスナップショット一貫性により proof 自体は整合する)
+   * 待ち方は進捗ベース (#225): PoSW は Worker 障害時もメインスレッドで必ず完了するため、
+   * 排出が終わらない主因は「キューが長い」であって恒久停止ではない。固定 5 秒で諦めず、
+   * 残件が減り続けている限り待ち、停滞したときだけ諦める (上限は `maxWaitMs`)。
+   *
+   * @returns 排出できたか (`drained`) と打ち切り理由・残件数。`drained === false` のとき
+   *   content と chain は食い違いうるので、その content で proof を作ってはいけない。
    */
-  async waitForQueueDrain(timeoutMs = 5000): Promise<boolean> {
-    const start = performance.now();
-    while (this.pendingEvents.length > 0 || this.queuedEventCount > 0) {
-      if (performance.now() - start > timeoutMs) return false;
-      await new Promise((resolve) => setTimeout(resolve, 25));
-    }
-    return true;
+  async waitForQueueDrain(options: QueueDrainOptions = {}): Promise<QueueDrainResult> {
+    return waitForQueueDrain(
+      () => ({
+        remaining: Math.max(this.pendingEvents.length, this.queuedEventCount),
+        committed: this.events.length,
+      }),
+      options
+    );
   }
 
   /**

--- a/packages/shared/src/typingProof/index.ts
+++ b/packages/shared/src/typingProof/index.ts
@@ -13,6 +13,15 @@ export { CheckpointManager } from './CheckpointManager.js';
 export { ChainVerifier } from './ChainVerifier.js';
 export { StatisticsCalculator } from './StatisticsCalculator.js';
 
+// 記録キューの排出待ち (#225): 進捗ベースの待機ロジック (純関数)
+export {
+  waitForQueueDrain,
+  DEFAULT_QUEUE_DRAIN_STALL_MS,
+  DEFAULT_QUEUE_DRAIN_MAX_WAIT_MS,
+  DEFAULT_QUEUE_DRAIN_POLL_MS,
+} from './queueDrain.js';
+export type { QueueDrainOptions, QueueDrainResult, QueueDrainProbe, QueueDrainReason } from './queueDrain.js';
+
 // 入力タイプ検証ユーティリティ
 export {
   isAllowedInputType,

--- a/packages/shared/src/typingProof/queueDrain.ts
+++ b/packages/shared/src/typingProof/queueDrain.ts
@@ -1,0 +1,111 @@
+/**
+ * 記録キュー (PoSW 待ち) の排出待ちポリシー (#225)。
+ *
+ * 固定タイムアウトで打ち切ると、単に「キューが長い」だけの正常なケースでも待ちを諦めて
+ * しまう (PoSW は Worker が落ちてもメインスレッドにフォールバックして必ず完了するので、
+ * 排出が終わらない主因は恒久停止ではなくキュー長)。そこで **進捗が続く限り待ち、進捗が
+ * 止まったとき (stall) だけ諦める**。無限待ちを避けるため全体の上限も持つ。
+ *
+ * ロジックは `TypingProof` の内部状態から切り離した純関数として置く (観測は probe 経由、
+ * 時計と sleep は注入可能)。
+ */
+
+/** 排出待ちの観測値。`remaining` が 0 になれば排出完了。 */
+export interface QueueDrainProbe {
+  /** まだチェーンに載っていないイベント数 (pending + キュー待ち)。 */
+  remaining: number;
+  /** チェーンに確定済みのイベント数。単調増加するので進捗判定に使う。 */
+  committed: number;
+}
+
+/** 排出待ちの打ち切り理由。 */
+export type QueueDrainReason =
+  /** キューが空になった (content と chain が一致する) */
+  | 'drained'
+  /** 進捗がないまま `stallTimeoutMs` が経過した */
+  | 'stalled'
+  /** 進捗はあったが `maxWaitMs` を超えた */
+  | 'timeout';
+
+/** 排出待ちのオプション。時計 / sleep はテストのために注入可能。 */
+export interface QueueDrainOptions {
+  /** 進捗がまったく無いまま経過したら諦める時間 (既定 5000ms)。 */
+  stallTimeoutMs?: number;
+  /** 進捗が続いていても待ち続ける上限 (既定 60000ms)。無限待ちを防ぐ。 */
+  maxWaitMs?: number;
+  /** ポーリング間隔 (既定 25ms)。 */
+  pollIntervalMs?: number;
+  /** 残件数が変化するたびに呼ばれる (待機中であることを UI に出すため。初回も 1 度呼ぶ)。 */
+  onProgress?: (remaining: number) => void;
+  /** 時計 (既定 `performance.now`)。 */
+  now?: () => number;
+  /** 待機 (既定 `setTimeout`)。 */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/** 排出待ちの結果。`drained === false` の間は content と chain が食い違いうる。 */
+export interface QueueDrainResult {
+  /** キューが空になったか。 */
+  drained: boolean;
+  /** 打ち切り時点の残件数。 */
+  remaining: number;
+  /** 打ち切り理由。 */
+  reason: QueueDrainReason;
+  /** 実際に待った時間 (ms)。 */
+  waitedMs: number;
+}
+
+export const DEFAULT_QUEUE_DRAIN_STALL_MS = 5000;
+export const DEFAULT_QUEUE_DRAIN_MAX_WAIT_MS = 60000;
+export const DEFAULT_QUEUE_DRAIN_POLL_MS = 25;
+
+/**
+ * `probe` が `remaining === 0` を返すまで待つ。
+ *
+ * 進捗 = 「残件数がこれまでの最小値を下回った」または「確定イベント数が増えた」。
+ * 前者だけだと export 中に新規イベントが積まれたとき (スクショ / visibility の broadcast)
+ * 残件数が増減して停滞と誤判定しうるので、単調増加する確定数も進捗として数える。
+ */
+export async function waitForQueueDrain(
+  probe: () => QueueDrainProbe,
+  options: QueueDrainOptions = {}
+): Promise<QueueDrainResult> {
+  const stallTimeoutMs = options.stallTimeoutMs ?? DEFAULT_QUEUE_DRAIN_STALL_MS;
+  const maxWaitMs = options.maxWaitMs ?? DEFAULT_QUEUE_DRAIN_MAX_WAIT_MS;
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_QUEUE_DRAIN_POLL_MS;
+  const now = options.now ?? (() => performance.now());
+  const sleep = options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+  const start = now();
+  let current = probe();
+  let minRemaining = current.remaining;
+  let maxCommitted = current.committed;
+  let lastProgressAt = start;
+
+  options.onProgress?.(current.remaining);
+
+  while (current.remaining > 0) {
+    const elapsed = now() - start;
+    if (elapsed >= maxWaitMs) {
+      return { drained: false, remaining: current.remaining, reason: 'timeout', waitedMs: elapsed };
+    }
+    if (now() - lastProgressAt >= stallTimeoutMs) {
+      return { drained: false, remaining: current.remaining, reason: 'stalled', waitedMs: now() - start };
+    }
+
+    await sleep(pollIntervalMs);
+
+    const next = probe();
+    if (next.remaining < minRemaining || next.committed > maxCommitted) {
+      minRemaining = Math.min(minRemaining, next.remaining);
+      maxCommitted = Math.max(maxCommitted, next.committed);
+      lastProgressAt = now();
+    }
+    if (next.remaining !== current.remaining) {
+      options.onProgress?.(next.remaining);
+    }
+    current = next;
+  }
+
+  return { drained: true, remaining: 0, reason: 'drained', waitedMs: now() - start };
+}


### PR DESCRIPTION
## 目的

`ProofExporter` は `waitForQueueDrain(5000)` が timeout しても **console 警告のみで続行**し、pending の打鍵を含む `model.getValue()` を content として export していた。一方 `exportProof` のスナップショットには pending イベントが入らないため、「**content にはあるが chain には無い**」proof ができ、`verifyContentReplay` (検証 Layer 4 / `chainValid` 直結) で **proof 全体が invalid** になる。学生に過失が無いまま答案が検証不能になる (#225)。

コード中の「その場合もスナップショット一貫性により proof 自体は整合する」というコメントは Layer 4 を見落としており不正確だった。

## 変更点

### 1. 排出待ちを進捗ベースにする (shared)

`PoswManager` は Worker が落ちてもメインスレッドにフォールバックして PoSW を**必ず完了させる**設計なので、drain timeout の主因は「Worker の恒久停止」ではなく「キューが長くて 5 秒で終わらない」。固定 5 秒で諦めるのは早すぎる。

- `packages/shared/src/typingProof/queueDrain.ts` (新規): 進捗が続く限り待ち、**停滞したときだけ**諦める純関数。時計と sleep は注入可能
  - 進捗 = 「残件数が最小値を下回った」または「チェーン確定数が増えた」(export 中に broadcast イベントが積まれても停滞と誤判定しない)
  - 打ち切り理由を `drained` / `stalled` / `timeout` で返す。上限 (`maxWaitMs`) は残すので無限には待たない
- `TypingProof.waitForQueueDrain(options)`: 戻り値を `boolean` から `QueueDrainResult` に変更し、上記へ委譲 (呼び出し元は `ProofExporter` と shared のテストのみ)
- exporter 側の待機ポリシーは stall 5s / 上限 60s。待機が長引く間は残件数を `ExportProgressDialog` に表示する

### 2. 排出できなければ export を中止する (editor)

Issue の選択肢 (B)。(A) の「content を replay 結果に切り詰める」は、**画面に見えている直前の打鍵が提出物から黙って消える**データ欠落であり採らない (復元経路の `reconcileRestoredContent` が切り詰めるのは、クラッシュ後で buffer を信用できずチェーンだけが真実という別状況)。

- `drainQueueOrAbort()` に集約し、単一タブ / 全タブ export の両方から使う。全タブ export は 1 タブでも排出できなければ ZIP 全体を中止する (invalid な proof を混ぜない)
- 中止時は「打鍵の記録が完了していないため中止した / コードは残っている / 数秒待って再試行」を ja・en で通知 (`export.queueNotDrained`、待機表示は `export.statusDraining`)

### 3. コメント修正

`ProofExporter.ts` / `TypingProof.ts` の「スナップショット一貫性により proof 自体は整合する」を実挙動に合わせて修正。スナップショット一貫性が守るのは署名 / メタデータ / checkpoint までで、**content との整合は守らない**ことを明記した。

## 確認方法

再現テストを先に書き、修正前に赤くなることを確認している。

修正前 (`ProofExporter` を HEAD に戻した状態) の実挙動:

```
TEMP replay result: {"valid":false,"reason":"Replayed content does not match exported final content",
                     "reconstructedContent":"ab","mismatchIndex":2}
→ ZIP がダウンロードされ、その proof は content replay で invalid
→ 期待挙動のテスト 3 件が赤 (Tests 3 failed | 2 passed)
```

追加したテスト:

- `packages/editor/src/export/__tests__/ProofExporter.drainConsistency.test.ts` — 排出できないとき export が中止される / `exportProof` が呼ばれない / 排出できたときは従来どおり export され content replay が通る (回帰防止) / 全タブ export も同様
- `packages/shared/src/__tests__/queueDrainWait.test.ts` — 進捗が続く限り stall 窓を超えて待つ / 停滞したら `stalled` / 上限超過は `timeout` / チェーンが伸びていれば進捗と数える / `onProgress` の通知 / 待機時間の報告
- `packages/shared/src/__tests__/exportSnapshot.test.ts` — 「チェーンに無い打鍵を含む content を渡すと content replay が落ちる」= 中止する理由そのものを固定

作業ディレクトリでの実行結果 (すべて green):

```
npm ci
npm run lint                              # Checked 413 files, 0 errors
npm run typecheck                         # 全 6 パッケージ
npm run test:run --workspaces --if-present  # editor 120 / shared 460 (+3 skipped) / verify 30 / verify-cli 15 / workers 50
npm run build
```

proof フォーマット・チェーンの意味 (`POSW_ITERATIONS` / `PROOF_FORMAT_VERSION` / 決定的シリアライズ / Event #0) は一切変更していない。

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)