### PR TITLE
refactor(verify): 検証結果の合成を shared の verifyProofFile に委譲する

### DIFF
--- a/packages/shared/src/verification.ts
+++ b/packages/shared/src/verification.ts
@@ -67,6 +67,13 @@ export interface FullVerificationResult {
    * exam / 旧 proof / オフライン劣化では false。warning 判定は呼び出し側 (exam は除外)。
    */
   rootAnchored?: boolean;
+  /**
+   * `sessionStartToken` の sessionId と署名 cp の sessionId が食い違ったか (spec §6.3 / ADR-0017)。
+   * true = 別セッションのトークンを流用した proof。`valid` には既に反映済みだが、UI が
+   * 「どの層が落ちたか」を chain ではなく時刻アンカー層として提示できるよう独立に返す
+   * (chain に畳み込むと「改ざんされた」と誤って告発する — #211)。
+   */
+  sessionTokenMismatch?: boolean;
 }
 
 /**
@@ -945,6 +952,7 @@ export async function verifyProofFile(
     errorMessage: verificationError,
     poswSkipped: skipPosw,
     signedCheckpoints: signedCheckpointResult,
+    sessionTokenMismatch: !!tokenSessionMismatch,
   };
 }
 

--- a/packages/verify-cli/src/verify.ts
+++ b/packages/verify-cli/src/verify.ts
@@ -22,6 +22,7 @@ import {
   type ExamPackageManifest,
   type ExamBindingVerificationResult,
   type ScreenshotVerificationSummary,
+  type CheckpointPublicKey,
 } from '@typedcode/shared';
 import { ProgressBar } from './progress.js';
 
@@ -98,6 +99,11 @@ export interface VerifyProofOptions {
    * tampered > 0 は verify (web) の error 軸と同じく valid を落とす。未指定 = 未検査。
    */
   screenshotSummary?: ScreenshotVerificationSummary;
+  /**
+   * 署名 cp / セッション開始トークンの公開鍵レジストリ。未指定なら shared の既定 registry
+   * (本番運用はこちら)。テスト鍵を注入して web↔CLI パリティを比較するための口 (#216)。
+   */
+  signedCheckpointKeyRegistry?: readonly CheckpointPublicKey[];
 }
 
 export async function verifyProof(proof: ProofFile, options: VerifyProofOptions = {}): Promise<CLIVerificationResult> {
@@ -131,6 +137,7 @@ export async function verifyProof(proof: ProofFile, options: VerifyProofOptions 
     requireRootAnchor: options.requireRootAnchor,
     // 免除は検証済み束縛のみ。package 未提供 (binding=undefined) の exam proof は gate 対象。
     examBindingVerified: binding?.valid === true,
+    signedCheckpointKeyRegistry: options.signedCheckpointKeyRegistry,
   });
 
   progressBar.complete();

--- a/packages/verify/CLAUDE.md
+++ b/packages/verify/CLAUDE.md
@@ -26,8 +26,8 @@
 | `ui/controllers/` | `VerificationController`, `TabController`, `FileController`, `FolderController`, `ChartController` |
 | `state/` | `VerificationQueue`, `UIStateManager`, `VerifyTabManager`, `ChartState` |
 | `charts/` | `TimelineChart`, `MouseChart`, `IntegratedChart`, `SeekbarController` (Chart.js) |
-| `services/` | `FileSystemAccessService`, `FolderSyncManager`, `SyntaxHighlighter`, `TrustCalculator`, `DiffService`, `ChartPreferencesService` |
-| `workers/` | `verificationWorker.ts` (Web Worker ベースの検証) |
+| `services/` | `FileSystemAccessService`, `FolderSyncManager`, `SyntaxHighlighter`, `TrustCalculator`, `DiffService`, `ChartPreferencesService`, `proofVerification` (shared への委譲アダプタ + 総合判定 / 保証入力の写像) |
+| `workers/` | `verificationWorker.ts` (Web Worker のメッセージ入出力のみ。検証は `services/proofVerification` へ) |
 
 ## データフロー
 
@@ -36,26 +36,31 @@ File Selection (drag&drop / FSA API)
   → FileProcessor (JSON / ZIP)
   → 形式判定 (single / multi: タブ毎に独立 proof)
   → VerificationController → VerificationQueue
-  → workers/verificationWorker.ts (Web Worker)
-     ├─ sequence 連続性
-     ├─ timestamp 単調性
-     ├─ previousHash 検証
-     ├─ ハッシュ再計算
-     ├─ PoSW (POSW_ITERATIONS 反復)
-     ├─ 署名済み cp の連結検証 (任意)
+  → workers/verificationWorker.ts (Web Worker。メッセージ入出力のみ)
+  → services/proofVerification.runProofVerification
+     ├─ verifyExamBinding (ADR-0006。package 提供時のみ・verifyProofFile より前)
+     ├─ shared の verifyProofFile (metadata / chain / PoSW / finalHash / content /
+     │  checkpoint / 署名済み cp / sessionStartToken 突合 の合成は**すべて shared**)
      └─ runAnalysis (ADR-0009。advisory のみ・valid に不反映・失敗しても検証結果を落とさない)
   → AttestationService.verify() (Workers API)
   → ResultPanel + charts
 ```
 
+**Worker 内で検証を再合成しないこと** (#211)。過去にここでレイヤを組み直していたため、
+`sessionStartToken` ↔ 署名 cp の sessionId 突合 (spec §6.3) が web だけ欠落し、`chainValid` に
+署名 cp の失敗を畳み込んで整合性チップが誤って FAILED になっていた。web↔CLI の結論一致は
+`services/__tests__/webCliParity.test.ts` (#216) が CI で固定する — verify-cli の `verifyProof` を
+実際に呼んで `valid` / 三層保証 / exam 束縛 / スクショ集計 (tampered・chainOnly) を突き合わせるので、
+片側だけ直すと落ちる。スクショの**読込経路** (ZIP vs フォルダ) の一致は `screenshotParity.test.ts` (#212) の担当。
+
 ## 信頼スコア (`TrustCalculator`)
 
 `TrustCalculator.calculate` は加減点スコアではなく **issue リスト** を組み立て、`determineLevel` で `failed`(error あり) / `partial`(warning あり) / `verified`(issue なし) に落とす。issue を上げる要素:
 
-- **error**: metadata 不正、ハッシュチェーン不正、スクショ改竄、署名 cp が anchored だが invalid、exam 束縛失敗 (package 提供時)
+- **error**: metadata 不正、ハッシュチェーン不正、スクショ改竄、署名 cp が anchored だが invalid、**セッション開始トークンと署名 cp の sessionId 不一致 (spec §6.3。整合性ではなく `anchoring` 層に上げる)**、exam 束縛失敗 (package 提供時)
 - **warning**: 未アンカー (署名 cp なし)、post-hoc 一括署名疑い、**アンカー密度が疎 (ADR-0016, `signedCheckpointDensity.sparse`)**、**root 未サーバアンカー (ADR-0017, `!rootAnchored` かつ非 exam)**、非ピュアタイピング (ペースト/バルク挿入)、ソース不一致、attestation 検証失敗、`screenShareOptOut`、exam だが問題パッケージ未読込、スクショ欠損
 
-`VerificationController.handleComplete` のタブ status 判定と **同じ軸** を見るので、両者を揃えて変更すること (タブが緑なのに信頼バッジが警告、のような不整合を避ける)。`component` を増やしたら `ResultPanel.getComponentLabel` にラベルも追加する。#146 で handleComplete にスクショ改竄 (error)・スクショ欠損・`screenShareOptOut` (warning) を合流済み。attestation 失敗は `humanAttestationResult` の書き込み元が現状無い (dead) ため status 軸に入れていない。
+`VerificationController.handleComplete` のタブ status 判定と **同じ軸** を見るので、両者を揃えて変更すること (タブが緑なのに信頼バッジが警告、のような不整合を避ける)。status の error 側は `proofVerification.isOverallValid` (= verify-cli の `valid` と同じ合成: shared の `verifyProofFile` × exam 束縛 × スクショ改竄) 一本に寄せてあるので、error 条件を増やすときは CLI 側も同時に見ること。`component` を増やしたら `ResultPanel.getComponentLabel` にラベルも追加する。#146 で handleComplete にスクショ改竄 (error)・スクショ欠損・`screenShareOptOut` (warning) を合流済み。attestation 失敗は `humanAttestationResult` の書き込み元が現状無い (dead) ため status 軸に入れていない。
 
 スクショの per-image 判定 (ハッシュ突合 + チェーン裏付け) の実体は **shared の `checkScreenshotImage`** (#147)。verify 側で再実装しない — verify-cli と結論が食い違うため。
 
@@ -77,7 +82,7 @@ File Selection (drag&drop / FSA API)
 ## 三層保証バッジ (ADR-0020)
 
 - 結果画面最上部の `#assurance-strip` に **整合性 / 時刻アンカー / 著述性** の 3 チップ (+ 自己申告 mode の参考チップ) を出す。導出は shared の `deriveAssurance` (**verify 側で再実装しない** — CLI と食い違うため)
-- 導出は `TabController.renderResult` で行う (スクショ改竄数を持つのがこの層だけのため)。入力は実証拠のみで **自己申告 `proof.mode` は使わない**
+- 導出は `TabController.renderResult` で行う (スクショ改竄数を持つのがこの層だけのため)。入力は実証拠のみで **自己申告 `proof.mode` は使わない**。`AssuranceInput` への写像は `proofVerification.buildAssuranceInput` に切り出してあり、verify-cli の同じ写像との一致をパリティテストが固定する (#216)
 - **著述性チップは常に advisory**: 判定色 (緑/赤) を使わず破線・中立色。pureTyping + シグナル数の事実併記のみ。ここを判定に見せる変更は ADR-0009/0020 違反
 - 既存の TrustCalculator (issue リスト) とタブ status は詳細表示として併存。三層バッジは語彙、issue は根拠の列挙という役割分担
 

--- a/packages/verify/src/i18n/translations/en.ts
+++ b/packages/verify/src/i18n/translations/en.ts
@@ -372,6 +372,8 @@ export const en: VerifyTranslationKeys = {
     issueAnchoringPostHoc: 'Post-hoc batch signing suspected (server span is far shorter than the claimed session)',
     issueAnchoringSparse:
       'Anchor density is sparse (signed checkpoints are too few / too late for the claimed session)',
+    issueSessionTokenMismatch:
+      'Session start token does not match the signed checkpoint session id (token from another session suspected)',
     issueRootNotAnchored: 'Chain root is not server-anchored (start time unfixed; offline forgery possible)',
     issueNotPureTyping: 'Not pure typing (paste / bulk insertion detected)',
     issueExamBindingFailed: 'Exam binding (signature / content hash) verification failed',

--- a/packages/verify/src/i18n/translations/ja.ts
+++ b/packages/verify/src/i18n/translations/ja.ts
@@ -369,6 +369,8 @@ export const ja: VerifyTranslationKeys = {
     issueAnchoringMissing: '時刻アンカー（署名チェックポイント）がありません',
     issueAnchoringPostHoc: 'post-hoc 一括署名の疑いがあります（サーバ時刻が申告時間より極端に短い）',
     issueAnchoringSparse: 'アンカー密度が疎です（署名チェックポイントが申告セッションに対し少ない/遅い）',
+    issueSessionTokenMismatch:
+      'セッション開始トークンと署名チェックポイントのセッションIDが一致しません（別セッションのトークン流用の疑い）',
     issueRootNotAnchored: 'チェーン根がサーバアンカーされていません（開始時刻が未固定・オフライン捏造の余地）',
     issueNotPureTyping: 'ピュアタイピングではありません（ペースト/バルク挿入あり）',
     issueExamBindingFailed: '問題束縛（署名/内容ハッシュ）の検証に失敗しました',

--- a/packages/verify/src/i18n/types.ts
+++ b/packages/verify/src/i18n/types.ts
@@ -390,6 +390,7 @@ export interface VerifyTranslationKeys {
     issueAnchoringMissing: string;
     issueAnchoringPostHoc: string;
     issueAnchoringSparse: string;
+    issueSessionTokenMismatch: string;
     issueRootNotAnchored: string;
     issueNotPureTyping: string;
     issueExamBindingFailed: string;

--- a/packages/verify/src/services/TrustCalculator.ts
+++ b/packages/verify/src/services/TrustCalculator.ts
@@ -175,6 +175,17 @@ export class TrustCalculator {
       }
     }
 
+    // 7.2 セッション開始トークンと署名 cp の sessionId 突合（spec §6.3 / ADR-0017）。
+    //     別セッションのトークンを流用した proof。暗号的な改ざんではないので整合性（chain）ではなく
+    //     時刻アンカー層の error として上げる（chain に混ぜると「改ざんされた」と誤って告発する）。
+    if (verificationResult?.sessionTokenMismatch) {
+      issues.push({
+        component: 'anchoring',
+        severity: 'error',
+        message: t('trust.issueSessionTokenMismatch'),
+      });
+    }
+
     // 7.5 root のサーバアンカー（ADR-0017）。serverNonce 付きトークンで root がアンカーされていない
     //     (= 完全オフライン捏造の余地) なら警告。exam は独自の T0 束縛を持つため対象外。
     if (

--- a/packages/verify/src/services/__tests__/TrustCalculator.test.ts
+++ b/packages/verify/src/services/__tests__/TrustCalculator.test.ts
@@ -13,6 +13,7 @@ import type { ScreenshotVerificationSummary, VerificationResultData } from '../.
 /** 健全な anchored proof の検証結果 (テストごとに上書きして崩す)。 */
 function healthyResult(): VerificationResultData {
   return {
+    valid: true,
     metadataValid: true,
     chainValid: true,
     isPureTyping: true,
@@ -80,6 +81,29 @@ describe('TrustCalculator.calculate — level determination', () => {
     });
     expect(r.level).toBe('failed');
     expect(r.issues.some((i) => i.component === 'anchoring' && i.severity === 'error')).toBe(true);
+  });
+
+  it('attributes an invalid signed checkpoint to anchoring, never to the hash chain (#211)', () => {
+    // 委譲前は worker が chainValid に署名 cp を畳み込んでいたため「ハッシュチェーン: <anchoring の理由>」
+    // という誤帰属が出ていた。整合性 (chain) と時刻アンカーは別層 (ADR-0020)。
+    const r = calc({
+      ...healthyResult(),
+      valid: false,
+      chainValid: true,
+      signedCheckpointAnchored: true,
+      signedCheckpointValid: false,
+    });
+    expect(r.issues.some((i) => i.component === 'chain')).toBe(false);
+    expect(r.issues.some((i) => i.component === 'anchoring' && i.severity === 'error')).toBe(true);
+  });
+
+  it('fails when the session start token does not match the signed checkpoint session (#211)', () => {
+    // 別セッションのトークン流用 (spec §6.3)。CLI は invalid とするので web も緑にしない。
+    const r = calc({ ...healthyResult(), valid: false, sessionTokenMismatch: true });
+    expect(r.level).toBe('failed');
+    expect(r.issues.some((i) => i.component === 'anchoring' && i.severity === 'error')).toBe(true);
+    // 暗号的な改ざんではないので整合性 (chain) の error にはしない。
+    expect(r.issues.some((i) => i.component === 'chain')).toBe(false);
   });
 
   it('warns (partial) when no signed checkpoint anchors the proof', () => {

--- a/packages/verify/src/services/__tests__/webCliParity.test.ts
+++ b/packages/verify/src/services/__tests__/webCliParity.test.ts
@@ -1,0 +1,533 @@
+/**
+ * web ↔ CLI パリティテスト (#216)
+ *
+ * 同じ proof を「verify (web) の検証経路」と「verify-cli の検証経路」に通し、**結論が一致する**
+ * ことを CI で固定する。2026-08-02 のレビューで見つかった重大な乖離は例外なく
+ * 「shared に委譲していない箇所」に集中していた (#211) ので、文書ルールではなくテストで縛る。
+ *
+ * そろえる観点: 総合判定 (valid) / 三層保証 (integrity・temporal・provenance) / exam 束縛 /
+ * スクリーンショット集計 (tampered・chainOnly)。正常系だけでなく **片方だけが落ちうるケース**
+ * (別セッションのトークン流用・署名 cp のみ無効・スクショ改竄・スクショ剥ぎ取り) を含める。
+ *
+ * 注: スクショの **読込経路** (ZIP vs フォルダ) の一致は `screenshotParity.test.ts` (#212) が持つ。
+ * ここが見るのは「同じ材料から web と CLI が同じ集計と同じ結論に至るか」(#213 の軸を含む)。
+ */
+
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  TypingProof,
+  checkScreenshotImage,
+  collectChainImageHashes,
+  computeHash,
+  createSessionStartToken,
+  deriveAssurance,
+  sha256HexOfBytes,
+  summarizeScreenshotArtifacts,
+  type AssuranceResult,
+  type CheckpointData,
+  type ExamPackageManifest,
+  type ExamSessionContext,
+  type FingerprintComponents,
+  type ScreenshotCaptureData,
+  type ScreenshotVerificationSummary,
+  type SessionStartToken,
+} from '@typedcode/shared';
+import {
+  buildSignedCheckpoints,
+  createTestKey,
+  type TestKey,
+} from '../../../../shared/src/__tests__/fixtures/signedCheckpointFixtures.js';
+import { buildSamplePackage, makeExamAuthority } from '../../../../shared/src/__tests__/fixtures/examFixtures.js';
+import { verifyProof } from '../../../../verify-cli/src/verify.js';
+import { buildAssuranceInput, isOverallValid, runProofVerification } from '../proofVerification.js';
+import { summarizeTabScreenshots } from '../screenshotSummary.js';
+import type { ProofFile, VerifyScreenshot } from '../../types.js';
+
+const SERVER_NONCE = 'a1'.repeat(32);
+const ISSUED_AT = '2026-06-12T00:00:00.000Z';
+
+/**
+ * PoSW 用 Web Worker のスタブ (shared の `src/__tests__/setup.ts` と同じ役割)。
+ * proof 生成時に `TypingProof` が Worker を起こすが Node 環境には存在しない。PoSW の
+ * 反復再計算はどちらの経路でも `mode: 'fast'` でスキップするので、値は固定で構わない。
+ */
+class PoswWorkerStub {
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: ErrorEvent) => void) | null = null;
+
+  postMessage(message: Record<string, unknown>): void {
+    queueMicrotask(() => {
+      if (!this.onmessage) return;
+      const data =
+        message.type === 'compute-posw'
+          ? {
+              type: 'posw-result',
+              requestId: message.requestId,
+              iterations: message.iterations,
+              nonce: 'stub-nonce',
+              intermediateHash: 'stub-intermediate-hash',
+              computeTimeMs: 1,
+            }
+          : { type: 'verify-result', requestId: message.requestId, valid: true };
+      this.onmessage({ data } as MessageEvent);
+    });
+  }
+
+  terminate(): void {
+    // no-op
+  }
+}
+
+vi.stubGlobal('Worker', PoswWorkerStub);
+
+const createMockFingerprintComponents = (): FingerprintComponents => ({
+  userAgent: 'Mozilla/5.0 (Parity Test)',
+  language: 'en',
+  languages: ['en'],
+  platform: 'TestOS',
+  hardwareConcurrency: 4,
+  deviceMemory: 8,
+  screen: {
+    width: 1440,
+    height: 900,
+    availWidth: 1440,
+    availHeight: 860,
+    colorDepth: 24,
+    pixelDepth: 24,
+    devicePixelRatio: 2,
+  },
+  timezone: 'UTC',
+  timezoneOffset: 0,
+  canvas: 'mock-canvas',
+  webgl: { vendor: 'Mock', renderer: 'Mock' },
+  fonts: ['Arial'],
+  cookieEnabled: true,
+  doNotTrack: 'unspecified',
+  maxTouchPoints: 0,
+});
+
+async function makeToken(key: TestKey, sessionId: string, fingerprintHash: string): Promise<SessionStartToken> {
+  return createSessionStartToken(
+    { sessionId, fingerprintHash },
+    {
+      serverNonce: SERVER_NONCE,
+      issuedAt: ISSUED_AT,
+      turnstileVerified: true,
+      hostname: 'typedcode.dev',
+      action: 'create_tab',
+    },
+    { keyId: key.keyId, privateKey: key.privateKey }
+  );
+}
+
+async function typeInto(proof: TypingProof, text: string): Promise<string> {
+  let content = '';
+  for (const ch of text) {
+    await proof.recordEvent({
+      type: 'contentChange',
+      inputType: 'insertText',
+      data: ch,
+      rangeOffset: content.length,
+      rangeLength: 0,
+    });
+    content += ch;
+  }
+  return content;
+}
+
+/**
+ * root がサーバアンカーされ、署名 cp も付いた「健全な」proof を作る。
+ * `tokenSessionId` と `checkpointSessionId` を別々に指定できるのは、別セッションのトークンを
+ * 流用した proof (spec §6.3 が弾く) を再現するため。
+ */
+async function buildAnchoredProof(options: {
+  key: TestKey;
+  tokenSessionId: string;
+  checkpointSessionId: string;
+}): Promise<ProofFile> {
+  const components = createMockFingerprintComponents();
+  const fingerprintHash = await computeHash(JSON.stringify(components, null, 0));
+  const token = await makeToken(options.key, options.tokenSessionId, fingerprintHash);
+
+  const proof = new TypingProof();
+  await proof.initializeAnchored(fingerprintHash, components, SERVER_NONCE, token);
+  const content = await typeInto(proof, 'hello');
+  const exported = await proof.exportProof(content);
+
+  const checkpoints = await buildSignedCheckpoints({
+    events: exported.proof.events,
+    initialEventChainHash: exported.typingProofData.initialEventChainHash ?? '',
+    key: options.key,
+    sessionId: options.checkpointSessionId,
+  });
+
+  return { ...exported, checkpoints, content, language: 'text' } as ProofFile;
+}
+
+/** 署名 cp を持たない casual proof (exam ブロックは任意)。 */
+async function buildPlainProof(examContext?: ExamSessionContext): Promise<ProofFile> {
+  const components = createMockFingerprintComponents();
+  const fingerprintHash = await computeHash(JSON.stringify(components, null, 0));
+  const proof = new TypingProof();
+  if (examContext) {
+    await proof.initializeExam(fingerprintHash, components, examContext);
+  } else {
+    await proof.initialize(fingerprintHash, components);
+  }
+  const content = await typeInto(proof, 'abc');
+  const exported = await proof.exportProof(content);
+  return { ...exported, content, language: 'text' } as ProofFile;
+}
+
+/**
+ * チェーンに `screenshotCapture` (imageHash 付き) を 1 枚焼いた casual proof。
+ * チェーンは改ざん不能なので、この imageHash がスクショの唯一の真正な記録になる。
+ */
+async function buildProofWithScreenshot(imageHash: string): Promise<ProofFile> {
+  const components = createMockFingerprintComponents();
+  const fingerprintHash = await computeHash(JSON.stringify(components, null, 0));
+  const proof = new TypingProof();
+  await proof.initialize(fingerprintHash, components);
+  const content = await typeInto(proof, 'ab');
+  const capture: ScreenshotCaptureData = {
+    imageHash,
+    captureType: 'periodic',
+    timestamp: 10,
+    displayInfo: { width: 1440, height: 900, devicePixelRatio: 2 } as ScreenshotCaptureData['displayInfo'],
+    storageKey: 'shot-0',
+    fileSizeBytes: 24,
+  };
+  await proof.recordEvent({ type: 'screenshotCapture', data: capture });
+  const exported = await proof.exportProof(content);
+  return { ...exported, content, language: 'text' } as ProofFile;
+}
+
+/** manifest entry (CLI 入口) と VerifyScreenshot (web 入口) を同じ材料から作る。 */
+async function buildScreenshotInputs(options: {
+  proof: ProofFile;
+  /** manifest が申告する imageHash。チェーンの値とずらすと「差し替え」になる。 */
+  manifestImageHash: string;
+  /** 実ファイルのバイト列。null なら欠損。 */
+  bytes: Uint8Array | null;
+}): Promise<{ web: ScreenshotVerificationSummary | undefined; cli: ScreenshotVerificationSummary }> {
+  const { proof, manifestImageHash, bytes } = options;
+  const chainImageHashes = collectChainImageHashes([proof.proof.events]);
+  const entries = [{ filename: 'shot-0.webp', imageHash: manifestImageHash }];
+
+  // CLI 入口: manifest entry + 画像バイト列 → shared がまとめて集計する。
+  const cli = await summarizeScreenshotArtifacts({
+    entries,
+    getImageBytes: async () => bytes,
+    chainImageHashes,
+  });
+
+  // web 入口: 読込時に per-image 判定 (ScreenshotService と同じ shared の checkScreenshotImage)
+  // を済ませた VerifyScreenshot を per-tab 集計にかける。
+  const check = bytes ? await checkScreenshotImage(bytes, manifestImageHash, chainImageHashes) : null;
+  const screenshots: VerifyScreenshot[] = [
+    {
+      imageHash: manifestImageHash,
+      verified: check?.verified ?? false,
+      tampered: check?.tampered ?? false,
+      missing: bytes === null,
+    } as unknown as VerifyScreenshot,
+  ];
+  const web = summarizeTabScreenshots({ screenshots, events: proof.proof.events });
+  return { web, cli };
+}
+
+/** 架空の束縛値で exam root を自己整合させた proof (束縛は package を当てれば必ず落ちる)。 */
+const forgedExamContext = (): ExamSessionContext => ({
+  examId: 'exam-1',
+  problemId: 'p1',
+  variant: null,
+  packageHash: 'f'.repeat(64),
+  problemContentHash: 'e'.repeat(64),
+  startToken: 'ABCD1234',
+});
+
+interface ParityConclusion {
+  valid: boolean;
+  assurance: AssuranceResult;
+  exam: { present: boolean; packageProvided: boolean; bindingValid?: boolean } | null;
+}
+
+interface ConclusionOptions {
+  manifest?: ExamPackageManifest;
+  /**
+   * スクリーンショット集計。`undefined` = 未検査 (proof.json 単体) で、どちらの経路でも
+   * 判定に影響させない。web は `summarizeTabScreenshots`、CLI は `summarizeScreenshotArtifacts`
+   * が作る同じ型 (shared の `ScreenshotVerificationSummary`)。
+   */
+  screenshots?: ScreenshotVerificationSummary;
+}
+
+/** verify (web) の経路: Worker が使う合成 → UI (TabController / VerificationController) の総合判定と三層保証。 */
+async function webConclusion(
+  proof: ProofFile,
+  registry: readonly TestKey['registryEntry'][],
+  options: ConclusionOptions = {}
+): Promise<ParityConclusion> {
+  const result = await runProofVerification(proof, {
+    mode: 'fast',
+    manifest: options.manifest,
+    signedCheckpointKeyRegistry: registry,
+  });
+  const screenshotsTampered = options.screenshots?.tampered;
+  return {
+    valid: isOverallValid(result, { screenshotsTampered }),
+    assurance: deriveAssurance(buildAssuranceInput(result, { screenshotsTampered })),
+    exam: result.exam
+      ? {
+          present: result.exam.present,
+          packageProvided: result.exam.packageProvided,
+          bindingValid: result.exam.binding?.valid,
+        }
+      : null,
+  };
+}
+
+/** verify-cli の経路: CLI 本体の verifyProof をそのまま呼ぶ。 */
+async function cliConclusion(
+  proof: ProofFile,
+  registry: readonly TestKey['registryEntry'][],
+  options: ConclusionOptions = {}
+): Promise<ParityConclusion> {
+  const result = await verifyProof(proof, {
+    mode: 'fast',
+    examPackageManifest: options.manifest,
+    signedCheckpointKeyRegistry: registry,
+    screenshotSummary: options.screenshots,
+  });
+  return {
+    valid: result.valid,
+    assurance: result.assurance,
+    exam: result.exam
+      ? {
+          present: result.exam.present,
+          packageProvided: result.exam.packageProvided,
+          bindingValid: result.exam.binding?.valid,
+        }
+      : null,
+  };
+}
+
+/** 分析層 (ADR-0009) は advisory なので比較対象は integrity / temporal と pureTyping に絞る。 */
+function comparableAssurance(a: AssuranceResult) {
+  return { integrity: a.integrity, temporal: a.temporal, pureTyping: a.provenance.pureTyping };
+}
+
+function expectSameConclusion(web: ParityConclusion, cli: ParityConclusion): void {
+  expect(web.valid).toBe(cli.valid);
+  expect(comparableAssurance(web.assurance)).toEqual(comparableAssurance(cli.assurance));
+  expect(web.exam).toEqual(cli.exam);
+}
+
+let testKey: TestKey;
+let registry: readonly TestKey['registryEntry'][];
+
+beforeAll(async () => {
+  testKey = await createTestKey();
+  registry = [testKey.registryEntry];
+});
+
+describe('web ↔ CLI parity (#216)', () => {
+  it('agrees that a healthy anchored proof is valid and fully anchored', async () => {
+    const proof = await buildAnchoredProof({
+      key: testKey,
+      tokenSessionId: 'session-A',
+      checkpointSessionId: 'session-A',
+    });
+
+    const web = await webConclusion(proof, registry);
+    const cli = await cliConclusion(proof, registry);
+
+    expectSameConclusion(web, cli);
+    expect(web.valid).toBe(true);
+    expect(web.assurance.integrity).toBe('proven');
+    expect(web.assurance.temporal).toBe('anchored');
+  });
+
+  it('agrees that a proof reusing another session token is invalid (spec §6.3)', async () => {
+    // 別セッションで発行されたトークンを流用: root は自己整合するが署名 cp の sessionId と食い違う。
+    const proof = await buildAnchoredProof({
+      key: testKey,
+      tokenSessionId: 'session-B',
+      checkpointSessionId: 'session-A',
+    });
+
+    const web = await webConclusion(proof, registry);
+    const cli = await cliConclusion(proof, registry);
+
+    expectSameConclusion(web, cli);
+    expect(cli.valid).toBe(false);
+    // 暗号的な改ざんはないので「整合性」は proven のまま — 誤って改ざん告発しない。
+    expect(cli.assurance.integrity).toBe('proven');
+  });
+
+  it('agrees that a proof whose signed checkpoint is invalid keeps integrity proven but fails overall', async () => {
+    const proof = await buildAnchoredProof({
+      key: testKey,
+      tokenSessionId: 'session-A',
+      checkpointSessionId: 'session-A',
+    });
+    // 署名だけを壊す (チェーン・メタデータ・content は無傷)。
+    const checkpoints = (proof.checkpoints ?? []).map((cp, index): CheckpointData => {
+      if (index !== 0 || !cp.signature) return cp;
+      const signature = cp.signature.signature;
+      const flipped = (signature[0] === 'a' ? 'b' : 'a') + signature.slice(1);
+      return { ...cp, signature: { ...cp.signature, signature: flipped } };
+    });
+    const tampered: ProofFile = { ...proof, checkpoints };
+
+    const web = await webConclusion(tampered, registry);
+    const cli = await cliConclusion(tampered, registry);
+
+    expectSameConclusion(web, cli);
+    expect(cli.valid).toBe(false);
+    // ADR-0020 の三層: 落ちたのは時刻アンカー層であって整合性ではない。
+    expect(cli.assurance.integrity).toBe('proven');
+    expect(cli.assurance.temporal).toBe('partial');
+  });
+
+  it('agrees that a tampered hash chain fails integrity', async () => {
+    const proof = await buildAnchoredProof({
+      key: testKey,
+      tokenSessionId: 'session-A',
+      checkpointSessionId: 'session-A',
+    });
+    const events = proof.proof.events.map((event, index) => (index === 1 ? { ...event, data: 'X' } : event));
+    const tampered: ProofFile = { ...proof, proof: { ...proof.proof, events } };
+
+    const web = await webConclusion(tampered, registry);
+    const cli = await cliConclusion(tampered, registry);
+
+    expectSameConclusion(web, cli);
+    expect(cli.valid).toBe(false);
+    expect(cli.assurance.integrity).toBe('failed');
+  });
+
+  it('agrees on an unanchored casual proof (no signed checkpoints)', async () => {
+    const proof = await buildPlainProof();
+
+    const web = await webConclusion(proof, registry);
+    const cli = await cliConclusion(proof, registry);
+
+    expectSameConclusion(web, cli);
+    expect(cli.valid).toBe(true);
+    expect(cli.assurance.temporal).toBe('unanchored');
+  });
+
+  it('agrees on an exam proof whose package was not provided (binding unverified)', async () => {
+    const proof = await buildPlainProof(forgedExamContext());
+
+    const web = await webConclusion(proof, registry);
+    const cli = await cliConclusion(proof, registry);
+
+    expectSameConclusion(web, cli);
+    expect(cli.exam).toEqual({ present: true, packageProvided: false, bindingValid: undefined });
+    // 自己申告の exam ブロックだけでは exam-t0 を名乗れない (#131 / ADR-0020)。
+    expect(cli.assurance.temporal).not.toBe('exam-t0');
+  });
+
+  it('agrees that a provided exam package failing binding invalidates the proof', async () => {
+    const authority = await makeExamAuthority();
+    // registry (本番の出題者鍵) に載っていないテスト鍵で署名した package → 束縛は必ず落ちる。
+    const { manifest } = await buildSamplePackage(authority.signer);
+    const proof = await buildPlainProof(forgedExamContext());
+
+    const web = await webConclusion(proof, registry, { manifest });
+    const cli = await cliConclusion(proof, registry, { manifest });
+
+    expectSameConclusion(web, cli);
+    expect(cli.valid).toBe(false);
+    expect(cli.exam?.bindingValid).toBe(false);
+    expect(cli.assurance.integrity).toBe('failed');
+  });
+
+  it('agrees on a healthy screenshot (chain-backed image, no issue)', async () => {
+    const bytes = new TextEncoder().encode('genuine-screenshot-bytes');
+    const imageHash = await sha256HexOfBytes(bytes);
+    const proof = await buildProofWithScreenshot(imageHash);
+
+    const summaries = await buildScreenshotInputs({ proof, manifestImageHash: imageHash, bytes });
+    expect(summaries.web).toEqual(summaries.cli);
+    expect(summaries.cli).toMatchObject({ total: 1, verified: 1, tampered: 0, chainOnly: 0 });
+
+    const web = await webConclusion(proof, registry, { screenshots: summaries.web });
+    const cli = await cliConclusion(proof, registry, { screenshots: summaries.cli });
+
+    expectSameConclusion(web, cli);
+    expect(cli.valid).toBe(true);
+    expect(cli.assurance.integrity).toBe('proven');
+  });
+
+  it('agrees that a screenshot swapped together with its manifest hash fails integrity (#212)', async () => {
+    // manifest と画像をセットで差し替えた提出物。画像の SHA-256 は manifest と一致する
+    // (verified) が、チェーンに焼かれた imageHash には無い → 改竄。
+    const chainBytes = new TextEncoder().encode('genuine-screenshot-bytes');
+    const chainImageHash = await sha256HexOfBytes(chainBytes);
+    const swappedBytes = new TextEncoder().encode('swapped-screenshot-bytes');
+    const swappedImageHash = await sha256HexOfBytes(swappedBytes);
+    const proof = await buildProofWithScreenshot(chainImageHash);
+
+    const summaries = await buildScreenshotInputs({
+      proof,
+      manifestImageHash: swappedImageHash,
+      bytes: swappedBytes,
+    });
+    expect(summaries.web).toEqual(summaries.cli);
+    // 差し替えた 1 枚は tampered、チェーン側の 1 枚は manifest に無いので chainOnly。
+    expect(summaries.cli).toMatchObject({ tampered: 1, chainOnly: 1 });
+
+    const web = await webConclusion(proof, registry, { screenshots: summaries.web });
+    const cli = await cliConclusion(proof, registry, { screenshots: summaries.cli });
+
+    expectSameConclusion(web, cli);
+    expect(cli.valid).toBe(false);
+    // スクショ改竄は整合性 (error 軸) — チェーン自体は無傷でも proof 全体を落とす。
+    expect(cli.assurance.integrity).toBe('failed');
+  });
+
+  it('agrees that stripped screenshots are a warning, not an integrity failure (#213)', async () => {
+    // `screenshots/` を丸ごと落とした提出物: manifest entry は 0 だが、チェーンには記録が残る。
+    const bytes = new TextEncoder().encode('genuine-screenshot-bytes');
+    const imageHash = await sha256HexOfBytes(bytes);
+    const proof = await buildProofWithScreenshot(imageHash);
+    const chainImageHashes = collectChainImageHashes([proof.proof.events]);
+
+    const cliSummary = await summarizeScreenshotArtifacts({
+      entries: [],
+      getImageBytes: async () => null,
+      chainImageHashes,
+    });
+    const webSummary = summarizeTabScreenshots({ screenshots: [], events: proof.proof.events });
+    expect(webSummary).toEqual(cliSummary);
+    expect(cliSummary).toMatchObject({ total: 0, tampered: 0, chainOnly: 1 });
+
+    const web = await webConclusion(proof, registry, { screenshots: webSummary });
+    const cli = await cliConclusion(proof, registry, { screenshots: cliSummary });
+
+    expectSameConclusion(web, cli);
+    // 剥ぎ取りは warning 軸 (exit code / valid には干渉しない)。誤って改ざん告発しないこと。
+    expect(cli.valid).toBe(true);
+    expect(cli.assurance.integrity).toBe('proven');
+  });
+
+  it('agrees that screenshots are simply not checked for a bare proof.json', async () => {
+    const bytes = new TextEncoder().encode('genuine-screenshot-bytes');
+    const imageHash = await sha256HexOfBytes(bytes);
+    const proof = await buildProofWithScreenshot(imageHash);
+
+    // proof.json 単体投入 = 検査対象が無い。「0 枚」と混同すると剥ぎ取り扱いになって誤検知。
+    const webSummary = summarizeTabScreenshots({ screenshots: undefined, events: proof.proof.events });
+    expect(webSummary).toBeUndefined();
+
+    const web = await webConclusion(proof, registry, { screenshots: webSummary });
+    const cli = await cliConclusion(proof, registry, { screenshots: undefined });
+
+    expectSameConclusion(web, cli);
+    expect(cli.valid).toBe(true);
+    expect(cli.assurance.integrity).toBe('proven');
+  });
+});

--- a/packages/verify/src/services/proofVerification.ts
+++ b/packages/verify/src/services/proofVerification.ts
@@ -1,0 +1,367 @@
+/**
+ * proofVerification - verify (web) の検証実行 (Web Worker から呼ばれる純ロジック)
+ *
+ * **検証そのものは shared の `verifyProofFile` に全面委譲する** (#211)。ここは
+ * 「shared の結果を UI 型 (VerificationResultData) に写す」だけのアダプタで、判定ロジックを
+ * 書かない (verify/CLAUDE.md の不変条件: shared の検証ロジックを再実装しない)。
+ *
+ * 過去にここでレイヤを再合成していたため、
+ * - `sessionStartToken` ↔ 署名 cp の sessionId 突合 (spec §6.3) が web だけ欠落
+ * - `chainValid` に署名 cp の失敗を畳み込み、整合性チップが誤って FAILED になる (ADR-0020 違反)
+ * という乖離が生まれていた。web↔CLI パリティは `__tests__/webCliParity.test.ts` が固定する (#216)。
+ */
+
+import {
+  CHECKPOINT_PUBLIC_KEYS,
+  findCheckpointPublicKey,
+  runAnalysis,
+  summarizeAnalysisForAssurance,
+  verifyExamBinding,
+  verifyProofFile,
+} from '@typedcode/shared';
+import type {
+  AnalysisReport,
+  AssuranceInput,
+  CheckpointData,
+  CheckpointPublicKey,
+  ExamPackageManifest,
+  ProofFile as SharedProofFile,
+  SignedCheckpointsVerificationResult,
+  StoredEvent,
+} from '@typedcode/shared';
+import type {
+  AnchorEnvelopeIssue,
+  AnchorKeyInfo,
+  AnchorPoint,
+  PoswMode,
+  ProofFile,
+  SignedCheckpointReport,
+  VerificationMode,
+  VerificationResultData,
+} from '../types.js';
+
+/** 検証以前に弾く不備 (i18n キー)。Worker はこれを sendError で返す。 */
+export type UnsupportedProofReason = 'errors.unsupportedFormat' | 'errors.noEvents';
+
+export interface RunProofVerificationOptions {
+  mode?: VerificationMode;
+  /** 試験モード (ADR-0006): 問題パッケージ。あれば exam 束縛を完全検証する。 */
+  manifest?: ExamPackageManifest;
+  /** チェーン検証の進捗 (current, total)。shared の `VerificationProgressCallback` と同形。 */
+  onChainProgress?: (current: number, total: number) => void;
+  /** 公開鍵レジストリ (テストから注入)。未指定なら shared の既定 registry。 */
+  signedCheckpointKeyRegistry?: readonly CheckpointPublicKey[];
+}
+
+/**
+ * 検証に入る前の形式チェック。null なら検証可能。
+ * metadata (v3.0.0 以降) と events が無い proof は検証対象外として UI にエラーを出す。
+ */
+export function findUnsupportedProofReason(proof: ProofFile): UnsupportedProofReason | null {
+  // content は空文字列を許可（初期化のみのファイル）
+  const hasContent = proof.content !== undefined && proof.content !== null;
+  if (!proof.typingProofHash || !proof.typingProofData || !hasContent) {
+    return 'errors.unsupportedFormat';
+  }
+  if (!proof.proof?.events) {
+    return 'errors.noEvents';
+  }
+  return null;
+}
+
+function poswModeFor(mode: VerificationMode): PoswMode {
+  switch (mode) {
+    case 'fast':
+      return 'skipped';
+    case 'audit':
+      // Phase 2 ではプレースホルダ (現状 full と同じ挙動)
+      return 'full';
+    default:
+      return 'full';
+  }
+}
+
+/**
+ * PoSW統計を計算 (表示専用。判定には使わない)
+ */
+function calculatePoSWStats(events: StoredEvent[]): VerificationResultData['poswStats'] {
+  const eventsWithPoSW = events.filter((event) => 'posw' in event && event.posw && typeof event.posw === 'object');
+
+  if (eventsWithPoSW.length === 0) {
+    return undefined;
+  }
+
+  let totalComputeTime = 0;
+  let iterations = 0;
+
+  for (const event of eventsWithPoSW) {
+    const posw = event.posw as { iterations: number; computeTimeMs: number };
+    totalComputeTime += posw.computeTimeMs;
+    if (iterations === 0) {
+      iterations = posw.iterations;
+    }
+  }
+
+  const avgTimeMs = eventsWithPoSW.length > 0 ? totalComputeTime / eventsWithPoSW.length : 0;
+
+  return {
+    count: eventsWithPoSW.length,
+    avgTimeMs,
+    totalTimeMs: totalComputeTime,
+    iterations,
+  };
+}
+
+/** signed checkpoint 検証が省略された場合の空結果 (型を埋めるためのみ)。 */
+const EMPTY_SIGNED_CHECKPOINTS: SignedCheckpointsVerificationResult = {
+  valid: false,
+  anchored: false,
+  details: [],
+  coverage: { signedCount: 0, lastSignedEventIndex: null, coverageRatio: 0 },
+  temporal: null,
+  density: null,
+};
+
+/**
+ * 検証を実行し UI 型の結果を返す。
+ *
+ * 手順は verify-cli (`packages/verify-cli/src/verify.ts`) と同じ順序:
+ * exam 束縛 → `verifyProofFile` → `runAnalysis` (advisory)。
+ */
+export async function runProofVerification(
+  proof: ProofFile,
+  options: RunProofVerificationOptions = {}
+): Promise<VerificationResultData> {
+  const mode: VerificationMode = options.mode ?? 'full';
+  const sharedProof = proof as unknown as SharedProofFile;
+  const totalEvents = proof.proof?.events?.length ?? 0;
+
+  // 1. 試験モード (ADR-0006): exam ブロックがあり package も渡されたときのみ完全束縛を検証する。
+  //    root アンカー gate (#131) の exam 免除は「検証済み束縛」に基づくので verifyProofFile より前に計算する。
+  let examBinding: NonNullable<VerificationResultData['exam']>['binding'];
+  if (proof.exam && options.manifest) {
+    try {
+      examBinding = await verifyExamBinding(sharedProof, options.manifest);
+    } catch (err) {
+      examBinding = {
+        valid: false,
+        packageSignatureValid: false,
+        packageHashMatches: false,
+        rootMatches: false,
+        problemContentHashMatches: false,
+        timeBox: null,
+        reason: `Exam binding verification threw: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+
+  // 2. 検証本体。metadata / chain / finalHash / content / checkpoint / 署名 cp /
+  //    sessionStartToken 突合 の合成はすべて shared 側 (CLI と同一の結論)。
+  const result = await verifyProofFile(sharedProof, options.onChainProgress, {
+    mode,
+    examBindingVerified: examBinding?.valid === true,
+    signedCheckpointKeyRegistry: options.signedCheckpointKeyRegistry,
+  });
+
+  const signedCheckpoints = result.signedCheckpoints ?? EMPTY_SIGNED_CHECKPOINTS;
+
+  // 3. 分析層 (ADR-0009): 検証と直交する post-hoc 分析。advisory であって判定ではない
+  //    (valid には一切反映しない)。分析の失敗は検証結果を落とさない。
+  let analysis: AnalysisReport | undefined;
+  try {
+    analysis = await runAnalysis({ proof: sharedProof, verification: result });
+  } catch {
+    analysis = undefined;
+  }
+
+  const examResult: VerificationResultData['exam'] = proof.exam
+    ? {
+        present: true,
+        rootValid: result.rootValid ?? false,
+        packageProvided: !!options.manifest,
+        binding: examBinding,
+      }
+    : undefined;
+
+  return {
+    valid: result.valid,
+    metadataValid: result.metadataValid,
+    rootValid: result.rootValid,
+    rootAnchored: result.rootAnchored,
+    sessionTokenMismatch: result.sessionTokenMismatch,
+    chainValid: result.chainValid,
+    finalHashValid: result.finalHashValid,
+    contentValid: result.contentValid,
+    checkpointValid: result.checkpointValid,
+    isPureTyping: result.isPureTyping,
+    message: result.errorMessage,
+    errorAt: result.errorAt,
+    totalEvents,
+    poswStats: calculatePoSWStats(proof.proof.events),
+    verificationMode: mode,
+    poswMode: poswModeFor(mode),
+    signedCheckpointValid: signedCheckpoints.anchored ? signedCheckpoints.valid : undefined,
+    signedCheckpointAnchored: signedCheckpoints.anchored,
+    signedCheckpointCoverage: signedCheckpoints.coverage,
+    signedCheckpointTemporal: signedCheckpoints.temporal,
+    signedCheckpointDensity: signedCheckpoints.density,
+    signedCheckpointReason: signedCheckpoints.reason,
+    signedCheckpointReport: buildSignedCheckpointReport(
+      proof.checkpoints ?? [],
+      signedCheckpoints,
+      options.signedCheckpointKeyRegistry
+    ),
+    analysis,
+    exam: examResult,
+  };
+}
+
+/**
+ * UI の総合判定。verify-cli の `valid` (= `verifyProofFile` の valid × exam 束縛 × スクショ改竄)
+ * と**同じ合成**にする。ここが CLI とずれると「Web で OK / CLI で NG」が起きる。
+ */
+export function isOverallValid(
+  result: VerificationResultData,
+  options: { screenshotsTampered?: number } = {}
+): boolean {
+  // package が渡されたときのみ束縛失敗を全体 fail にする (proof 自己整合とは別軸の真正性)。
+  const examBindingFailed = !!result.exam?.packageProvided && result.exam.binding?.valid === false;
+  return result.valid && !examBindingFailed && (options.screenshotsTampered ?? 0) === 0;
+}
+
+/**
+ * 三層保証 (ADR-0020) の導出入力を検証結果から組み立てる。
+ *
+ * verify-cli (`packages/verify-cli/src/verify.ts`) の同じ写像と**一致していること**が
+ * web↔CLI パリティの要。導出そのものは shared の `deriveAssurance` に委譲する。
+ */
+export function buildAssuranceInput(
+  result: VerificationResultData,
+  options: { screenshotsTampered?: number } = {}
+): AssuranceInput {
+  return {
+    metadataValid: result.metadataValid,
+    chainValid: result.chainValid,
+    screenshotsTampered: options.screenshotsTampered,
+    exam: result.exam
+      ? {
+          present: true,
+          packageProvided: result.exam.packageProvided,
+          bindingValid: result.exam.binding?.valid,
+        }
+      : undefined,
+    rootAnchored: result.rootAnchored ?? false,
+    signedCheckpoints:
+      result.signedCheckpointAnchored !== undefined
+        ? {
+            anchored: result.signedCheckpointAnchored,
+            valid: result.signedCheckpointValid,
+            sparse: result.signedCheckpointDensity?.sparse,
+            postHocSuspected: result.signedCheckpointTemporal?.postHocSuspected,
+          }
+        : undefined,
+    isPureTyping: result.isPureTyping,
+    analysis: result.analysis ? summarizeAnalysisForAssurance(result.analysis) : undefined,
+  };
+}
+
+/**
+ * Signed checkpoint カードの「展開時の根拠」表示に渡す詳細情報を組み立てる。
+ *
+ * 含める情報:
+ * - 検証の母集団: proof 内の checkpoint 総数 / 署名済み数 / valid 数
+ * - 範囲: 最初の anchor (cp #0) と最後の anchor の (checkpointIndex, eventIndex,
+ *   serverTimestamp, clientTimestamp)。Coverage 行の補強として使える。
+ * - 鍵レジストリ整合: 各 envelope の keyId を一意化して registry を引き、
+ *   description / status / validFrom 等を返す (鍵 rotation や revoke の根拠)。
+ * - 失敗 / 警告 envelope の特定: verifySignedCheckpoints の details から
+ *   valid=false や warning 付きのものを抜き出す。エラー位置の根拠になる。
+ */
+export function buildSignedCheckpointReport(
+  checkpoints: readonly CheckpointData[],
+  result: SignedCheckpointsVerificationResult,
+  registry: readonly CheckpointPublicKey[] | undefined = CHECKPOINT_PUBLIC_KEYS
+): SignedCheckpointReport {
+  const signed = checkpoints.filter((cp) => cp.signature);
+  const detailByEvent = new Map(result.details.map((d) => [d.eventIndex, d]));
+
+  const firstEnvelope = signed[0]?.signature;
+  const lastEnvelope = signed[signed.length - 1]?.signature;
+
+  const toAnchor = (
+    env:
+      | { payload: { checkpointIndex: number; eventIndex: number; serverTimestamp: string; clientTimestamp: string } }
+      | undefined
+  ): AnchorPoint | undefined =>
+    env
+      ? {
+          checkpointIndex: env.payload.checkpointIndex,
+          eventIndex: env.payload.eventIndex,
+          serverTimestamp: env.payload.serverTimestamp,
+          clientTimestamp: env.payload.clientTimestamp,
+        }
+      : undefined;
+
+  // 一意な keyId を抽出 (順序保持)
+  const uniqueKeyIds: string[] = [];
+  const seenKeyIds = new Set<string>();
+  for (const cp of signed) {
+    const kid = cp.signature?.keyId;
+    if (!kid || seenKeyIds.has(kid)) continue;
+    seenKeyIds.add(kid);
+    uniqueKeyIds.push(kid);
+  }
+
+  const keys: AnchorKeyInfo[] = uniqueKeyIds.map((keyId) => {
+    const entry = findCheckpointPublicKey(keyId, registry);
+    if (!entry) {
+      return { keyId, status: 'unknown' };
+    }
+    return {
+      keyId,
+      status: entry.status,
+      algorithm: entry.algorithm,
+      description: entry.description,
+      validFrom: entry.validFrom,
+      validUntil: entry.validUntil,
+      revokedAt: entry.revokedAt,
+    };
+  });
+
+  const failedEnvelopes: AnchorEnvelopeIssue[] = [];
+  const warningEnvelopes: AnchorEnvelopeIssue[] = [];
+  for (const cp of signed) {
+    const payload = cp.signature?.payload;
+    if (!payload) continue;
+    const detail = detailByEvent.get(payload.eventIndex);
+    if (detail && !detail.valid) {
+      failedEnvelopes.push({
+        checkpointIndex: payload.checkpointIndex,
+        eventIndex: payload.eventIndex,
+        reason: detail.reason ?? 'invalid',
+      });
+    }
+    if (detail?.warning) {
+      warningEnvelopes.push({
+        checkpointIndex: payload.checkpointIndex,
+        eventIndex: payload.eventIndex,
+        reason: detail.warning,
+      });
+    }
+  }
+
+  const validCount = result.details.filter((d) => d.valid).length;
+
+  return {
+    totalCheckpoints: checkpoints.length,
+    signedCount: signed.length,
+    validCount,
+    firstSeenAt: firstEnvelope?.payload.firstSeenAt,
+    initialEventChainHash: firstEnvelope?.payload.initialEventChainHash,
+    firstAnchor: toAnchor(firstEnvelope),
+    lastAnchor: toAnchor(lastEnvelope),
+    keys,
+    failedEnvelopes,
+    warningEnvelopes,
+  };
+}

--- a/packages/verify/src/state/VerificationQueue.ts
+++ b/packages/verify/src/state/VerificationQueue.ts
@@ -18,7 +18,6 @@ export interface ProgressCallbackParams {
   id: string;
   progress: number;
   details: ProgressDetails;
-  hashInfo?: { computed: string; expected: string; poswHash?: string };
 }
 
 export type ProgressCallback = (params: ProgressCallbackParams) => void;
@@ -162,7 +161,6 @@ export class VerificationQueue {
               id: msg.id,
               progress,
               details,
-              hashInfo: msg.hashInfo,
             });
           } catch (error) {
             console.error('[VerificationQueue] Error in onProgressCallback:', error);

--- a/packages/verify/src/types.ts
+++ b/packages/verify/src/types.ts
@@ -68,10 +68,21 @@ export type PoswMode = 'skipped' | 'sampled' | 'full';
 
 /** 検証結果データ（Worker→メインスレッドへ渡すデータ） */
 export interface VerificationResultData {
+  /**
+   * 総合判定。shared の `verifyProofFile` が返す `valid` をそのまま持つ (= verify-cli と同一の結論)。
+   * metadata / chain に加えて、署名 cp の失敗とセッショントークンの sessionId 不一致 (spec §6.3) を含む。
+   * スクショ改竄 / exam 束縛は proof 外の証拠なので UI 側 (VerificationController) で合流させる。
+   */
+  valid: boolean;
   metadataValid: boolean;
   rootValid?: boolean;
   /** root がサーバアンカーされているか (ADR-0017)。`sessionStartToken` で root がアンカーされていれば true。 */
   rootAnchored?: boolean;
+  /**
+   * `sessionStartToken` の sessionId と署名 cp の sessionId が食い違ったか (spec §6.3)。
+   * true = 別セッションのトークン流用。**整合性 (chainValid) ではなく時刻アンカー層の問題**として扱う。
+   */
+  sessionTokenMismatch?: boolean;
   chainValid: boolean;
   finalHashValid?: boolean;
   contentValid?: boolean;
@@ -274,7 +285,6 @@ export interface WorkerResponseMessage {
   total?: number;
   phase?: string;
   totalEvents?: number; // 全イベント数
-  hashInfo?: { computed: string; expected: string; poswHash?: string };
   // result
   result?: VerificationResultData;
   // error

--- a/packages/verify/src/ui/controllers/TabController.ts
+++ b/packages/verify/src/ui/controllers/TabController.ts
@@ -17,12 +17,8 @@ import type { VerifyTabState, ProgressDetails, VerifyScreenshot, VerificationSte
 import { buildResultData, calculateChartStats } from '../../services/ResultDataService';
 import { TrustCalculator } from '../../services/TrustCalculator';
 import { summarizeTabScreenshots } from '../../services/screenshotSummary';
-import {
-  deriveAssurance,
-  summarizeAnalysisForAssurance,
-  summarizeProcess,
-  type AssuranceResult,
-} from '@typedcode/shared';
+import { buildAssuranceInput } from '../../services/proofVerification';
+import { deriveAssurance, summarizeProcess, type AssuranceResult } from '@typedcode/shared';
 import { t } from '../../i18n/index';
 
 export interface TabControllerDependencies {
@@ -295,33 +291,12 @@ export class TabController {
     if (!resultData) return;
 
     // 三層保証語彙 (ADR-0020): 実証拠のみから導出 (自己申告 mode は使わない)。
-    // スクショ改竄数を持つのはここだけなので導出はこの層で行う。
+    // スクショ改竄数を持つのはここだけなので導出はこの層で行う。写像は verify-cli と揃えた
+    // buildAssuranceInput、導出は shared の deriveAssurance (verify 側で再実装しない)。
     const vr = tabState.verificationResult;
     const assurance: AssuranceResult | undefined = vr
-      ? deriveAssurance({
-          metadataValid: vr.metadataValid,
-          chainValid: vr.chainValid,
-          screenshotsTampered: screenshotSummary?.tampered ?? 0,
-          exam: vr.exam
-            ? {
-                present: true,
-                packageProvided: vr.exam.packageProvided,
-                bindingValid: vr.exam.binding?.valid,
-              }
-            : undefined,
-          rootAnchored: vr.rootAnchored ?? false,
-          signedCheckpoints:
-            vr.signedCheckpointAnchored !== undefined
-              ? {
-                  anchored: vr.signedCheckpointAnchored,
-                  valid: vr.signedCheckpointValid,
-                  sparse: vr.signedCheckpointDensity?.sparse,
-                  postHocSuspected: vr.signedCheckpointTemporal?.postHocSuspected,
-                }
-              : undefined,
-          isPureTyping: vr.isPureTyping,
-          analysis: vr.analysis ? summarizeAnalysisForAssurance(vr.analysis) : undefined,
-        })
+      ? // undefined = 未検査 (proof.json 単体)。CLI も同じく undefined を渡すので integrity に影響しない。
+        deriveAssurance(buildAssuranceInput(vr, { screenshotsTampered: screenshotSummary?.tampered }))
       : undefined;
 
     // trustResult を追加してレンダリング

--- a/packages/verify/src/ui/controllers/VerificationController.ts
+++ b/packages/verify/src/ui/controllers/VerificationController.ts
@@ -10,6 +10,7 @@ import type { ResultPanel } from '../ResultPanel';
 import type { TabController } from './TabController';
 import type { ProgressDetails, VerificationResultData } from '../../types';
 import { summarizeTabScreenshots } from '../../services/screenshotSummary';
+import { isOverallValid } from '../../services/proofVerification';
 import { t } from '../../i18n/index';
 
 export interface VerificationControllerDependencies {
@@ -85,24 +86,17 @@ export class VerificationController {
     const hasScreenShareOptOut = events.some((e: { type: string }) => e.type === 'screenShareOptOut');
 
     // ステータス判定: エラー > 警告 > 成功。
-    // - error: チェーン/メタデータ破綻、署名 cp があるのに無効、package 提供下で exam 束縛失敗 (spec §6.4)、
-    //          スクショ改竄 (#146)
+    // - error: shared の総合判定 (`isOverallValid`) が false — チェーン/メタデータ破綻、署名 cp が
+    //          あるのに無効、セッショントークンの sessionId 不一致 (spec §6.3)、package 提供下で
+    //          exam 束縛失敗 (spec §6.4)、スクショ改竄 (#146)。**verify-cli の valid と同じ合成**。
     // - warning: 非ピュアタイピング / ソース不一致 / 時刻アンカー無し (偽造不能要素が無い) /
     //            post-hoc 一括署名疑い / anchoring 密度が疎 (ADR-0016) / exam だが問題パッケージ未検証 (真正性未確認) /
     //            スクショ欠損 / 剥ぎ取り疑い (#213) / 画面共有オプトアウト (#146)
-    const examBindingFailed = !!result.exam?.packageProvided && result.exam.binding?.valid === false;
-    const anchoredButInvalid = !!result.signedCheckpointAnchored && result.signedCheckpointValid === false;
     const examPresentButUnverified = !!result.exam?.present && !result.exam.packageProvided;
     // ADR-0017: root 未アンカー (serverNonce トークン無し) は警告。exam は独自束縛のため対象外。
     const rootNotAnchored = !result.rootAnchored && !result.exam?.present;
     let status: FileStatus;
-    if (
-      !result.metadataValid ||
-      !result.chainValid ||
-      examBindingFailed ||
-      anchoredButInvalid ||
-      screenshotsTampered > 0
-    ) {
+    if (!isOverallValid(result, { screenshotsTampered })) {
       status = 'error';
     } else if (
       !result.isPureTyping ||

--- a/packages/verify/src/workers/verificationWorker.ts
+++ b/packages/verify/src/workers/verificationWorker.ts
@@ -1,41 +1,15 @@
 /**
  * verificationWorker - ハッシュ鎖検証用Web Worker
  * メインスレッドをブロックせずにハッシュ鎖とPoSWの検証を行う
+ *
+ * ここはメッセージの入出力だけを担う薄いアダプタ。検証と結果の組み立ては
+ * `services/proofVerification.ts` (最終的には shared の `verifyProofFile`) が持つ。
+ * Worker 内に検証ロジックを書き戻さないこと (#211: 再実装が web↔CLI の乖離を生んだ)。
  */
 
-import {
-  CHECKPOINT_PUBLIC_KEYS,
-  TypingProof,
-  findCheckpointPublicKey,
-  runAnalysis,
-  verifyCheckpoints,
-  verifyContentReplay,
-  verifyFinalChainHash,
-  verifyInitialHashRoot,
-  verifyProofMetadata,
-  verifyProofSignedCheckpoints,
-  verifyExamBinding,
-} from '@typedcode/shared';
-import type {
-  AnalysisReport,
-  CheckpointData,
-  ExportedProof,
-  ExamPackageManifest,
-  ExamProofBlock,
-  FingerprintComponents,
-  ProofData,
-  SignedCheckpointsVerificationResult,
-  StoredEvent,
-} from '@typedcode/shared';
-import type {
-  AnchorEnvelopeIssue,
-  AnchorKeyInfo,
-  AnchorPoint,
-  PoswMode,
-  SignedCheckpointReport,
-  VerificationMode,
-  VerificationResultData,
-} from '../types.js';
+import { findUnsupportedProofReason, runProofVerification } from '../services/proofVerification.js';
+import type { ExamPackageManifest } from '@typedcode/shared';
+import type { ProofFile, VerificationMode, VerificationResultData } from '../types.js';
 
 // Worker内で使用するメッセージ型
 interface VerifyRequest {
@@ -44,24 +18,7 @@ interface VerifyRequest {
   mode?: VerificationMode;
   /** 試験モード (ADR-0006): 問題パッケージ。あれば exam 束縛を完全検証する。 */
   manifest?: ExamPackageManifest;
-  proofData: {
-    version?: string;
-    typingProofHash?: string;
-    typingProofData?: ProofData;
-    content?: string;
-    proof: {
-      events: StoredEvent[];
-      finalHash: string | null;
-    };
-    fingerprint: {
-      hash: string;
-      components: FingerprintComponents;
-    };
-    checkpoints?: CheckpointData[];
-    language?: string;
-    /** 試験モード (ADR-0006) の proof のみ持つ。root 式の分岐と exam 束縛検証に使う。 */
-    exam?: ExamProofBlock;
-  };
+  proofData: ProofFile;
 }
 
 interface ProgressResponse {
@@ -71,7 +28,6 @@ interface ProgressResponse {
   total: number;
   phase: string;
   totalEvents?: number; // 全イベント数
-  hashInfo?: { computed: string; expected: string; poswHash?: string };
 }
 
 interface ResultResponse {
@@ -89,14 +45,7 @@ interface ErrorResponse {
 /**
  * 進捗メッセージを送信
  */
-function sendProgress(
-  id: string,
-  current: number,
-  total: number,
-  phase: string,
-  totalEvents?: number,
-  hashInfo?: { computed: string; expected: string; poswHash?: string }
-): void {
+function sendProgress(id: string, current: number, total: number, phase: string, totalEvents?: number): void {
   const msg: ProgressResponse = {
     type: 'progress',
     id,
@@ -104,7 +53,6 @@ function sendProgress(
     total,
     phase,
     totalEvents,
-    hashInfo,
   };
   self.postMessage(msg);
 }
@@ -134,360 +82,39 @@ function sendError(id: string, error: string): void {
 }
 
 /**
- * PoSW統計を計算
- */
-function calculatePoSWStats(events: StoredEvent[]): VerificationResultData['poswStats'] {
-  const eventsWithPoSW = events.filter((event) => 'posw' in event && event.posw && typeof event.posw === 'object');
-
-  if (eventsWithPoSW.length === 0) {
-    return undefined;
-  }
-
-  let totalComputeTime = 0;
-  let iterations = 0;
-
-  for (const event of eventsWithPoSW) {
-    const posw = event.posw as { iterations: number; computeTimeMs: number };
-    totalComputeTime += posw.computeTimeMs;
-    if (iterations === 0) {
-      iterations = posw.iterations;
-    }
-  }
-
-  const avgTimeMs = eventsWithPoSW.length > 0 ? totalComputeTime / eventsWithPoSW.length : 0;
-
-  return {
-    count: eventsWithPoSW.length,
-    avgTimeMs,
-    totalTimeMs: totalComputeTime,
-    iterations,
-  };
-}
-
-function poswModeFor(mode: VerificationMode): PoswMode {
-  switch (mode) {
-    case 'fast':
-      return 'skipped';
-    case 'audit':
-      // Phase 2 ではプレースホルダ (現状 full と同じ挙動)
-      return 'full';
-    case 'full':
-    default:
-      return 'full';
-  }
-}
-
-/**
  * 検証を実行
  */
 async function verify(request: VerifyRequest): Promise<void> {
   const { id, proofData } = request;
   const mode: VerificationMode = request.mode ?? 'full';
-  const skipPosw = mode === 'fast';
 
   try {
-    const typingProof = new TypingProof();
-
-    // 1. メタデータ整合性の検証
-    let metadataValid = false;
-    let rootValid = false;
-    let rootAnchored = false;
-    let isPureTyping = false;
-    let metadataMessage: string | undefined;
-
     const totalEvents = proofData.proof?.events?.length ?? 0;
 
-    // content は空文字列を許可（初期化のみのファイル）
-    const hasContent = proofData.content !== undefined && proofData.content !== null;
-    if (proofData.typingProofHash && proofData.typingProofData && hasContent) {
-      sendProgress(id, 1, 3, 'metadata', totalEvents);
-
-      const hashVerification = await typingProof.verifyTypingProofHash(
-        proofData.typingProofHash,
-        proofData.typingProofData,
-        proofData.content ?? ''
-      );
-
-      // 上の guard で typingProofData は defined だが、TS は narrowing できないので
-      // 明示的に narrowed 型として渡す。
-      const narrowedProof = proofData as unknown as ExportedProof;
-      const rootVerification = await verifyInitialHashRoot(narrowedProof);
-      const eventMetadataVerification = verifyProofMetadata(proofData.typingProofData, proofData.proof?.events ?? []);
-      rootValid = rootVerification.valid;
-      rootAnchored = rootVerification.rootAnchored; // ADR-0017: serverNonce 付きトークンで root がアンカーされたか
-      metadataValid = hashVerification.valid && rootValid && eventMetadataVerification.valid;
-      metadataMessage = !hashVerification.valid
-        ? hashVerification.reason
-        : !rootVerification.valid
-          ? rootVerification.reason
-          : eventMetadataVerification.reason;
-      isPureTyping = eventMetadataVerification.isPureTyping;
-    } else {
-      // メタデータがない場合はサポート対象外（v3.0.0以降が必要）
-      // Worker 内ではユーザーのロケール設定 (localStorage) を参照できないため、
-      // 翻訳キーをそのまま送り、メインスレッド側 (VerificationController) で t() 解決する
-      sendError(id, 'errors.unsupportedFormat');
+    // メタデータ / events を持たない proof はサポート対象外 (v3.0.0 以降が必要)。
+    // Worker 内ではユーザーのロケール設定 (localStorage) を参照できないため、翻訳キーを
+    // そのまま送り、メインスレッド側 (VerificationController) で t() 解決する。
+    const unsupported = findUnsupportedProofReason(proofData);
+    if (unsupported) {
+      sendError(id, unsupported);
       return;
     }
 
-    sendProgress(id, 2, 3, 'metadata', totalEvents);
+    sendProgress(id, 1, 3, 'metadata', totalEvents);
 
-    // 2. ハッシュ鎖の検証
-    if (!proofData.proof?.events) {
-      sendError(id, 'errors.noEvents');
-      return;
-    }
-
-    typingProof.events = proofData.proof.events;
-    typingProof.currentHash = proofData.proof.finalHash;
-
-    // チェックポイントは未署名の補助情報なので、成功判定には常に全件検証を使う。
-    // fast モードでも sequence / timestamp / previousHash / hash 連鎖は完全検証する。
-    // skip するのは PoSW の反復再計算 (1 event あたり SHA-256 1 万回) のみ。
-    const chainVerification = await typingProof.verify(
-      (current: number, total: number, hashInfo?: { computed: string; expected: string; poswHash: string }) => {
-        sendProgress(id, current, total, 'chain', totalEvents, hashInfo);
+    const result = await runProofVerification(proofData, {
+      mode,
+      manifest: request.manifest,
+      onChainProgress: (current, total) => {
+        sendProgress(id, current, total, 'chain', totalEvents);
       },
-      { skipPosw }
-    );
+    });
 
     sendProgress(id, 3, 3, 'complete', totalEvents);
-    const finalHashVerification = chainVerification.valid
-      ? verifyFinalChainHash(proofData as unknown as ExportedProof, chainVerification.computedHash)
-      : { valid: false, reason: chainVerification.message };
-    const contentVerification = verifyContentReplay(proofData.proof.events, proofData.content ?? '');
-    const checkpointVerification = await verifyCheckpoints(proofData.proof.events, proofData.checkpoints);
-
-    // 3. Signed checkpoint 検証 (モード非依存)
-    // 上の metadata guard で typingProofData は defined 済み
-    let signedCheckpointResult: SignedCheckpointsVerificationResult | undefined;
-    try {
-      const narrowedForSigned = proofData as unknown as ExportedProof;
-      signedCheckpointResult = await verifyProofSignedCheckpoints(narrowedForSigned);
-    } catch (err) {
-      // signed checkpoint 検証中の例外で全体を落とさない (registry / 鍵 import 失敗等)
-      signedCheckpointResult = {
-        valid: false,
-        anchored: false,
-        details: [],
-        coverage: { signedCount: 0, lastSignedEventIndex: null, coverageRatio: 0 },
-        temporal: null,
-        density: null,
-        reason: `Signed checkpoint verification threw: ${err instanceof Error ? err.message : String(err)}`,
-      };
-    }
-
-    const signedCheckpointBlocks = signedCheckpointResult.anchored && !signedCheckpointResult.valid;
-
-    const chainValid =
-      chainVerification.valid &&
-      finalHashVerification.valid &&
-      checkpointVerification.valid &&
-      contentVerification.valid &&
-      !signedCheckpointBlocks;
-
-    const verificationMessage = !metadataValid
-      ? metadataMessage
-      : !chainVerification.valid
-        ? chainVerification.message
-        : !finalHashVerification.valid
-          ? finalHashVerification.reason
-          : !checkpointVerification.valid
-            ? checkpointVerification.reason
-            : !contentVerification.valid
-              ? contentVerification.reason
-              : signedCheckpointBlocks
-                ? signedCheckpointResult.reason
-                : chainVerification.message;
-
-    // 4. PoSW統計を計算
-    const poswStats = calculatePoSWStats(proofData.proof.events);
-
-    // 5. 「時刻アンカー」カードの根拠表示用の詳細情報を組み立てる
-    const signedCheckpointReport = buildSignedCheckpointReport(proofData.checkpoints ?? [], signedCheckpointResult);
-
-    // 5.5 試験モード (ADR-0006): exam ブロックがあれば束縛検証結果を組み立てる。
-    // root 束縛は rootValid (verifyInitialHashRoot の exam 分岐) で既に検証済み・package 不要。
-    // manifest が渡されたときのみ署名→packageHash→root→内容ハッシュ→time-box まで完全検証する。
-    let examResult: VerificationResultData['exam'];
-    if (proofData.exam) {
-      let examBinding: NonNullable<VerificationResultData['exam']>['binding'];
-      if (request.manifest) {
-        try {
-          examBinding = await verifyExamBinding(proofData as unknown as ExportedProof, request.manifest);
-        } catch (err) {
-          examBinding = {
-            valid: false,
-            packageSignatureValid: false,
-            packageHashMatches: false,
-            rootMatches: false,
-            problemContentHashMatches: false,
-            timeBox: null,
-            reason: `Exam binding verification threw: ${err instanceof Error ? err.message : String(err)}`,
-          };
-        }
-      }
-      examResult = {
-        present: true,
-        rootValid,
-        packageProvided: !!request.manifest,
-        binding: examBinding,
-      };
-    }
-
-    // 5.7 分析層 (ADR-0009): 検証と直交する post-hoc 分析。advisory であって判定ではない
-    // (valid には一切反映しない)。分析の失敗は検証結果を落とさない。
-    let analysis: AnalysisReport | undefined;
-    try {
-      analysis = await runAnalysis({
-        proof: proofData as unknown as ExportedProof,
-        verification: {
-          valid: metadataValid && chainValid,
-          metadataValid,
-          rootValid,
-          rootAnchored,
-          chainValid,
-          finalHashValid: finalHashVerification.valid,
-          contentValid: contentVerification.valid,
-          checkpointValid: checkpointVerification.valid,
-          isPureTyping,
-          poswSkipped: skipPosw,
-          signedCheckpoints: signedCheckpointResult,
-        },
-      });
-    } catch {
-      analysis = undefined;
-    }
-
-    // 6. 結果を送信
-    sendResult(id, {
-      metadataValid,
-      rootValid,
-      rootAnchored,
-      chainValid,
-      finalHashValid: finalHashVerification.valid,
-      contentValid: contentVerification.valid,
-      checkpointValid: checkpointVerification.valid,
-      isPureTyping,
-      message: verificationMessage,
-      errorAt: chainVerification.errorAt ?? checkpointVerification.errorAt ?? signedCheckpointResult.errorAt,
-      totalEvents,
-      poswStats,
-      verificationMode: mode,
-      poswMode: poswModeFor(mode),
-      signedCheckpointValid: signedCheckpointResult.anchored ? signedCheckpointResult.valid : undefined,
-      signedCheckpointAnchored: signedCheckpointResult.anchored,
-      signedCheckpointCoverage: signedCheckpointResult.coverage,
-      signedCheckpointTemporal: signedCheckpointResult.temporal,
-      signedCheckpointDensity: signedCheckpointResult.density,
-      signedCheckpointReason: signedCheckpointResult.reason,
-      signedCheckpointReport,
-      analysis,
-      exam: examResult,
-    });
+    sendResult(id, result);
   } catch (error) {
     sendError(id, error instanceof Error ? error.message : String(error));
   }
-}
-
-/**
- * Signed checkpoint カードの「展開時の根拠」表示に渡す詳細情報を組み立てる。
- *
- * 含める情報:
- * - 検証の母集団: proof 内の checkpoint 総数 / 署名済み数 / valid 数
- * - 範囲: 最初の anchor (cp #0) と最後の anchor の (checkpointIndex, eventIndex,
- *   serverTimestamp, clientTimestamp)。Coverage 行の補強として使える。
- * - 鍵レジストリ整合: 各 envelope の keyId を一意化して registry を引き、
- *   description / status / validFrom 等を返す (鍵 rotation や revoke の根拠)。
- * - 失敗 / 警告 envelope の特定: verifySignedCheckpoints の details から
- *   valid=false や warning 付きのものを抜き出す。エラー位置の根拠になる。
- */
-function buildSignedCheckpointReport(
-  checkpoints: readonly CheckpointData[],
-  result: SignedCheckpointsVerificationResult
-): SignedCheckpointReport {
-  const signed = checkpoints.filter((cp) => cp.signature);
-  const detailByEvent = new Map(result.details.map((d) => [d.eventIndex, d]));
-
-  const firstEnvelope = signed[0]?.signature;
-  const lastEnvelope = signed[signed.length - 1]?.signature;
-
-  const toAnchor = (
-    env:
-      | { payload: { checkpointIndex: number; eventIndex: number; serverTimestamp: string; clientTimestamp: string } }
-      | undefined
-  ): AnchorPoint | undefined =>
-    env
-      ? {
-          checkpointIndex: env.payload.checkpointIndex,
-          eventIndex: env.payload.eventIndex,
-          serverTimestamp: env.payload.serverTimestamp,
-          clientTimestamp: env.payload.clientTimestamp,
-        }
-      : undefined;
-
-  // 一意な keyId を抽出 (順序保持)
-  const uniqueKeyIds: string[] = [];
-  const seenKeyIds = new Set<string>();
-  for (const cp of signed) {
-    const kid = cp.signature?.keyId;
-    if (!kid || seenKeyIds.has(kid)) continue;
-    seenKeyIds.add(kid);
-    uniqueKeyIds.push(kid);
-  }
-
-  const keys: AnchorKeyInfo[] = uniqueKeyIds.map((keyId) => {
-    const entry = findCheckpointPublicKey(keyId, CHECKPOINT_PUBLIC_KEYS);
-    if (!entry) {
-      return { keyId, status: 'unknown' };
-    }
-    return {
-      keyId,
-      status: entry.status,
-      algorithm: entry.algorithm,
-      description: entry.description,
-      validFrom: entry.validFrom,
-      validUntil: entry.validUntil,
-      revokedAt: entry.revokedAt,
-    };
-  });
-
-  const failedEnvelopes: AnchorEnvelopeIssue[] = [];
-  const warningEnvelopes: AnchorEnvelopeIssue[] = [];
-  for (const cp of signed) {
-    const payload = cp.signature?.payload;
-    if (!payload) continue;
-    const detail = detailByEvent.get(payload.eventIndex);
-    if (detail && !detail.valid) {
-      failedEnvelopes.push({
-        checkpointIndex: payload.checkpointIndex,
-        eventIndex: payload.eventIndex,
-        reason: detail.reason ?? 'invalid',
-      });
-    }
-    if (detail?.warning) {
-      warningEnvelopes.push({
-        checkpointIndex: payload.checkpointIndex,
-        eventIndex: payload.eventIndex,
-        reason: detail.warning,
-      });
-    }
-  }
-
-  const validCount = result.details.filter((d) => d.valid).length;
-
-  return {
-    totalCheckpoints: checkpoints.length,
-    signedCount: signed.length,
-    validCount,
-    firstSeenAt: firstEnvelope?.payload.firstSeenAt,
-    initialEventChainHash: firstEnvelope?.payload.initialEventChainHash,
-    firstAnchor: toAnchor(firstEnvelope),
-    lastAnchor: toAnchor(lastEnvelope),
-    keys,
-    failedEnvelopes,
-    warningEnvelopes,
-  };
 }
 
 // メッセージハンドラ


### PR DESCRIPTION
## 目的

`packages/verify/src/workers/verificationWorker.ts` が shared の `verifyProofFile` を呼ばず、metadata / chain / finalHash / content / checkpoint / signedCheckpoint の合成を**自前で再実装**していた。その結果、shared (= verify-cli) と 2 点で結論が食い違っていた。

**(a) `sessionStartToken` ↔ 署名 cp の sessionId 突合が web に無い (#211)**
別セッションのトークンを流用した proof を CLI は `valid=false` とするのに、web はタブ緑・整合性チップ「証明済み」。仕様 (docs/system-spec.md §6.3) が要求する検査を実施しないまま決定的保証の語彙を出す overclaim。

**(b) `chainValid` に `signedCheckpointBlocks` を畳み込んでいた (#211)**
署名 cp が無効なだけの proof の「整合性」チップが FAILED になっていた (CLI では PROVEN)。ADR-0020 の三層の意味が web だけ壊れており、「改ざんされた」と誤って告発する方向の誤表示。副作用として TrustCalculator の issue が「ハッシュチェーン: <anchoring の理由>」という誤帰属になっていた。

再発防止として web↔CLI の結論一致を CI で固定する (#216)。

Closes #211
Closes #216

## 変更点

### 委譲 (#211)

- **`packages/verify/src/services/proofVerification.ts` (新規)**: 検証の実体。`verifyExamBinding` → shared の `verifyProofFile` → `runAnalysis` の順で走らせ、結果を UI 型 `VerificationResultData` に写すだけのアダプタ。判定ロジックは持たない
  - `isOverallValid` … UI の総合判定。verify-cli の `valid` (= `verifyProofFile` の valid × exam 束縛 × スクショ改竄) と同じ合成
  - `buildAssuranceInput` … 三層保証 (ADR-0020) の導出入力への写像。verify-cli の同じ写像と揃える
- **`verificationWorker.ts`**: メッセージ入出力だけの薄いアダプタに縮小 (419 行 → 約 120 行)。進捗 (`onChainProgress` → `phase: 'chain'`) の配線は維持
- **`VerificationController.handleComplete`**: タブ status の error 判定を `isOverallValid` 一本に集約。セッショントークン不一致でも緑にならない
- **`TabController.renderResult`**: `deriveAssurance` の入力組み立てを `buildAssuranceInput` に集約 (導出は従来どおり shared)
- **`TrustCalculator`**: セッショントークン不一致を **`anchoring` 層の error** として追加 (整合性 = `chain` には混ぜない)。i18n キー `trust.issueSessionTokenMismatch` を ja/en + types に追加
- **`packages/shared/src/verification.ts`**: `FullVerificationResult` に `sessionTokenMismatch?: boolean` を追加 (`valid` には既に反映済みだが、UI が「どの層が落ちたか」を提示できるよう独立に返す)
- **`packages/verify-cli/src/verify.ts`**: `VerifyProofOptions.signedCheckpointKeyRegistry` を追加し `verifyProofFile` に素通し (テストで両経路に同じテスト鍵を注入するため。既定は従来どおり shared の registry)

### パリティテスト (#216)

`packages/verify/src/services/__tests__/webCliParity.test.ts` (7 ケース)。shared の既存 fixture (`signedCheckpointFixtures` / `examFixtures`) で proof を組み立て、**verify (web) の経路**と**verify-cli の `verifyProof` 本体**を同じ入力に通して `valid` / 三層保証 (integrity・temporal・provenance の pureTyping) / exam 束縛の一致を突き合わせる。

- 健全な anchored proof (valid / integrity=proven / temporal=anchored)
- **別セッションのトークン流用** ((a) の再現。両者 invalid・integrity は proven のまま)
- **署名 cp のみ無効** ((b) の再現。両者 invalid・integrity=proven / temporal=partial)
- ハッシュチェーン改竄 (両者 invalid・integrity=failed)
- 署名 cp なしの casual proof (両者 valid・temporal=unanchored)
- exam proof (package 未提供 → 束縛未確認・exam-t0 を名乗らない)
- exam proof (package 提供 → 束縛失敗で両者 invalid)

`TrustCalculator.test.ts` にも 2 件追加: 署名 cp 無効を `chain` に誤帰属しないこと / セッショントークン不一致を `anchoring` の error として上げること。

スクリーンショット関連のパリティ (#212 / #213) は別 PR の担当なので本 PR では扱っていない。

### ドキュメント

`packages/verify/CLAUDE.md` のデータフロー・ディレクトリ表・TrustCalculator の issue 一覧を実装に追従させ、「Worker 内で検証を再合成しないこと」とパリティテストの存在を明記した。

## 確認方法

パリティテストは**修正前に赤くなることを確認済み**。委譲前 (旧 worker の合成をそのまま関数化したもの) では、追加した 7 ケース中まさに (a)(b) の 2 件だけが落ちた:

```
× agrees that a proof reusing another session token is invalid (spec §6.3)
  AssertionError: expected true to be false   ← web だけ valid=true

× agrees that a proof whose signed checkpoint is invalid keeps integrity proven but fails overall
  - Expected  "integrity": "proven"     (CLI)
  + Received  "integrity": "failed"     (web)
```

委譲後は 7/7 green。`TrustCalculator` の 2 ケースも、該当分岐を潰すとそれぞれ赤くなることを確認している。

作業ツリーでの実行結果:

```
npm ci                                     ok
npm run lint                               ok (error 0 / warning 60 = main と同数)
npm run typecheck                          ok (全パッケージ)
npm run test:run --workspaces --if-present ok (shared 452 / verify 39 / verify-cli 15 / editor 115 / workers 50)
npm run build                              ok
npm run test -w @typedcode/e2e             ok (17 passed, 2.7m)
```

UI の表示項目が減っていないことは、`VerificationResultData` の全フィールド (`signedCheckpointReport` / `poswStats` / `exam` / `analysis` / `verificationMode` / `poswMode` ほか) を委譲後も同じ値で埋めていること、および `ResultDataService.buildResultData` / `ResultPanel` が読む項目がすべて維持されていることで確認した。バンドルサイズも main 比で verify の index +0.5 kB / verificationWorker −26 kB。

なお、進捗メッセージの `hashInfo` (計算途中ハッシュ) は shared の `VerificationProgressCallback` が持たないため送出されなくなった。元から `VerificationQueue` → `AppController` で握り潰されており **UI に出ていなかった dead な配線**なので、型ごと除去している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)